### PR TITLE
Add generated assets to classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
 						</goals>
 						<configuration>
 							<mainClass>fr.insee.eno.xsl.FodsToXSLCompiler</mainClass>
+							<systemProperties>
+								<property>
+									<key>dest</key>
+									<value>${project.basedir}/src/main/resources</value>
+								</property>
+							</systemProperties>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/main/java/fr/insee/eno/Constants.java
+++ b/src/main/java/fr/insee/eno/Constants.java
@@ -1,13 +1,13 @@
 package fr.insee.eno;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * This class contains all the different paths used in the application Based on
@@ -58,7 +58,7 @@ public final class Constants {
 	public static final InputStream TRANSFORMATIONS_DDI2FR_DDI2FR_XSL = getInputStreamFromPath(TRANSFORMATIONS_FOLDER + "/ddi2fr/ddi2fr.xsl");
 	
 	public static final String TRANSFORMATIONS_DDI2FR_DRIVERS_FODS = TRANSFORMATIONS_FOLDER + "/ddi2fr/drivers.fods";
-	public static final String TRANSFORMATIONS_DDI2FR_DRIVERS_XSL = TRANSFORMATIONS_FOLDER + "/ddi2fr/drivers.xsl";
+//	public static final String TRANSFORMATIONS_DDI2FR_DRIVERS_XSL = TRANSFORMATIONS_FOLDER + "/ddi2fr/drivers.xsl";
 	
 	public static final String TRANSFORMATIONS_DDI2FR_FUNCTIONS_FODS = TRANSFORMATIONS_FOLDER	+ "/ddi2fr/functions.fods";
 	public static final String TRANSFORMATIONS_DDI2FR_FUNCTIONS_XSL = TRANSFORMATIONS_FOLDER + "/ddi2fr/functions.xsl";
@@ -75,14 +75,14 @@ public final class Constants {
 	public static final String INPUTS_DDI_TEMPLATES_XSL = INPUTS_FOLDER + "/ddi/templates.xsl";
 	
 	public static final String INPUTS_DDI_SOURCE_FIXED_XSL = INPUTS_FOLDER + "/ddi/source-fixed.xsl";
-	public static final String INPUTS_DDI_SOURCE_XSL = INPUTS_FOLDER + "/ddi/source.xsl";
+//	public static final String INPUTS_DDI_SOURCE_XSL = INPUTS_FOLDER + "/ddi/source.xsl";
 	public static final String FODS_2_XML_XSL = TRANSFORMATIONS_FOLDER + "/fods2xml.xsl";
 	public static final String XML_2_XSL_XSL = TRANSFORMATIONS_FOLDER + "/xml2xsl.xsl";
 	
 	// ---------- Temporary file system
 	
 	// ----- Folders
-	public static final String TEMP_FOLDER_PATH = System.getProperty("java.io.tmpdir") + "Eno";
+	public static final String TEMP_FOLDER_PATH = System.getProperty("java.io.tmpdir") + "/eno";
 	
 	public static final File TEMP_FOLDER = getFileOrDirectoryFromPath(TEMP_FOLDER_PATH);
 	public static final File SUB_TEMP_FOLDER = getFileOrDirectoryFromPath(TEMP_FOLDER_PATH + "/temp");
@@ -137,10 +137,10 @@ public final class Constants {
 
 	// Root folder of the project : must be filled
 	// FIXME use a dynamic path
-	public static final String ROOT_FOLDER = "D:/arkn1q/Mes Documents/eclipse_workspace/Eno";
-
-	public static final String QUESTIONNAIRE_FOLDER = ROOT_FOLDER + "/questionnaires";
-	public static final String TEMP_TEST_FOLDER = TEMP_FOLDER_PATH + "/nonRegressionTest";
+//	public static final String ROOT_FOLDER = "D:/arkn1q/Mes Documents/eclipse_workspace/Eno";
+//
+//	public static final String QUESTIONNAIRE_FOLDER = ROOT_FOLDER + "/questionnaires";
+//	public static final String TEMP_TEST_FOLDER = TEMP_FOLDER_PATH + "/nonRegressionTest";
 
 	/********************************************************/
 	/******************* ENOPreprocessing *******************/

--- a/src/main/java/fr/insee/eno/DummyMain.java
+++ b/src/main/java/fr/insee/eno/DummyMain.java
@@ -1,14 +1,13 @@
 package fr.insee.eno;
 
-import java.io.File;
-import java.io.IOException;
-
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * Only for dev purposes.
@@ -19,12 +18,20 @@ public class DummyMain {
 
 	public static void main(String[] args) {
 		logger.info("Starting generation program");
+		String inputFilePath = "";
+		try {
+			inputFilePath = args[0];
+		} catch(ArrayIndexOutOfBoundsException e) {
+			logger.error("Please provide path to a valid ddi input file as an argument");
+		}
+		System.out.println(args[0]);
+
 		cleanTempDirectory();		
 		Injector injector = Guice.createInjector(new DDI2FRContext());
 		GenerationService service = injector.getInstance(GenerationService.class);
 		try {
 			File generatedFile = service.generateQuestionnaire(
-					new File("D:/__TEMP/eno-test/simpsons.xml"),
+					new File(inputFilePath),
 					null);
 			logger.info("Generation successful! >> " + generatedFile);
 		} catch (Exception e) {

--- a/src/main/java/fr/insee/eno/xsl/FodsToXSLCompiler.java
+++ b/src/main/java/fr/insee/eno/xsl/FodsToXSLCompiler.java
@@ -1,16 +1,16 @@
 package fr.insee.eno.xsl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
+import fr.insee.eno.Constants;
+import fr.insee.eno.transform.xsl.XslTransformation;
+import fr.insee.eno.utils.FolderCleaner;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import fr.insee.eno.Constants;
-import fr.insee.eno.transform.xsl.XslTransformation;
-import fr.insee.eno.utils.FolderCleaner;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * The core engine of Eno is based on XSL functions that are generated from a catalog
@@ -43,12 +43,13 @@ public class FodsToXSLCompiler {
 			generateDDI2FRTreeNavigation();
 			// Fods2Xsl for /output/ddi/.fods files
 			generateDDIFunctions();
-			generateDDITemplates();			
+			generateDDITemplates();
 			logger.info("Fods2Xsl : xsl stylesheets created.");
 			// Incorporation target : creating ddi2fr.xsl
 			ddi2frIncorporationTarget();
 			// TODO Copy generated files to JAR or classpath
 			logger.debug("Fods to XSL: END");
+			copyGeneratedFiles();
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);
 			logger.debug("Fods to XSL : END");
@@ -281,7 +282,17 @@ public class FodsToXSLCompiler {
 	 * When every file has been generated, we want to copy them in the /xslt directory to be
 	 * used through the Java API.
 	 * */
-	private static void copyGeneratedFiles(Env env) {
-		// FIXME how to implement something that works when developping and when publishing Eno ?
+	private static void copyGeneratedFiles() throws Exception {
+		String destinationBasePath = System.getProperty("dest");
+		logger.info(String.format("Copying generated files to %s", destinationBasePath));
+		File inputsDestination = new File(destinationBasePath + "/xslt/inputs/ddi");
+		File transformsDestination = new File(destinationBasePath + "/xslt/transformations/ddi2fr");
+		try {
+			FileUtils.copyDirectory(Constants.INPUTS_DDI_FUNCTIONS_XSL_TMP.getParentFile(), inputsDestination);
+			FileUtils.copyDirectory(Constants.TRANSFORMATIONS_DDI2FR_DDI2FR_XSL_TMP.getParentFile(), transformsDestination);
+		} catch(Exception e){
+			throw e;
+		}
 	}
+
 }


### PR DESCRIPTION
Code Review: 4de69f4
 
- Maven goal now adds generated assets to classpath
   - *Note: developers must run ```mvn package``` before running the project*
- DummyMain filepath is now given as a program argument
- Typo was fixed in Constants.java








