### PR TITLE
279-BO Fix: Adding Sequence type unstead of Child in ControlConstruct…

### DIFF
--- a/src/main/resources/xslt/transformations/pogues-xml2ddi/pogues-xml2ddi-fixed.xsl
+++ b/src/main/resources/xslt/transformations/pogues-xml2ddi/pogues-xml2ddi-fixed.xsl
@@ -90,7 +90,7 @@
             <xsl:when test="local-name(.)='IfThenElse'">                                   
                 <xsl:value-of select="'IfThenElse'"/>
             </xsl:when>
-            <xsl:when test="pogues:Child or pogues:IfThenElse/descendant::pogues:Child">
+            <xsl:when test="local-name(.)='Child' or pogues:Child or pogues:IfThenElse/descendant::pogues:Child">
                 <xsl:value-of select="'Sequence'"/>                
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
commit c32977e1117d8607b05553125c22a60988ea16fb
    279-BO Fix: Adding Sequence type unstead of Child in ControlConstructReference node