### PR TITLE
pdf Esa

### DIFF
--- a/questionnaires/esa-2018-a00/barcode-specific-treatment.xsl
+++ b/questionnaires/esa-2018-a00/barcode-specific-treatment.xsl
@@ -39,7 +39,7 @@
                         <xsl:non-matching-substring>
                             <xsl:analyze-string select="$descendant-id" regex="^(.+)-([0-9])+$">
                                 <xsl:matching-substring>
-                                    <xsl:value-of select="concat(upper-case(replace(regex-group(1),'_','')),'_0')"/>
+                                    <xsl:value-of select="concat(upper-case(replace(regex-group(1),'_','')),'00')"/>
                                 </xsl:matching-substring>
                                 <xsl:non-matching-substring>
                                     <xsl:value-of select="upper-case(replace($descendant-id,'_',''))"/>

--- a/src/main/resources/styles/style.xsl
+++ b/src/main/resources/styles/style.xsl
@@ -1,12 +1,16 @@
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    
- <xsl:attribute-set name="Titre-sequence">
+
+    <xsl:attribute-set name="Titre-sequence">
         <xsl:attribute name="background-color">#666666</xsl:attribute>
         <xsl:attribute name="color">white</xsl:attribute>
         <xsl:attribute name="font-weight">bold</xsl:attribute>
         <xsl:attribute name="margin-bottom">9pt</xsl:attribute>
         <xsl:attribute name="margin-top">3pt</xsl:attribute>
         <xsl:attribute name="font-size">14pt</xsl:attribute>
+        <xsl:attribute name="border-color">black</xsl:attribute>
+        <xsl:attribute name="border-style">solid</xsl:attribute>
+        <xsl:attribute name="space-before">10mm</xsl:attribute>
+        <xsl:attribute name="space-before.conditionality">discard</xsl:attribute>
     </xsl:attribute-set>
     <xsl:attribute-set name="Titre-paragraphe">
         <xsl:attribute name="background-color">#CCCCCC</xsl:attribute>

--- a/src/main/resources/xslt/outputs/pdf/models.xsl
+++ b/src/main/resources/xslt/outputs/pdf/models.xsl
@@ -109,7 +109,17 @@
 			<xsl:otherwise>
 				<xsl:value-of select="$properties//Capture/Numeric"/>
 			</xsl:otherwise>
-		</xsl:choose>		
+		</xsl:choose>
+	</xsl:variable>
+	<xsl:variable name="page-break-between">
+		<xsl:choose>
+			<xsl:when test="$parameters//PageBreakBetween/pdf != ''">
+				<xsl:value-of select="$parameters//PageBreakBetween/pdf"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$properties//PageBreakBetween/pdf"/>
+			</xsl:otherwise>
+		</xsl:choose>
 	</xsl:variable>
 	
 	<xsl:include href="../../../styles/style.xsl"/>
@@ -140,27 +150,27 @@
 							<fo:region-body margin="13mm" column-count="{$column-count}"/>
 							<fo:region-before region-name="portrait-region-before" extent="25mm" display-align="before" precedence="true"/>
 							<fo:region-after region-name="portrait-region-after" extent="25mm" display-align="before" precedence="true"/>
-						</fo:simple-page-master>						
+						</fo:simple-page-master>
 					</xsl:when>
 					<xsl:otherwise>
 						<fo:simple-page-master master-name="A4-landscape-odd" page-height="297mm"
 							page-width="210mm" font-family="Arial" font-size="10pt" reference-orientation="{$orientation}"
-							font-weight="normal" margin-bottom="5mm">
-							<fo:region-body margin="13mm" column-count="{$column-count}"/>
+							font-weight="normal">
+							<fo:region-body margin="15mm" column-count="{$column-count}"/>
 							<fo:region-before region-name="landscape-region-before-odd" extent="25mm" display-align="before" precedence="true"/>
 							<fo:region-after region-name="landscape-region-after-odd" extent="25mm" display-align="before" precedence="true"/>
 							<fo:region-start region-name="landscape-region-start" extent="10mm" display-align="before"/>
-							<fo:region-end region-name="landscape-region-end" extent="10mm" display-align="before"/>
+							<!--<fo:region-end region-name="landscape-region-end" extent="10mm" display-align="before"/>-->
 						</fo:simple-page-master>
 						<fo:simple-page-master master-name="A4-landscape-even" page-height="297mm"
 							page-width="210mm" font-family="Arial" font-size="10pt" reference-orientation="{$orientation}"
-							font-weight="normal" margin-bottom="5mm">
-							<fo:region-body margin="13mm" column-count="{$column-count}"/>
+							font-weight="normal">
+							<fo:region-body margin="15mm" column-count="{$column-count}"/>
 							<fo:region-before region-name="landscape-region-before-even" extent="25mm" display-align="before" precedence="true"/>
 							<fo:region-after region-name="landscape-region-after-even" extent="25mm" display-align="before" precedence="true"/>
 							<fo:region-start region-name="landscape-region-start" extent="10mm" display-align="before"/>
-							<fo:region-end region-name="landscape-region-end" extent="10mm" display-align="before"/>
-						</fo:simple-page-master>						
+							<!--<fo:region-end region-name="landscape-region-end" extent="10mm" display-align="before"/>-->
+						</fo:simple-page-master>
 					</xsl:otherwise>
 				</xsl:choose>
 				<fo:page-sequence-master master-name="A4">
@@ -180,7 +190,7 @@
 					</xsl:choose>
 				</fo:page-sequence-master>
 			</fo:layout-master-set>
-			<fo:page-sequence master-reference="A4" initial-page-number="2">
+			<fo:page-sequence master-reference="A4" initial-page-number="2" force-page-count="odd">
 				<xsl:choose>
 					<xsl:when test="$orientation = '0'">
 						<fo:static-content flow-name="portrait-region-before">
@@ -194,12 +204,12 @@
 									<fo:instream-foreign-object>
 										<barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" orientation="90">
 											<xsl:attribute name="message" select="'${idQuestionnaire}-#page-number#'"/>
-											<barcode:code128>
+											<barcode:code39>
 												<barcode:height>8mm</barcode:height>
 												<barcode:human-readable>
 													<barcode:placement>none</barcode:placement>
 												</barcode:human-readable>
-											</barcode:code128>
+											</barcode:code39>
 										</barcode:barcode>
 									</fo:instream-foreign-object>
 									<fo:block-container reference-orientation="90" margin-left="5mm">
@@ -222,14 +232,14 @@
 					</xsl:when>
 					<xsl:otherwise>
 						<fo:static-content flow-name="landscape-region-before-odd">
-							<fo:block position="absolute" margin="10mm" text-align="right">
+							<fo:block position="absolute" margin-top="6mm" margin-right="6mm" text-align="right">
 								<xsl:call-template name="insert-image">
 									<xsl:with-param name="image-name" select="'encoche-top-right.png'"/>
 								</xsl:call-template>
 							</fo:block>
 						</fo:static-content>
 						<fo:static-content flow-name="landscape-region-after-odd">
-							<fo:block position="absolute" margin-left="10mm" margin-top="10mm" bottom="0mm" text-align="left">
+							<fo:block position="absolute" margin-left="6mm" margin-top="14mm" bottom="0mm" text-align="left">
 								<xsl:call-template name="insert-image">
 									<xsl:with-param name="image-name" select="'encoche-bottom-left.png'"/>
 								</xsl:call-template>
@@ -237,46 +247,46 @@
 							<fo:block text-align="center">
 								<fo:page-number/> / <fo:page-number-citation ref-id="TheVeryLastPage"/>
 							</fo:block>
-							<fo:block-container text-align="left" absolute-position="absolute" left="220mm" top="10mm">
+							<fo:block-container text-align="left" absolute-position="absolute" left="180mm" top="15mm">
 								<fo:block>
 									<fo:instream-foreign-object>
 										<barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns">
 											<xsl:attribute name="message" select="'${idQuestionnaire}-#page-number#'"/>
-											<barcode:code128>
+											<barcode:code39>
 												<barcode:height>8mm</barcode:height>
 												<barcode:human-readable>
 													<barcode:placement>top</barcode:placement>
 												</barcode:human-readable>
-											</barcode:code128>
+											</barcode:code39>
 										</barcode:barcode>
 									</fo:instream-foreign-object>
 								</fo:block>
 							</fo:block-container>
 						</fo:static-content>
 						<fo:static-content flow-name="landscape-region-before-even">
-							<fo:block-container text-align="left" absolute-position="absolute" left="220mm" top="5mm">
+							<fo:block-container text-align="left" absolute-position="absolute" left="180mm" top="0mm">
 								<fo:block>
 									<fo:instream-foreign-object>
 										<barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns">
 											<xsl:attribute name="message" select="'${idQuestionnaire}-#page-number#'"/>
-											<barcode:code128>
+											<barcode:code39>
 												<barcode:height>8mm</barcode:height>
 												<barcode:human-readable>
 													<barcode:placement>bottom</barcode:placement>
 												</barcode:human-readable>
-											</barcode:code128>
+											</barcode:code39>
 										</barcode:barcode>
 									</fo:instream-foreign-object>
 								</fo:block>
 							</fo:block-container>
-							<fo:block position="absolute" margin="10mm" text-align="right">
+							<fo:block position="absolute" margin-top="6mm" margin-right="6mm" text-align="right">
 								<xsl:call-template name="insert-image">
 									<xsl:with-param name="image-name" select="'encoche-top-right.png'"/>
 								</xsl:call-template>
 							</fo:block>
 						</fo:static-content>
 						<fo:static-content flow-name="landscape-region-after-even">
-							<fo:block position="absolute" margin-left="10mm" margin-top="10mm" bottom="0mm" text-align="left">
+							<fo:block position="absolute" margin-left="6mm" margin-top="14mm" bottom="0mm" text-align="left">
 								<xsl:call-template name="insert-image">
 									<xsl:with-param name="image-name" select="'encoche-bottom-left.png'"/>
 								</xsl:call-template>
@@ -286,39 +296,39 @@
 							</fo:block>
 						</fo:static-content>
 						<fo:static-content flow-name="landscape-region-start">
-							<fo:block-container absolute-position="absolute" left="0mm" top="100mm">
+							<fo:block-container absolute-position="absolute" left="5mm" top="85mm">
 								<fo:block>
 									<fo:instream-foreign-object>
 										<barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" orientation="-90">
 											<xsl:attribute name="message" select="'${idQuestionnaire}-#page-number#'"/>
-											<barcode:code128>
+											<barcode:code39>
 												<barcode:height>8mm</barcode:height>
 												<barcode:human-readable>
-													<barcode:placement>top</barcode:placement>
+													<barcode:placement>none</barcode:placement>
 												</barcode:human-readable>
-											</barcode:code128>
+											</barcode:code39>
 										</barcode:barcode>
 									</fo:instream-foreign-object>
 								</fo:block>
 							</fo:block-container>
 						</fo:static-content>
-						<fo:static-content flow-name="landscape-region-end">
-							<fo:block-container absolute-position="absolute" left="0mm" top="100mm">
+						<!--<fo:static-content flow-name="landscape-region-end">
+							<fo:block-container absolute-position="absolute" left="0mm" top="85mm">
 								<fo:block>
 									<fo:instream-foreign-object>
 										<barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" orientation="-90">
 											<xsl:attribute name="message" select="'${idQuestionnaire}-#page-number#'"/>
-											<barcode:code128>
-												<barcode:height>8mm</barcode:height>
+											<barcode:code39>
+												<barcode:height>10mm</barcode:height>
 												<barcode:human-readable>
 													<barcode:placement>bottom</barcode:placement>
 												</barcode:human-readable>
-											</barcode:code128>
+											</barcode:code39>
 										</barcode:barcode>
 									</fo:instream-foreign-object>
 								</fo:block>
 							</fo:block-container>
-						</fo:static-content>
+						</fo:static-content>-->
 					</xsl:otherwise>
 				</xsl:choose>
 				
@@ -350,7 +360,10 @@
 		<xsl:param name="source-context" as="item()" tunnel="yes"/>
 		<xsl:param name="languages" tunnel="yes"/>
 		
-		<fo:block xsl:use-attribute-sets="Titre-sequence" border-color="black" border-style="solid" page-break-inside="avoid" keep-with-next="always">
+		<fo:block xsl:use-attribute-sets="Titre-sequence" page-break-inside="avoid" keep-with-next="always">
+			<xsl:if test="lower-case($page-break-between) = 'module' or lower-case($page-break-between) = 'submodule'">
+				<xsl:attribute name="page-break-before" select="'always'"/>
+			</xsl:if>
 			<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 		</fo:block>
 		<xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
@@ -371,6 +384,9 @@
 		<xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
 			<xsl:with-param name="driver" select="." tunnel="yes"/>
 		</xsl:apply-templates>
+		<xsl:if test="lower-case($page-break-between) = 'submodule'">
+			<fo:block page-break-after="always"> </fo:block>
+		</xsl:if>
 	</xsl:template>
 
 	<xd:doc>
@@ -482,7 +498,7 @@
 		<xsl:variable name="length" select="enopdf:get-length($source-context)"/>
 		
 		<xsl:if test="enopdf:get-label($source-context, $languages[1]) != ''">
-			<fo:block font-size="10pt" font-weight="bold" color="black"> <!--linefeed-treatment="preserve"-->
+			<fo:block xsl:use-attribute-sets="label-question"> <!--linefeed-treatment="preserve"-->
 				<xsl:copy-of select="enopdf:get-label($source-context, $languages[1])"/>
 			</fo:block>
 		</xsl:if>
@@ -553,10 +569,20 @@
 								</xsl:for-each>
 							</xsl:when>
 							<xsl:otherwise>
+								<xsl:variable name="width-coefficient" as="xs:integer">
+									<xsl:choose>
+										<xsl:when test="not($isTable = 'YES') or ($no-border = 'no-border')">
+											<xsl:value-of select="4"/>
+										</xsl:when>
+										<xsl:otherwise>
+											<xsl:value-of select="3"/>
+										</xsl:otherwise>
+									</xsl:choose>
+								</xsl:variable>
 								<fo:inline-container>
-									<xsl:attribute name="width" select="concat(string($length*3),'mm')"/>
+									<xsl:attribute name="width" select="concat(string($length*$width-coefficient),'mm')"/>
 									<fo:block-container height="8mm">
-										<xsl:attribute name="width" select="concat(string($length*3),'mm')"/>
+										<xsl:attribute name="width" select="concat(string($length*$width-coefficient),'mm')"/>
 										<xsl:if test="not($isTable = 'YES') or ($no-border = 'no-border')">
 											<xsl:attribute name="border-color" select="'black'"/>
 											<xsl:attribute name="border-style" select="'solid'"/>
@@ -604,8 +630,6 @@
 		<xsl:choose>
 			<xsl:when test="$no-border = 'no-border'">
 				<fo:inline>
-					<!--<fo:inline font-family="ZapfDingbats" font-size="10pt" padding-before="5mm" padding-after="1mm" wrap-option="inherit">&#x274F;</fo:inline>-->
-					<!--<fo:inline font-family="Arial" font-size="15pt" margin-left="5mm" margin-right="1mm" wrap-option="inherit" margin-bottom="10mm">&#9633;</fo:inline>-->
 					<fo:inline>
 						<xsl:call-template name="insert-image">
 							<xsl:with-param name="image-name" select="'check_case.png'"/>
@@ -629,8 +653,6 @@
 				<fo:list-item>
 					<fo:list-item-label end-indent="label-end()">
 						<fo:block text-align="right">
-							<!--<fo:inline font-family="ZapfDingbats" font-size="10pt" padding="5mm">&#x274F;</fo:inline>-->
-							<!--<fo:inline font-family="Arial" font-size="15pt" padding="4mm" baseline-shift="super">&#9633;</fo:inline>-->
 							<xsl:call-template name="insert-image">
 								<xsl:with-param name="image-name" select="'check_case.png'"/>
 							</xsl:call-template>
@@ -754,7 +776,17 @@
 						</xsl:otherwise>
 					</xsl:choose>
 					<xsl:if test="$total-lines &gt; $maxlines-by-table -1">
-						<xsl:value-of select="concat('-',$page-position)"/>
+						<xsl:choose>
+							<!-- For TableLoop, "-" character will be used to identify pages which will have the same input mask -->
+							<!-- For Table, input masks of page 2 and page 3 will be different -->
+							<xsl:when test="$table-type = 'Table'">
+								<xsl:value-of select="'0'"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:value-of select="'-'"/>	
+							</xsl:otherwise>
+						</xsl:choose>
+						<xsl:value-of select="$page-position"/>
 					</xsl:if>
 				</xsl:attribute>
 				<xsl:if test="$current-match/name()='TableLoop' and $total-lines &gt; $maxlines-by-table -1">

--- a/src/main/resources/xslt/util/pdf/static-pages.fo
+++ b/src/main/resources/xslt/util/pdf/static-pages.fo
@@ -11,7 +11,7 @@
                     odd-or-even="even"/>
             </fo:repeatable-page-master-alternatives>
         </fo:page-sequence-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="ouvertureCOL-recto" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -19,7 +19,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="ouvertureCOL-verso" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -36,7 +36,7 @@
                     odd-or-even="even"/>
             </fo:repeatable-page-master-alternatives>
         </fo:page-sequence-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="entreeCOL-recto" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -44,7 +44,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="entreeCOL-verso" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -61,7 +61,7 @@
                     odd-or-even="even"/>
             </fo:repeatable-page-master-alternatives>
         </fo:page-sequence-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="relanceCOL-recto" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -69,7 +69,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="relanceCOL-verso" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -86,7 +86,7 @@
                     odd-or-even="even"/>
             </fo:repeatable-page-master-alternatives>
         </fo:page-sequence-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="cnrCOL-recto" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -94,7 +94,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="cnrCOL-verso" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -111,7 +111,7 @@
                     odd-or-even="even"/>
             </fo:repeatable-page-master-alternatives>
         </fo:page-sequence-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="medCOL-recto" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -119,7 +119,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" master-name="medCOL-verso" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -128,7 +128,7 @@
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
         
-        <fo:simple-page-master master-name="Cover-A4" font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master master-name="Cover-A4" font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" page-height="297mm" page-width="210mm">
             <fo:region-body column-count="1" margin="0mm"/>
             <fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -136,7 +136,7 @@
             <fo:region-after display-align="before" extent="100mm" precedence="true"
                 region-name="xsl-region-after-cover"/>
         </fo:simple-page-master>
-        <fo:simple-page-master master-name="Cover-A4-90" font-family="Liberation Sans" font-size="10pt" font-weight="normal"
+        <fo:simple-page-master master-name="Cover-A4-90" font-family="Arial" font-size="10pt" font-weight="normal"
             margin-bottom="5mm" page-height="297mm" page-width="210mm" reference-orientation="90">
             <fo:region-body column-count="1" margin="0mm"/>
             <!--<fo:region-before display-align="before" extent="100mm" precedence="true"
@@ -146,7 +146,7 @@
         </fo:simple-page-master>
 
         <fo:simple-page-master master-name="questions-fin" page-height="297mm"
-            page-width="210mm" font-family="arial" font-size="10pt"
+            page-width="210mm" font-family="Arial" font-size="10pt"
             font-weight="normal" margin-bottom="5mm">
             <fo:region-body margin="13mm" column-count="1"/>
             <fo:region-before region-name="xsl-region-before" extent="25mm" display-align="before" precedence="true"/>
@@ -154,7 +154,7 @@
         </fo:simple-page-master>
     </fo:layout-master-set>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="ouvertureCOL">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="ouvertureCOL">
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
                 &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
@@ -239,7 +239,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="107.2mm"
-                    width="180mm" height="155mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="155mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify">
                     <fo:block>
                         <fo:inline-container>
@@ -307,7 +307,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="258mm"
-                    width="180mm" height="25mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="25mm" overflow="hidden" font-family="Arial"
                     font-size="7pt">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="solid black 0.5pt">
                         <fo:inline-container margin-top="0.5mm" margin-left="1mm">
@@ -338,7 +338,7 @@
             <fo:block page-break-after="always">
                 <fo:block/>
                 <fo:block-container absolute-position="absolute" left="30mm" top="33mm"
-                    width="150mm" height="190mm" overflow="hidden" font-family="Liberation Sans"
+                    width="150mm" height="190mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify" border="black solid 0.5pt">
                     <fo:block border="black solid 0.5pt">
                         <fo:inline-container>
@@ -370,7 +370,7 @@
                                         passe.</fo:block>
                                 </fo:inline-container>
                             </fo:block>
-                            <fo:block-container height="11mm" overflow="hidden" font-family="Liberation Sans" font-size="9pt">
+                            <fo:block-container height="11mm" overflow="hidden" font-family="Arial" font-size="9pt">
                                 <fo:block text-align="center" margin-top="1mm" margin-left="7mm" margin-right="7mm" border="black solid 0.5pt">
                                     <fo:inline-container>
                                         <fo:block>Identifiant : ${BddIdentifiantContact}</fo:block>
@@ -455,7 +455,7 @@
         </fo:flow>
     </fo:page-sequence>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="entreeCOL">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="entreeCOL">
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
                 &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
@@ -539,7 +539,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="107.2mm"
-                    width="180mm" height="155mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="155mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify">
                     <fo:block>
                         <fo:inline-container>
@@ -607,7 +607,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="258mm"
-                    width="180mm" height="25mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="25mm" overflow="hidden" font-family="Arial"
                     font-size="7pt">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="solid black 0.5pt">
                         <fo:inline-container margin-top="0.5mm" margin-left="1mm">
@@ -638,7 +638,7 @@
             <fo:block page-break-after="always">
                 <fo:block/>
                 <fo:block-container absolute-position="absolute" left="30mm" top="33mm"
-                    width="150mm" height="190mm" overflow="hidden" font-family="Liberation Sans"
+                    width="150mm" height="190mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify" border="black solid 0.5pt">
                     <fo:block border="black solid 0.5pt">
                         <fo:inline-container>
@@ -670,7 +670,7 @@
                                         passe.</fo:block>
                                 </fo:inline-container>
                             </fo:block>
-                            <fo:block-container height="11mm" overflow="hidden" font-family="Liberation Sans" font-size="9pt">
+                            <fo:block-container height="11mm" overflow="hidden" font-family="Arial" font-size="9pt">
                                 <fo:block text-align="center" margin-top="1mm" margin-left="7mm" margin-right="7mm" border="black solid 0.5pt">
                                     <fo:inline-container>
                                         <fo:block>Identifiant : ${BddIdentifiantContact}</fo:block>
@@ -754,7 +754,7 @@
         </fo:flow>
     </fo:page-sequence>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="relanceCOL">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="relanceCOL">
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
                 &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
@@ -838,7 +838,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="107.2mm"
-                    width="180mm" height="155mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="155mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify">
                     <fo:block>
                         <fo:inline-container>
@@ -885,7 +885,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="258mm"
-                    width="180mm" height="25mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="25mm" overflow="hidden" font-family="Arial"
                     font-size="7pt">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="solid black 0.5pt">
                         <fo:inline-container margin-top="0.5mm" margin-left="1mm">
@@ -916,7 +916,7 @@
             <fo:block page-break-after="always">
                 <fo:block/>
                 <fo:block-container absolute-position="absolute" left="30mm" top="33mm"
-                    width="150mm" height="190mm" overflow="hidden" font-family="Liberation Sans"
+                    width="150mm" height="190mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify" border="black solid 0.5pt">
                     <fo:block border="black solid 0.5pt">
                         <fo:inline-container>
@@ -1003,7 +1003,7 @@
         </fo:flow>
     </fo:page-sequence>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="cnrCOL">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="cnrCOL">
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
                 &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
@@ -1087,7 +1087,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="107.2mm"
-                    width="180mm" height="155mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="155mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify">
                     <fo:block>
                         <fo:inline-container>
@@ -1125,7 +1125,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="258mm"
-                    width="180mm" height="25mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="25mm" overflow="hidden" font-family="Arial"
                     font-size="7pt">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="solid black 0.5pt">
                         <fo:inline-container margin-top="0.5mm" margin-left="1mm">
@@ -1156,7 +1156,7 @@
             <fo:block page-break-after="always">
                 <fo:block/>
                 <fo:block-container absolute-position="absolute" left="30mm" top="33mm"
-                    width="150mm" height="190mm" overflow="hidden" font-family="Liberation Sans"
+                    width="150mm" height="190mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify" border="black solid 0.5pt">
                     <fo:block border="black solid 0.5pt">
                         <fo:inline-container>
@@ -1242,7 +1242,7 @@
         </fo:flow>
     </fo:page-sequence>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="medCOL">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="medCOL">
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
                 &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
@@ -1326,7 +1326,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="107.2mm"
-                    width="180mm" height="155mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="155mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify">
                     <fo:block>
                         <fo:inline-container>
@@ -1359,7 +1359,7 @@
                     </fo:block>
                 </fo:block-container>
                 <fo:block-container absolute-position="absolute" left="15mm" top="258mm"
-                    width="180mm" height="25mm" overflow="hidden" font-family="Liberation Sans"
+                    width="180mm" height="25mm" overflow="hidden" font-family="Arial"
                     font-size="7pt">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="solid black 0.5pt">
                         <fo:inline-container margin-top="0.5mm" margin-left="1mm">
@@ -1390,7 +1390,7 @@
             <fo:block page-break-after="always">
                 <fo:block/>
                 <fo:block-container absolute-position="absolute" left="30mm" top="33mm"
-                    width="150mm" height="190mm" overflow="hidden" font-family="Liberation Sans"
+                    width="150mm" height="190mm" overflow="hidden" font-family="Arial"
                     font-size="9pt" text-align="justify" border="black solid 0.5pt">
                     <fo:block border="black solid 0.5pt">
                         <fo:inline-container>
@@ -1476,7 +1476,7 @@
         </fo:flow>
     </fo:page-sequence>
     
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="Cover-A4">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="Cover-A4">
         <fo:flow flow-name="xsl-region-body">
             <fo:block page-break-inside="avoid">
                 <fo:block-container absolute-position="absolute" top="15mm" left="15mm"
@@ -1605,9 +1605,9 @@
                             <fo:instream-foreign-object>
                                 <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns"
                                     message="Code Bar" orientation="0">
-                                    <barcode:code128>
+                                    <barcode:code39>
                                         <barcode:height>10mm</barcode:height>
-                                    </barcode:code128>
+                                    </barcode:code39>
                                 </barcode:barcode>
                             </fo:instream-foreign-object>
                         </fo:block>
@@ -1630,18 +1630,18 @@
             </fo:block>
         </fo:flow>
     </fo:page-sequence>
-    <fo:page-sequence font-family="Liberation Sans" font-size="10pt" master-reference="Cover-A4-90">
+    <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="Cover-A4-90">
         <fo:static-content flow-name="landscape-after-cover">
-            <fo:block-container text-align="left" absolute-position="absolute" left="200mm" top="15mm">
+            <fo:block-container text-align="left" absolute-position="absolute" left="190mm" top="10mm">
                 <fo:block>
                     <fo:instream-foreign-object>
                         <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" message="${idQuestionnaire}-1">
-                            <barcode:code128>
+                            <barcode:code39>
                                 <barcode:height>8mm</barcode:height>
                                 <barcode:human-readable>
                                     <barcode:placement>none</barcode:placement>
                                 </barcode:human-readable>
-                            </barcode:code128>
+                            </barcode:code39>
                         </barcode:barcode>
                     </fo:instream-foreign-object>
                 </fo:block>

--- a/src/test/resources/ddi-to-fo/out.fo
+++ b/src/test/resources/ddi-to-fo/out.fo
@@ -9,11 +9,11 @@
          xmlns:fo="http://www.w3.org/1999/XSL/Format"
          xmlns:fox="http://xmlgraphics.apache.org/fop/extensions">
    <fo:layout-master-set>
-      <fo:simple-page-master font-family="Liberation Sans"
+      <fo:simple-page-master master-name="Cover-A4"
+                             font-family="Arial"
                              font-size="10pt"
                              font-weight="normal"
                              margin-bottom="5mm"
-                             master-name="Cover-A4"
                              page-height="297mm"
                              page-width="210mm">
          <fo:region-body column-count="1" margin="0mm"/>
@@ -67,9 +67,7 @@
          </fo:repeatable-page-master-alternatives>
       </fo:page-sequence-master>
    </fo:layout-master-set>
-   <fo:page-sequence font-family="Liberation Sans"
-                     font-size="10pt"
-                     master-reference="Cover-A4">
+   <fo:page-sequence font-family="Arial" font-size="10pt" master-reference="Cover-A4">
       <fo:flow flow-name="xsl-region-body">
          <fo:block page-break-inside="avoid">
             <fo:block-container absolute-position="absolute"
@@ -254,9 +252,9 @@
                         <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns"
                                          message="Code Bar"
                                          orientation="0">
-                           <barcode:code128>
+                           <barcode:code39>
                               <barcode:height>10mm</barcode:height>
-                           </barcode:code128>
+                           </barcode:code39>
                         </barcode:barcode>
                      </fo:instream-foreign-object>
                   </fo:block>
@@ -283,7 +281,9 @@
          </fo:block>
       </fo:flow>
    </fo:page-sequence>
-   <fo:page-sequence master-reference="A4" initial-page-number="2">
+   <fo:page-sequence master-reference="A4"
+                     initial-page-number="2"
+                     force-page-count="odd">
       <fo:static-content flow-name="portrait-region-before">
          <fo:block position="absolute" margin="10mm" text-align="right">
             <fo:external-graphic src="encoche-top-right.png"/>
@@ -297,12 +297,12 @@
                   <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns"
                                    orientation="90"
                                    message="${idQuestionnaire}-#page-number#">
-                     <barcode:code128>
+                     <barcode:code39>
                         <barcode:height>8mm</barcode:height>
                      <barcode:human-readable>
                            <barcode:placement>none</barcode:placement>
                         </barcode:human-readable>
-                     </barcode:code128>
+                     </barcode:code39>
                   </barcode:barcode>
                </fo:instream-foreign-object>
             <fo:block-container reference-orientation="90" margin-left="5mm">
@@ -335,6 +335,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">I - Introduction</fo:block>
          <fo:block font-size="9pt"
@@ -498,6 +500,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">II - Simpsons' city</fo:block>
          <fo:block font-size="9pt"
@@ -633,6 +637,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">III - Characters</fo:block>
          <fo:block color="black"
@@ -1288,6 +1294,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">IV - General questions</fo:block>
          <fo:block background-color="#CCCCCC"
@@ -2466,6 +2474,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">V - Favourite characters</fo:block>
          <fo:block color="black"
@@ -5724,6 +5734,8 @@
                    font-size="14pt"
                    border-color="black"
                    border-style="solid"
+                   space-before="10mm"
+                   space-before.conditionality="discard"
                    page-break-inside="avoid"
                    keep-with-next="always">VI - Comment</fo:block>
          <fo:block color="black"


### PR DESCRIPTION
Codebar :
- remove _ in the codes
- code 128 -> code 39
- Arial everywhere
- id of arrays : the - is replaced by a 0 in arrays so that different pages have different page-id in "module courrier"
- moved to the good place

Others :
- force count page : odd
- new param : PageBreakBetween
- numeric width : 3mm per digit in arrays ; 4mm out of arrays