### PR TITLE
Publipostage Suite 

### DIFF
--- a/src/main/java/fr/insee/eno/Constants.java
+++ b/src/main/java/fr/insee/eno/Constants.java
@@ -38,10 +38,10 @@ public final class Constants {
 	public static final String PARAMETERS_XML = "parameters.xml";
 	
 	// ----- XSL Parameters path
-	public static final String CONFIG_DDI2FR = "/config/ddi2fr.xml";
-	public static final String CONFIG_DDI2ODT = "/config/ddi2odt.xml";
-	public static final String CONFIG_DDI2PDF = "/config/ddi2pdf.xml";
-	public static final String CONFIG_POGUES_XML2DDI = "/config/pogues-xml2ddi.xml";
+	public static final String CONFIG_DDI2FR = CONFIG_FOLDER + "/ddi2fr.xml";
+	public static final String CONFIG_DDI2ODT = CONFIG_FOLDER + "/ddi2odt.xml";
+	public static final String CONFIG_DDI2PDF = CONFIG_FOLDER + "/ddi2pdf.xml";
+	public static final String CONFIG_POGUES_XML2DDI = CONFIG_FOLDER + "/pogues-xml2ddi.xml";
 	public static final String PARAMETERS = "/parameters.xml";
 	public static final String LABELS_FOLDER = "/lang/fr/";
 	
@@ -59,10 +59,10 @@ public final class Constants {
 	public static final String UTIL_XSL_INCORPORATION_XSL = UTIL_FOLDER_PATH + "/xsl/incorporation.xsl";
 	public static final String UTIL_DDI_DEREFERENCING_XSL = UTIL_FOLDER_PATH + "/ddi/dereferencing.xsl";
 	public static final String BROWSING_FR_TEMPLATE_XSL = UTIL_FOLDER_PATH + "/fr/browsing.xsl";
-	public static final String PROPERTIES_FILE_FR = CONFIG_FOLDER + "/ddi2fr.xml";
-	public static final String PROPERTIES_FILE_ODT = CONFIG_FOLDER + "/ddi2odt.xml";
-	public static final String PROPERTIES_FILE_PDF = CONFIG_FOLDER + "/ddi2pdf.xml";
-	public static final String PROPERTIES_FILE_DDI = CONFIG_FOLDER + "/pogues-xml2ddi.xml";
+//	public static final String PROPERTIES_FILE_FR = CONFIG_FOLDER + "/ddi2fr.xml";
+//	public static final String PROPERTIES_FILE_ODT = CONFIG_FOLDER + "/ddi2odt.xml";
+//	public static final String PROPERTIES_FILE_PDF = CONFIG_FOLDER + "/ddi2pdf.xml";
+//	public static final String PROPERTIES_FILE_DDI = CONFIG_FOLDER + "/pogues-xml2ddi.xml";
 	
 	// ---------- XSL generation
 	public static final String TRANSFORMATIONS_DDI2FR_DDI2FR_XSL = TRANSFORMATIONS_FOLDER + "/ddi2fr/ddi2fr.xsl";
@@ -243,7 +243,7 @@ public final class Constants {
 	/********************************************************/
 	//// Plugin Conf
 	public static final String PDF_PLUGIN_XML_CONF = "src/main/resources/config/plugins-conf.xml";
-	public static final File PDF_PLUGIN_XML_CONF_FILE = getFileFromUrl(Constants.class.getResource("/config/plugins-conf.xml"));
+	public static final File PDF_PLUGIN_XML_CONF_FILE = getFileFromUrl(Constants.class.getResource(CONFIG_FOLDER + "/plugins-conf.xml"));
 	
 
 

--- a/src/main/java/fr/insee/eno/GenerationService.java
+++ b/src/main/java/fr/insee/eno/GenerationService.java
@@ -22,13 +22,13 @@ public class GenerationService {
 
 	private final Preprocessor preprocessor;
 	private final Generator generator;
-	private final Postprocessor postprocessor;
+	private final Postprocessor[] postprocessors;
 
 	@Inject
-	public GenerationService(Preprocessor preprocessor, Generator generator, Postprocessor postprocessor) {
+	public GenerationService(final Preprocessor preprocessor, final Generator generator, final Postprocessor[] postprocessors) {
 		this.preprocessor = preprocessor;
 		this.generator = generator;
-		this.postprocessor = postprocessor;
+		this.postprocessors = postprocessors;
 	}
 
 	/**
@@ -53,7 +53,13 @@ public class GenerationService {
 		cleanTempFolder(surveyName);
 		File preprocessResultFileName = this.preprocessor.process(inputFile, parametersFile,surveyName);
 		File generatedForm = this.generator.generate(preprocessResultFileName, surveyName); 
-		File outputForm = this.postprocessor.process(generatedForm, parametersFile, surveyName);
+		
+		//File generatedForm = new File("C:\\Users\\Tarik\\AppData\\Local\\Temp\\eno\\test\\instrument-i6vwid\\form\\form.fo");
+		File outputForm = this.postprocessors[0].process(generatedForm, parametersFile, surveyName);
+		for (int i = 1; i < postprocessors.length; i++) {
+			outputForm = this.postprocessors[i].process(outputForm, parametersFile, surveyName);
+		}
+			
 		logger.debug("Path to generated questionnaire: " + outputForm.getAbsolutePath());
 		return outputForm;
 	}
@@ -69,7 +75,7 @@ public class GenerationService {
 		FolderCleaner cleanService = new FolderCleaner();
 		if(Constants.TEMP_FOLDER_PATH !=null){
 			File folderTemp = new File(Constants.TEMP_FOLDER_PATH+"/"+name);
-			cleanService.cleanOneFolder(folderTemp);
+			cleanTempFolder(folderTemp);
 		}
 		else{
 			logger.debug("Temp Folder is null");
@@ -83,10 +89,9 @@ public class GenerationService {
 	 *           
 	 */
 	public void cleanTempFolder() throws IOException {
-		FolderCleaner cleanService = new FolderCleaner();
 		if(Constants.TEMP_FOLDER_PATH !=null){
 			File folderTemp = new File(Constants.TEMP_FOLDER_PATH);
-			cleanService.cleanOneFolder(folderTemp);
+			cleanTempFolder(folderTemp);
 		}
 		else{
 			logger.debug("Temp Folder is null");

--- a/src/main/java/fr/insee/eno/generation/DDI2FRGenerator.java
+++ b/src/main/java/fr/insee/eno/generation/DDI2FRGenerator.java
@@ -93,7 +93,7 @@ public class DDI2FRGenerator implements Generator {
 	private InputStream getPropertiesFiles() {
 		InputStream isPROPERTIES_FILE = null;
 		if (propertiesFiles == null) {
-			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.PROPERTIES_FILE_FR);
+			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.CONFIG_DDI2FR);
 		}else{
 			isPROPERTIES_FILE = propertiesFiles;
 		}

--- a/src/main/java/fr/insee/eno/generation/DDI2ODTGenerator.java
+++ b/src/main/java/fr/insee/eno/generation/DDI2ODTGenerator.java
@@ -77,7 +77,7 @@ public class DDI2ODTGenerator implements Generator {
 	private InputStream getPropertiesFiles() {
 		InputStream isPROPERTIES_FILE = null;
 		if (propertiesFiles == null) {
-			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.PROPERTIES_FILE_ODT);
+			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.CONFIG_DDI2ODT);
 		}else{
 			isPROPERTIES_FILE = propertiesFiles;
 		}

--- a/src/main/java/fr/insee/eno/generation/DDI2PDFGenerator.java
+++ b/src/main/java/fr/insee/eno/generation/DDI2PDFGenerator.java
@@ -59,7 +59,7 @@ public class DDI2PDFGenerator implements Generator {
 	private InputStream getPropertiesFiles() {
 		InputStream isPROPERTIES_FILE = null;
 		if (propertiesFiles == null) {
-			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.PROPERTIES_FILE_PDF);
+			isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.CONFIG_DDI2PDF);
 		}else{
 			isPROPERTIES_FILE = propertiesFiles;
 		}

--- a/src/main/java/fr/insee/eno/generation/PoguesXML2DDIGenerator.java
+++ b/src/main/java/fr/insee/eno/generation/PoguesXML2DDIGenerator.java
@@ -37,7 +37,7 @@ public class PoguesXML2DDIGenerator implements Generator {
 
 		InputStream isTRANSFORMATIONS_POGUES_XML2DDI_POGUES_XML2DDI_XSL = Constants
 				.getInputStreamFromPath(Constants.TRANSFORMATIONS_POGUES_XML2DDI_POGUES_XML2DDI_XSL);
-		InputStream isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.PROPERTIES_FILE_DDI);
+		InputStream isPROPERTIES_FILE = Constants.getInputStreamFromPath(Constants.CONFIG_POGUES_XML2DDI);
 		InputStream isPARAMETERS_FILE = Constants.getInputStreamFromPath(Constants.PARAMETERS_FILE);
 
 		InputStream isFinalInput = FileUtils.openInputStream(finalInput);

--- a/src/main/java/fr/insee/eno/postprocessing/CustomizationPostprocessor.java
+++ b/src/main/java/fr/insee/eno/postprocessing/CustomizationPostprocessor.java
@@ -1,0 +1,41 @@
+package fr.insee.eno.postprocessing;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import fr.insee.eno.Constants;
+import fr.insee.eno.transform.xsl.XslTransformation;
+
+/**
+ * Customization of FO postprocessor.
+ */
+public class CustomizationPostprocessor implements Postprocessor {
+
+	private static final Logger logger = LoggerFactory.getLogger(CustomizationPostprocessor.class);
+
+	// FIXME Inject !
+	private static XslTransformation saxonService = new XslTransformation();
+
+	@Override
+	public File process(File input, File parametersFile, String survey) throws Exception {
+
+		File outputCustomFOFile = new File(
+				FilenameUtils.removeExtension(input.getPath()) + Constants.CUSTOM_FO_EXTENSION);
+
+		InputStream FO_CUSTOMIZATION_XSL = Constants
+				.getInputStreamFromPath(Constants.TRANSFORMATIONS_CUSTOMIZATION_FO_4PDF);
+
+		saxonService.transformFOToCustomFO(FileUtils.openInputStream(input), 
+				FileUtils.openOutputStream(outputCustomFOFile),FO_CUSTOMIZATION_XSL);
+
+		logger.info("end of Customization of fo file : " + input.getAbsolutePath());
+
+		return outputCustomFOFile;
+	}
+
+}

--- a/src/main/java/fr/insee/eno/postprocessing/PDFPostprocessor.java
+++ b/src/main/java/fr/insee/eno/postprocessing/PDFPostprocessor.java
@@ -2,10 +2,8 @@ package fr.insee.eno.postprocessing;
 
 import java.io.File;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.StandardCopyOption;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,25 +47,11 @@ public class PDFPostprocessor implements Postprocessor {
 			isConfFile.close();
 			logger.debug("Get conf file : "+confFile.getAbsolutePath());
 		}
-				
-
-		
-		
+								
 		serviceTableColumnSize.tableColumnSizeProcessor(input.getAbsolutePath(), outputForFO,
 				confFilePath);
-		File outputForFOFile = new File(outputForFO);
-
-		File outputCustomFOFile = new File (FilenameUtils.removeExtension(input.getPath()) + Constants.CUSTOM_FO_EXTENSION);
-
-		InputStream PUBLIPOSTAGE_XSL = Constants.getInputStreamFromPath(Constants.TRANSFORMATIONS_CUSTOMIZATION_FO_4PDF);
-		saxonService.transform(
-				FileUtils.openInputStream(outputForFOFile),
-				PUBLIPOSTAGE_XSL, 
-				FileUtils.openOutputStream(outputCustomFOFile));
 		
-		logger.info("end of Customization of fo file : " + input.getAbsolutePath());
-
-		return outputCustomFOFile;
+		return new File(outputForFO);
 
 	}
 }

--- a/src/main/java/fr/insee/eno/transform/xsl/XslParameters.java
+++ b/src/main/java/fr/insee/eno/transform/xsl/XslParameters.java
@@ -20,6 +20,7 @@ public class XslParameters {
 	public static final String DDI2PDF_CAMPAIGN = "campaign";
 	public static final String DDI2PDF_MODEL = "model";
 	public static final String DDI2PDF_PROPERTIES_FILE = "properties-file";
+	public static final String FO2CUSTOMFO_PROPERTIES_FILE = "properties-file";
 	public static final String POGUES_XML2DDI_CAMPAIGN = "campaign";
 	public static final String POGUES_XML2DDI_MODEL = "model";
 	public static final String POGUES_XML2DDI_PROPERTIES_FILE = "properties-file";

--- a/src/main/java/fr/insee/eno/transform/xsl/XslTransformation.java
+++ b/src/main/java/fr/insee/eno/transform/xsl/XslTransformation.java
@@ -344,6 +344,20 @@ public class XslTransformation {
 		
 	}
 	
+	public void transformFOToCustomFO(InputStream inputFile, OutputStream outputFile, InputStream xslSheet) throws Exception {
+		logger.info("Producing a custom FO (PDF) from the FO with conditioning variables");
+		TransformerFactory tFactory = new net.sf.saxon.TransformerFactoryImpl();
+		tFactory.setURIResolver(new ClasspathURIResolver());
+		Transformer transformer = tFactory.newTransformer(new StreamSource(xslSheet));
+		transformer.setErrorListener(new EnoErrorListener());
+		transformer.setParameter(XslParameters.FO2CUSTOMFO_PROPERTIES_FILE, Constants.CONFIG_DDI2PDF);
+		logger.debug(
+				String.format(
+						"FO Transformer parameters file is: %s",
+						transformer.getParameter(Constants.CONFIG_DDI2PDF)));
+		xslTransform(transformer, inputFile, outputFile);
+	}
+	
 	
 	public void transformPoguesXML2DDI(InputStream inputFile, OutputStream outputFile, InputStream xslSheet,
 			InputStream propertiesFile, InputStream parametersFile) throws Exception {

--- a/src/main/resources/xslt/outputs/pdf/home-page.xsl
+++ b/src/main/resources/xslt/outputs/pdf/home-page.xsl
@@ -51,13 +51,13 @@
                     <fo:block-container height="35mm" overflow="hidden">
                         <fo:block margin-left="3mm" margin-right="3mm" margin-top="1mm" margin-bottom="1mm">
                             <fo:block font-weight="bold">Unité enquêtée</fo:block>
-                            <fo:block>Identifiant : $identifiant</fo:block>
-                            <fo:block>Raison sociale : $RS</fo:block>
+                            <fo:block>Identifiant : ${identifiant}</fo:block>
+                            <fo:block>Raison sociale : ${RS}</fo:block>
                             <fo:block>Adresse :</fo:block>
-                            <fo:block>$adresse_rep_L1</fo:block>
-                            <fo:block>$adresse_rep_L2</fo:block>
-                            <fo:block>$adresse_rep_L3</fo:block>
-                            <fo:block>$adresse_rep_L4</fo:block>
+                            <fo:block>${adresse_rep_L1}</fo:block>
+                            <fo:block>${adresse_rep_L2}</fo:block>
+                            <fo:block>${adresse_rep_L3}</fo:block>
+                            <fo:block>${adresse_rep_L4}</fo:block>
                         </fo:block>
                     </fo:block-container>
                 </fo:inline-container>
@@ -71,10 +71,10 @@
                         <fo:block margin-left="3mm" margin-right="3mm" margin-top="1mm" margin-bottom="1mm">
                             <fo:block font-weight="bold">Contacter l'assistance</fo:block>
                             <fo:block>Par téléphone</fo:block>
-                            <fo:block>$telephone1</fo:block>
-                            <fo:block>$telephone_SVI_1</fo:block>
+                            <fo:block>${telephone1}</fo:block>
+                            <fo:block>${telephone_SVI_1}</fo:block>
                             <fo:block>Par Mail :</fo:block>
-                            <fo:block>$mail_gestionnaire</fo:block>								
+                            <fo:block>${mail_gestionnaire}</fo:block>								
                         </fo:block>
                     </fo:block-container>
                 </fo:inline-container>
@@ -86,10 +86,10 @@
                         <fo:block margin-left="3mm" margin-right="3mm" margin-top="1mm" margin-bottom="1mm">
                             <fo:block font-weight="bold">Coordonnées de la personne ayant</fo:block>
                             <fo:block font-weight="bold">répondu à ce questionnaire :</fo:block>
-                            <fo:block>Nom : $nom_corresp</fo:block>
-                            <fo:block>Prénom : $prenom_corresp</fo:block>
-                            <fo:block>Téléphone : $tel_corresp</fo:block>
-                            <fo:block>Mel : $mel_corresp</fo:block>
+                            <fo:block>Nom : ${nom_corresp}</fo:block>
+                            <fo:block>Prénom : ${prenom_corresp}</fo:block>
+                            <fo:block>Téléphone : ${tel_corresp}</fo:block>
+                            <fo:block>Mel : ${mel_corresp}</fo:block>
                         </fo:block>
                     </fo:block-container>
                 </fo:inline-container>
@@ -98,7 +98,7 @@
             <fo:block font-weight="bold" margin-top="5mm" font-family="sans-serif" font-size="12pt" width="100%">
                 <fo:inline-container width="194mm">
                     <fo:block height="10mm">
-                        Merci de nous retourner ce questionnaire au plus tard le : $Date
+                        Merci de nous retourner ce questionnaire au plus tard le : ${Date}
                     </fo:block>
                 </fo:inline-container>
             </fo:block>
@@ -139,17 +139,17 @@
             <fo:block width="100%" height="35mm" font-family="sans-serif" font-size="7pt" margin-top="5mm" border="solid black 0.5pt">
                 <fo:inline-container width="194mm">
                     <fo:block margin="3mm">
-                        <fo:block>Vu l'avis favorable du Conseil national de l'information statistique, cette enquête, reconnue d$utilite_publique, est $obligatoire.</fo:block>
-                        <fo:block>Visa n°$visa du Ministre du travail, de l'emploi, de la formation professionnelle et du dialogue social, valable pour l'année $annee.</fo:block>
+                        <fo:block>Vu l'avis favorable du Conseil national de l'information statistique, cette enquête, reconnue d${utilite_publique}, est ${obligatoire}.</fo:block>
+                        <fo:block>Visa n°${visa} du Ministre du travail, de l'emploi, de la formation professionnelle et du dialogue social, valable pour l'année ${annee}.</fo:block>
                         <fo:block>Aux termes de l'article 6 de la loi n° 51-711 du 7 juin 1951 modifiée sur l'obligation, la coordination et le secret en matière de statistiques, les renseignements transmis</fo:block>
                         <fo:block>en réponse au présent questionnaire ne sauraient en aucun cas être utilisés à des fins de contrôle fiscal ou de répression économique.</fo:block>
                         <fo:block>L'article 7 de la loi précitée stipule d'autre part que tout défaut de réponse ou une réponse sciemment inexacte peut entraîner l'application d'une amende administrative.</fo:block>
                         
-                        <fo:block>Questionnaire confidentiel destiné à  $jenesaispasqui.</fo:block>
+                        <fo:block>Questionnaire confidentiel destiné à  ${jenesaispasqui}.</fo:block>
                         <fo:block>La loi n°78-17 du 6 janvier 1978 modifiée relative à l'informatique, aux fichiers et aux libertés, s'applique aux réponses faites à la présente enquête par les entreprises</fo:block>
                         <fo:block>individuelles.</fo:block>
                         <fo:block>Elle leur garantit un droit d'accès et de rectification pour les données les concernant.</fo:block>
-                        <fo:block>Ce droit peut être exercé auprès de $MOA.</fo:block>
+                        <fo:block>Ce droit peut être exercé auprès de ${MOA}.</fo:block>
                     </fo:block>
                 </fo:inline-container>
             </fo:block>
@@ -195,13 +195,13 @@
                 <fo:inline-container width="92mm" height="40mm">
                     <fo:block-container position="absolute" top="217mm" left="92mm">
                         <fo:block padding="3mm">
-                            <fo:block>$Adresse_retour_L1</fo:block>
-                            <fo:block>$Adresse_retour_L2</fo:block>
-                            <fo:block>$Adresse_retour_L3</fo:block>
-                            <fo:block>$Adresse_retour_L4</fo:block>
-                            <fo:block>$Adresse_retour_L5</fo:block>
-                            <fo:block>$Adresse_retour_L6</fo:block>
-                            <fo:block>$Adresse_retour_L7</fo:block>
+                            <fo:block>${Adresse_retour_L1}</fo:block>
+                            <fo:block>${Adresse_retour_L2}</fo:block>
+                            <fo:block>${Adresse_retour_L3}</fo:block>
+                            <fo:block>${Adresse_retour_L4}</fo:block>
+                            <fo:block>${Adresse_retour_L5}</fo:block>
+                            <fo:block>${Adresse_retour_L6}</fo:block>
+                            <fo:block>${Adresse_retour_L7}</fo:block>
                         </fo:block>
                     </fo:block-container>
                 </fo:inline-container>

--- a/src/main/resources/xslt/outputs/pdf/models.xsl
+++ b/src/main/resources/xslt/outputs/pdf/models.xsl
@@ -69,7 +69,7 @@
 			</fo:layout-master-set>
 			
 			
-			<!-- DEFINITION DELA PAGE DE GARDE -->
+			<!-- DEFINITION DE LA PAGE DE GARDE -->
 			<fo:page-sequence master-reference="Cover-A4" font-family="arial" font-size="10pt">
 				<fo:flow flow-name="xsl-region-body">
 					<xsl:copy-of select="eno:Home-Page($source-context)"/>
@@ -194,7 +194,8 @@
 			<xsl:when test="$noInstructions != 'YES'">
 				<xsl:choose>
 					<xsl:when test="enopdf:get-format($source-context) = 'footnote'">
-						<fo:block><Flag178>footnote</Flag178>
+ 						<fo:block>
+						<!-- <Flag178>footnote</Flag178> -->
 							<fo:footnote>
 								<fo:inline></fo:inline>
 								<fo:footnote-body  xsl:use-attribute-sets="footnote">
@@ -210,7 +211,7 @@
 						</fo:block>
 					</xsl:when>
 					<xsl:when test="enopdf:get-format($source-context) = 'tooltip'">
-						<Flag194>tooltip</Flag194>
+<!-- 						<Flag194>tooltip</Flag194> -->
 						<!-- Do nothing -->
 					</xsl:when>
 					<xsl:when test="enopdf:get-format($source-context) = 'comment' or enopdf:get-format($source-context) = 'help' or enopdf:get-format($source-context) = 'instruction'">
@@ -250,6 +251,7 @@
 							<xsl:if test="$isTable = 'YES'">
 								<xsl:attribute name="margin-left">1mm</xsl:attribute>
 							</xsl:if>
+							<ResponseBlock/>
 							<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 						</fo:block>
 					</xsl:otherwise>
@@ -275,6 +277,7 @@
 			<xsl:if test="$isTable = 'YES'">
 				<xsl:attribute name="margin-left">1mm</xsl:attribute>
 			</xsl:if>
+			<ResponseBlock/>
 			<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 		</fo:block>
 		
@@ -380,6 +383,7 @@
 
 		<xsl:if test="enopdf:get-label($source-context, $languages[1]) = ''">
 			<fo:block font-size="10pt" font-weight="bold" color="black" keep-with-next="always"> <!--linefeed-treatment="preserve"-->
+				<ResponseBlock/>
 				<xsl:value-of select="enopdf:get-label($source-context, $languages[1])"/>
 			</fo:block>
 		</xsl:if>
@@ -387,13 +391,15 @@
 			<xsl:if test="enopdf:get-type($source-context) = 'text'">
 				<fo:block>
 					<xsl:if test="enopdf:get-label($source-context, $languages[1]) != ''">
-						<fo:block xsl:use-attribute-sets="label-question" keep-with-next="always">
+						<fo:block  xsl:use-attribute-sets="label-question" keep-with-next="always">
+						<ResponseBlock/>
 							<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>						
 						</fo:block>
 					</xsl:if>
 					<xsl:choose>
 						<xsl:when test="enopdf:get-format($source-context)">
-							<fo:block xsl:use-attribute-sets="general-style">
+							<fo:block  xsl:use-attribute-sets="general-style">
+							<ResponseBlock/>
 								<xsl:for-each select="1 to xs:integer(number(enopdf:get-length($source-context)))">
 									<xsl:variable name="curVal" select="."/>
 									<xsl:if test="number(enopdf:get-length($source-context)) = $curVal">
@@ -430,7 +436,8 @@
 			<xsl:if test="enopdf:get-type($source-context) = 'date'">
 				<xsl:variable name="field" select="enopdf:get-format($source-context)"/>
 				<xsl:if test="enopdf:get-label($source-context, $languages[1]) != ''">
-					<fo:block xsl:use-attribute-sets="label-question" keep-with-next="always">
+					<fo:block  xsl:use-attribute-sets="label-question" keep-with-next="always">
+						<ResponseBlock/>
 						<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>						
 					</fo:block>
 				</xsl:if>
@@ -440,7 +447,7 @@
 						<xsl:attribute name="padding-top">0px</xsl:attribute>
 						<xsl:attribute name="padding-bottom">0px</xsl:attribute>
 					</xsl:if>
-					<Flag508>Date+Label_vide</Flag508>
+<!-- 					<Flag508>Date+Label_vide</Flag508> -->
 					
 					<xsl:for-each select="1 to xs:integer(number(string-length(replace($field,'/',''))))">
 								<xsl:variable name="curVal" select="."/>
@@ -472,7 +479,8 @@
 			<xsl:if test="enopdf:get-type($source-context) = 'number'">
 				<xsl:choose>
 					<xsl:when test="$autreHandle">
-						<fo:inline xsl:use-attribute-sets="general-style">
+						<fo:inline  xsl:use-attribute-sets="general-style">
+						
 							<xsl:for-each select="1 to xs:integer(number(enopdf:get-length($source-context)))">
 								<xsl:variable name="curVal" select="."/>
 								<xsl:if test="number(enopdf:get-length($source-context)) = $curVal">
@@ -507,7 +515,8 @@
 									<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 								</fo:block>
 							</xsl:if>
-							<fo:block xsl:use-attribute-sets="general-style" padding-bottom="0mm" padding-top="0mm">
+							<fo:block  xsl:use-attribute-sets="general-style" padding-bottom="0mm" padding-top="0mm">
+							<ResponseBlock/>
 								<!-- if decimals in mask -->
 								<xsl:choose>
 									<xsl:when test="enopdf:get-number-of-decimals($source-context) != ''">
@@ -623,7 +632,7 @@
 					<xsl:when test="$no-border = 'no-border'">
 						<xsl:choose>
 							<xsl:when test="enopdf:get-label($source-context, $languages[1]) != ''">
-								<Flag700>No border_label_vide</Flag700>
+<!-- 								<Flag700>No border_label_vide</Flag700> -->
 								<fo:inline font-family="ZapfDingbats" font-size="10pt"
 									margin-top="3mm">
 									&#x274F;
@@ -636,7 +645,7 @@
 								</xsl:apply-templates>
 							</xsl:when>
 							<xsl:otherwise>
-							<Flag712>No border_label_plein</Flag712>
+<!-- 							<Flag712>No border_label_plein</Flag712> -->
 								<fo:block font-family="ZapfDingbats" text-align="center" font-size="10pt" padding-right="4mm" padding-left="6mm"
 									margin-top="3mm">
 									&#x274F;
@@ -648,7 +657,7 @@
 						</xsl:choose>
 					</xsl:when>
 					<xsl:otherwise>
-						<Flag725>Avec Border</Flag725>
+<!-- 						<Flag725>Avec Border</Flag725> -->
 						<fo:block>
 							<fo:inline font-family="ZapfDingbats" font-size="10pt" padding-right="5mm"
 								margin-top="3mm">&#x274F;</fo:inline>
@@ -977,6 +986,7 @@
 				<xsl:attribute name="padding">0mm</xsl:attribute>
 			</xsl:if>
 			<fo:block>
+			<ResponseBlock/>
 				<xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
 					<xsl:with-param name="driver" select="." tunnel="yes"/>
 					<xsl:with-param name="isTable" select="'YES'" tunnel="yes"/>
@@ -1023,6 +1033,7 @@
 		
 		<fo:table-cell background-color="#CCCCCC" border-color="black" border-style="solid">
 			<fo:block>
+			<ResponseBlock/>
 				<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 			</fo:block>
 		</fo:table-cell>
@@ -1041,7 +1052,8 @@
 		<xsl:variable name="languages" select="enopdf:get-form-languages($source-context)"
 			as="xs:string +"/>
 
-		<fo:block font-size="10pt" font-weight="bold" color="black">
+		<fo:block  font-size="10pt" font-weight="bold" color="black">
+		<ResponseBlock/>
 			<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 		</fo:block>
 
@@ -1081,7 +1093,8 @@
 		<xsl:variable name="languages" select="enopdf:get-form-languages($source-context)"
 			as="xs:string +"/>
 
-		<fo:block font-size="10pt" font-weight="bold" color="black">
+		<fo:block  font-size="10pt" font-weight="bold" color="black">
+		<ResponseBlock/>
 			<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 		</fo:block>
 

--- a/src/main/resources/xslt/outputs/pdf/publipostage.xsl
+++ b/src/main/resources/xslt/outputs/pdf/publipostage.xsl
@@ -9,35 +9,68 @@
 	xmlns:fox="http://xmlgraphics.apache.org/fop/extensions" version="2.0"
 	xmlns:regexp="http://exslt.org/regular-expressions">
 
+	<xd:doc>
+		<xd:desc>
+			<xd:p>The FO/PDF properties file path.</xd:p>
+			<xd:p>Injected by the xsl transformation.</xd:p>
+		</xd:desc>
+	</xd:doc>
+	<xsl:param name="properties-file"/>
 
-	<!-- TODO : extract from parameters -->
+	<xd:doc>
+		<xd:desc>
+			<xd:p>The properties file of FO/PDF generation.</xd:p>
+		</xd:desc>
+	</xd:doc>	
+	<xsl:variable name="properties" select="doc($properties-file)"/>
+	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Get the conditioning characters from properties file</xd:p>
+		</xd:desc>
+	</xd:doc>
 	<xsl:variable name="SpecialCharacterSymbol1" select="'ø'" />
-	<xsl:variable name="SpecialCharacterSymbol2" select="'¤'" />
+	<xsl:variable name="SpecialCharacterSymbol2_before" select="$properties//TextConditioningVariable/ddi/Before" />
+	<xsl:variable name="SpecialCharacterSymbol2_after" select="$properties//TextConditioningVariable/ddi/After" />
+	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Pattern to match nodes containing the conditioning characters</xd:p>
+		</xd:desc>
+	</xd:doc>
 	<xsl:variable name="pattern"
-		select="concat('.*',$SpecialCharacterSymbol1,'.*',$SpecialCharacterSymbol1,'.*','|', '.*',$SpecialCharacterSymbol2,'.*',$SpecialCharacterSymbol2,'.*')" />
+		select="concat('.*',$SpecialCharacterSymbol1,'.*',$SpecialCharacterSymbol1,'.*','|', '.*',$SpecialCharacterSymbol2_before,'.*',$SpecialCharacterSymbol2_after,'.*')" />
+	
 	<xsl:variable name="valueofBlockPattern"
-		select="concat($SpecialCharacterSymbol1,'.*',$SpecialCharacterSymbol1,'|', $SpecialCharacterSymbol2,'.*',$SpecialCharacterSymbol2)" />
+		select="concat($SpecialCharacterSymbol1,'.*',$SpecialCharacterSymbol1,'|', $SpecialCharacterSymbol2_before,'.*',$SpecialCharacterSymbol2_after)" />
 	<xsl:variable name="valueOfStringCleanedPattern"
-		select="concat($SpecialCharacterSymbol1,'|',$SpecialCharacterSymbol2)" />
+		select="concat($SpecialCharacterSymbol1,'|',$SpecialCharacterSymbol2_before,'|',$SpecialCharacterSymbol2_after)" />
 
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Copy all nodes with their attributes.</xd:p>
+		</xd:desc>
+	</xd:doc>
 	<xsl:template match="@*|node()">
 		<xsl:copy>
 			<xsl:apply-templates select="@*|node()" />
 		</xsl:copy>
 	</xsl:template>
 
-	<xsl:template match="fo:block[text()[matches(.,$pattern)]]">
-	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Apply conversion of DDI variables to simple velocity variable syntax. Apply to all nodes but the response items (nodes having the element "ResponseBlock")</xd:p>
+		</xd:desc>
+	</xd:doc>
+	<xsl:template match="text()[matches(.,$pattern)]">
 		<xsl:variable name='valueOfBlock'>
 			<xsl:copy-of select="." />
 		</xsl:variable>
-		<xsl:call-template name="blockBegin" />
-	
 		<xsl:analyze-string select="$valueOfBlock" regex="ø.*ø|¤.*¤">
 			<xsl:matching-substring>
 			<xsl:variable name="valueOfStringCleaned"
 					select="translate(.,$valueOfStringCleanedPattern,'')" />
-				<xsl:call-template name="velocityCondition">
+				<xsl:call-template name="simpleVelocityCondition">
 					<xsl:with-param name="var" select="$valueOfStringCleaned" />
 				</xsl:call-template>
 			</xsl:matching-substring>
@@ -45,27 +78,39 @@
 				<xsl:copy-of select="." />
 			</xsl:non-matching-substring>
 		</xsl:analyze-string>
-		<xsl:call-template name="blockEnd" />
 	</xsl:template>
-
-	<!-- TODO : must retrieve the source block attributes -->
-	<xsl:template name="blockBegin">
-		<xsl:text disable-output-escaping="yes">
-				   &lt;fo:block       
-				   color="black"
-                   font-weight="bold"
-                   margin-bottom="3pt"
-                   margin-top="3pt"
-                   font-size="9pt"
-                   keep-with-next="always" &gt;
-	   </xsl:text>
+	
+	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Apply conversion of variables to velocity conditions syntax. Apply to response items (nodes having the element "ResponseBlock")</xd:p>
+		</xd:desc>
+	</xd:doc>
+	<xsl:template match="//*[child::ResponseBlock and text()[matches(.,$pattern)]]">
+		<xsl:variable name='valueOfBlock'>
+			<xsl:copy-of select="." />
+		</xsl:variable>
+		<xsl:copy><xsl:apply-templates select="@*"/></xsl:copy>
+		<xsl:analyze-string select="$valueOfBlock" regex="ø.*ø|¤.*¤">
+			<xsl:matching-substring>
+			<xsl:variable name="valueOfStringCleaned"
+					select="translate(.,$valueOfStringCleanedPattern,'')" />
+				<xsl:call-template name="velocityConditionForResponseItems">
+					<xsl:with-param name="var" select="$valueOfStringCleaned" />
+				</xsl:call-template>
+			</xsl:matching-substring>
+			<xsl:non-matching-substring>
+				<xsl:copy-of select="." />
+			</xsl:non-matching-substring>
+		</xsl:analyze-string>
 	</xsl:template>
-
-	<xsl:template name="blockEnd">
-		<xsl:text disable-output-escaping="yes">&lt;/fo:block&gt;</xsl:text>
-	</xsl:template>
-
-	<xsl:template name="velocityCondition">
+	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Velocity condition for replacement of ddi response items variables.</xd:p>
+		</xd:desc>
+	</xd:doc>
+	<xsl:template name="velocityConditionForResponseItems">
 		<xsl:param name="var" />
 		<xsl:text disable-output-escaping="yes"> if(${</xsl:text>
 		<xsl:value-of select="$var" />
@@ -73,6 +118,16 @@
 		<xsl:value-of select="$var" />
 		<xsl:text disable-output-escaping="yes">} #else &lt;fo:block border-bottom=&quot;1px dotted black&quot; &gt; &amp;#160; &lt;/fo:block&gt; #end 
 		</xsl:text>
+	</xsl:template>
+	
+	<xd:doc>
+		<xd:desc>
+			<xd:p>Velocity variable for replacement of all non ddi response items variables.</xd:p>
+		</xd:desc>
+	</xd:doc>
+	<xsl:template name="simpleVelocityCondition">
+		<xsl:param name="var" />
+		<xsl:text disable-output-escaping="yes"> ${</xsl:text> <xsl:value-of select="$var" /> <xsl:text disable-output-escaping="yes">} </xsl:text>
 	</xsl:template>
 </xsl:stylesheet>
 	

--- a/src/main/scripts/build-ddi2pdf.xml
+++ b/src/main/scripts/build-ddi2pdf.xml
@@ -2,6 +2,8 @@
 <project name="enoDDI2PDF" basedir="." default="full">
 
 	<import file="build-pdf.xml"/>
+	
+	<import file="build-customization.xml"/>
 
 	<!-- Importing the configuration part that is common to every script -->
 	<import file="build-configuration.xml"/>
@@ -241,8 +243,15 @@
 	<!-- ********************************************** Targets OutPostProcessing ************************************************ -->
 	<target name="OutPostProcessing">
 		<!-- Expects the input file ${temp.home}/pdf/${form-name}/basic-form.tmp -->
+
+		<property name="pdfFilePath"  value="${root-folder}/target/${survey-name}/${form-name}/form/out-form.${out-extension}"/>
 		<antcall target="pdfPostProcessing">
 			<param name="input-file" value="${temp.home}/pdf/${form-name}/basic-form.tmp"/>
+			<param name="output-file" value="${pdfFilePath}"/>
+		</antcall>
+		<antcall target="customizationPostProcessing">
+			<param name="input-file" value="${pdfFilePath}"/>
+			<param name="properties-file" value="${root-folder}/config/ddi2pdf.xml"/>
 		</antcall>
 	</target>
 

--- a/src/main/scripts/build-pdf.xml
+++ b/src/main/scripts/build-pdf.xml
@@ -50,10 +50,11 @@
 			<arg
 				value="inFileName=${root-folder}/target/${survey-name}/${form-name}/form/form.${out-extension}"/>
 			<arg
-				value="outFileName=${root-folder}/target/${survey-name}/${form-name}/form/out-form.${out-extension}"/>
+				value="outFileName=${output-file}"/>
 			<arg value="xmlConfFile=${root-folder}/src/main/resources/config/plugins-conf.xml"/>
 			<classpath refid="classpath"/>
 		</java>
 	</target>
+	
 
 </project>

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2FO.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2FO.java
@@ -5,6 +5,7 @@ import java.io.File;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2PDFGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2FO {
@@ -13,7 +14,7 @@ public class DummyTestDDI2FO {
 		
 		String basePathDDI2FO = "src/test/resources/ddi-to-fo";
 		GenerationService genServiceDDI2PDF = new GenerationService(new DDIPreprocessor(), new DDI2PDFGenerator(),
-				new NoopPostprocessor());
+				new Postprocessor[] {new NoopPostprocessor()});
 		File in = new File(String.format("%s/in.xml", basePathDDI2FO));
 		try {
 			File output = genServiceDDI2PDF.generateQuestionnaire(in, null,"test");

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2FOWithPlugins.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2FOWithPlugins.java
@@ -4,7 +4,9 @@ import java.io.File;
 
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2PDFGenerator;
+import fr.insee.eno.postprocessing.CustomizationPostprocessor;
 import fr.insee.eno.postprocessing.PDFPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2FOWithPlugins {
@@ -13,7 +15,7 @@ public class DummyTestDDI2FOWithPlugins {
 		
 		String basePathDDI2FO = "src/test/resources/ddi-to-fo";
 		GenerationService genServiceDDI2PDF = new GenerationService(new DDIPreprocessor(), new DDI2PDFGenerator(),
-				new PDFPostprocessor());
+				new Postprocessor[] {new PDFPostprocessor(), new CustomizationPostprocessor()});
 		File in = new File(String.format("%s/in.xml", basePathDDI2FO));
 		
 		try {

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2ODT.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2ODT.java
@@ -5,6 +5,7 @@ import java.io.File;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2ODTGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2ODT {
@@ -13,7 +14,7 @@ public class DummyTestDDI2ODT {
 		
 		String basePathDDI2ODT = "src/test/resources/ddi-to-odt";
 		GenerationService genServiceDDI2ODT = new GenerationService(new DDIPreprocessor(), new DDI2ODTGenerator(),
-				new NoopPostprocessor());
+				new Postprocessor[] {new NoopPostprocessor()});
 		File in = new File(String.format("%s/in.xml", basePathDDI2ODT));
 		
 		try {

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2PDF.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2PDF.java
@@ -22,7 +22,9 @@ import org.apache.fop.apps.MimeConstants;
 
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2PDFGenerator;
+import fr.insee.eno.postprocessing.CustomizationPostprocessor;
 import fr.insee.eno.postprocessing.PDFPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2PDF {
@@ -31,8 +33,8 @@ public class DummyTestDDI2PDF {
 
 		String basePathddi2PDF = "src/test/resources/ddi-to-pdf";
 		String basePathImg = "src/test/resources/examples/img/";
-		GenerationService genServiceDDI2PDF = new GenerationService(new DDIPreprocessor(), new DDI2PDFGenerator(),
-				new PDFPostprocessor());
+		Postprocessor[] postprocessors =  {new PDFPostprocessor(), new CustomizationPostprocessor()};
+		GenerationService genServiceDDI2PDF = new GenerationService(new DDIPreprocessor(), new DDI2PDFGenerator(), postprocessors);
 		File in = new File(String.format("%s/in.xml", basePathddi2PDF));
 		File xconf = new File(String.format("%s/fop.xconf", basePathddi2PDF));
 

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2PDFExamples.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2PDFExamples.java
@@ -23,7 +23,9 @@ import org.apache.fop.apps.MimeConstants;
 
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2PDFGenerator;
+import fr.insee.eno.postprocessing.CustomizationPostprocessor;
 import fr.insee.eno.postprocessing.PDFPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2PDFExamples {
@@ -44,7 +46,7 @@ public class DummyTestDDI2PDFExamples {
 			generator.setPropertiesFile(FileUtils.openInputStream(propertiesFile));
 			
 			GenerationService genServiceDDI2PDF = new GenerationService(new DDIPreprocessor(), generator,
-					new PDFPostprocessor());
+					new Postprocessor[] {new PDFPostprocessor(), new CustomizationPostprocessor()});
 			
 			File outputFO = genServiceDDI2PDF.generateQuestionnaire(in, null,"examples");
 			

--- a/src/test/java/fr/insee/eno/main/DummyTestDDI2XForms.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestDDI2XForms.java
@@ -10,6 +10,7 @@ import org.xmlunit.diff.Diff;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2FRGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class DummyTestDDI2XForms {
@@ -18,7 +19,7 @@ public class DummyTestDDI2XForms {
 		
 		String basePathDDI2XFORMS = "src/test/resources/ddi-to-xform";
 		GenerationService genServiceDDI2XFORMS = new GenerationService(new DDIPreprocessor(), new DDI2FRGenerator(),
-				new NoopPostprocessor());
+				new Postprocessor[] {new NoopPostprocessor()});
 		File in = new File(String.format("%s/in.xml", basePathDDI2XFORMS));
 		
 		try {

--- a/src/test/java/fr/insee/eno/main/DummyTestPoguesXML2DDI.java
+++ b/src/test/java/fr/insee/eno/main/DummyTestPoguesXML2DDI.java
@@ -5,6 +5,7 @@ import java.io.File;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.PoguesXML2DDIGenerator;
 import fr.insee.eno.postprocessing.DDIPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.PoguesXMLPreprocessor;
 
 public class DummyTestPoguesXML2DDI {
@@ -13,7 +14,7 @@ public class DummyTestPoguesXML2DDI {
 
 		String basePath = "src/test/resources/pogues-xml-to-ddi";
 		GenerationService genService = new GenerationService(new PoguesXMLPreprocessor(), new PoguesXML2DDIGenerator(),
-				new DDIPostprocessor());
+				new Postprocessor[] {new DDIPostprocessor()});
 		File in = new File(String.format("%s/in.xml", basePath));
 		try {
 			File output = genService.generateQuestionnaire(in, null, "test");

--- a/src/test/java/fr/insee/eno/test/TestDDIToFO.java
+++ b/src/test/java/fr/insee/eno/test/TestDDIToFO.java
@@ -11,6 +11,7 @@ import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2PDFGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
 import fr.insee.eno.postprocessing.PDFPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class TestDDIToFO {
@@ -27,7 +28,7 @@ public class TestDDIToFO {
 			
 			// Without plugins
 			GenerationService genService = new GenerationService(new DDIPreprocessor(), new DDI2PDFGenerator(),
-					new NoopPostprocessor());
+					new Postprocessor[] {new NoopPostprocessor()});
 			File outputFile = genService.generateQuestionnaire(in, null,"ddi-2-fo-test");
 			File expectedFile = new File(String.format("%s/out.fo", basePath));
 			diff = xmlDiff.getDiff(outputFile,expectedFile);

--- a/src/test/java/fr/insee/eno/test/TestDDIToODT.java
+++ b/src/test/java/fr/insee/eno/test/TestDDIToODT.java
@@ -10,6 +10,7 @@ import org.xmlunit.diff.Diff;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2ODTGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class TestDDIToODT {
@@ -22,7 +23,7 @@ public class TestDDIToODT {
 		try {
 			String basePath = "src/test/resources/ddi-to-odt";
 			GenerationService genService = new GenerationService(new DDIPreprocessor(), new DDI2ODTGenerator(),
-					new NoopPostprocessor());
+					new Postprocessor[] {new NoopPostprocessor()});
 			File in = new File(String.format("%s/in.xml", basePath));
 			File outputFile = genService.generateQuestionnaire(in, null,"ddi-2-odt-test");
 			File expectedFile = new File(String.format("%s/out.odt", basePath));

--- a/src/test/java/fr/insee/eno/test/TestDDIToXForm.java
+++ b/src/test/java/fr/insee/eno/test/TestDDIToXForm.java
@@ -1,19 +1,16 @@
 package fr.insee.eno.test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
-import org.apache.commons.io.FilenameUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.xmlunit.diff.Diff;
 
-import fr.insee.eno.Constants;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.DDI2FRGenerator;
 import fr.insee.eno.postprocessing.NoopPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.DDIPreprocessor;
 
 public class TestDDIToXForm {
@@ -26,7 +23,7 @@ public class TestDDIToXForm {
 		try {
 			String basePath = "src/test/resources/ddi-to-xform";
 			GenerationService genService = new GenerationService(new DDIPreprocessor(), new DDI2FRGenerator(),
-					new NoopPostprocessor());
+					new Postprocessor[] {new NoopPostprocessor()});
 			File in = new File(String.format("%s/in.xml", basePath));
 			File outputFile = genService.generateQuestionnaire(in, null,"ddi-2-fr-test");
 			File expectedFile = new File(String.format("%s/out.xhtml", basePath));

--- a/src/test/java/fr/insee/eno/test/TestPoguesXMLToDDI.java
+++ b/src/test/java/fr/insee/eno/test/TestPoguesXMLToDDI.java
@@ -12,6 +12,7 @@ import org.xmlunit.diff.Diff;
 import fr.insee.eno.GenerationService;
 import fr.insee.eno.generation.PoguesXML2DDIGenerator;
 import fr.insee.eno.postprocessing.DDIPostprocessor;
+import fr.insee.eno.postprocessing.Postprocessor;
 import fr.insee.eno.preprocessing.PoguesXMLPreprocessor;
 
 public class TestPoguesXMLToDDI {
@@ -23,7 +24,7 @@ public class TestPoguesXMLToDDI {
 		try {
 			String basePath = "src/test/resources/pogues-xml-to-ddi";
 			GenerationService genService = new GenerationService(new PoguesXMLPreprocessor(), new PoguesXML2DDIGenerator(),
-					new DDIPostprocessor());
+					new Postprocessor[] {new DDIPostprocessor()});
 			File in = new File(String.format("%s/in.xml", basePath));
 			File outputFile = genService.generateQuestionnaire(in, null,"xml-pogues-2-ddi-test");
 			File expectedFile = new File(String.format("%s/out.xml", basePath));


### PR DESCRIPTION
prise en compte des points remontés par Benoit et François (CF mails du 16 et 17 juillet) + améliorations/nettoyage code.

1/ Il faut paramétrer et rendre plus générique la transformation 
 
2/ récupération des attributs du noeud contenant le pattern à matcher (prise en compte remarque de François)
 
3/ traiter la séparation entre les noeuds de réponses et les autres noeuds=>
If variable then variable else "..." 
ne doit s'appliquer que pour les formats de réponse de type texte pas
partout...
 
Exemple ici avec la question 5, on retrouve les .......... alors que
c'est une instruction, le format de réponse arrive ensuite (format
date).
 
4/création d'un post processor de publipostage séparé
 
5/ inclusion de l'appel du postprocessor de publipostage dans la chaine ant

6- Prise en compte de la contrainte lié au SpecialCharacterSymbol2  
SpecialCharacterSymbol2 peut avoir 2 valeurs différentes : TextConditioningVariable\ddi\Before et TextConditioningVariable\ddi\After

7 - utilisation de la syntaxe Velocity pour la page de garde aussi.

8- nettoyage du code (constantes dupliquées, code inutile,...)