### PR TITLE
bugs with dates and numeric suffix

### DIFF
--- a/src/main/resources/xslt/outputs/fr/models.xsl
+++ b/src/main/resources/xslt/outputs/fr/models.xsl
@@ -1504,7 +1504,27 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </xsl:variable>
-                    <xsl:for-each select="xs:integer(number(@minimum)) to xs:integer(number(@maximum))">
+                    <xsl:variable name="min" as="xs:integer">
+                        <xsl:choose>
+                            <xsl:when test="contains(@minimum,'date')">
+                                <xsl:value-of select="year-from-date(current-date())"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="number(@minimum)"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:variable name="max" as="xs:integer">
+                        <xsl:choose>
+                            <xsl:when test="contains(@maximum,'date')">
+                                <xsl:value-of select="year-from-date(current-date())"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="number(@maximum)"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
+                    <xsl:for-each select="$min to $max">
                         <xsl:sort select="." order="{$number-order}"/>
                         <xsl:variable name="current-value" select="."/>
                         <item>

--- a/src/main/resources/xslt/outputs/fr/models.xsl
+++ b/src/main/resources/xslt/outputs/fr/models.xsl
@@ -1124,8 +1124,8 @@
                             <xsl:value-of select="'if (string(.) != '''' and . castable as xs:date) then ('"/>
                             <xsl:if test="$minimum != ''">
                                 <xsl:choose>
-                                    <xsl:when test="contains($minimum,'current-date()')">
-                                        <xsl:value-of select="'. &gt; current-date()'"/>
+                                    <xsl:when test="contains($minimum,'-date()')">
+                                        <xsl:value-of select="'. &gt;= xs:date(local-date())'"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:value-of select="concat('. &gt;= xs:date(''',$minimum,''')')"/>
@@ -1137,8 +1137,8 @@
                             </xsl:if>
                             <xsl:if test="$maximum != ''">
                                 <xsl:choose>
-                                    <xsl:when test="contains($maximum,'current-date()')">
-                                        <xsl:value-of select="'. &lt; current-date()'"/>
+                                    <xsl:when test="contains($maximum,'-date()')">
+                                        <xsl:value-of select="'. &lt;= xs:date(local-date())'"/>
                                     </xsl:when>
                                     <xsl:otherwise>
                                         <xsl:value-of select="concat('. &lt;= xs:date(''',$maximum,''')')"/>
@@ -1207,13 +1207,27 @@
                                 <xsl:otherwise>
                                     <xsl:value-of select="concat('if(string(../',$name,') != '''') then (')"/>
                                     <xsl:if test="$minimum != ''">
-                                        <xsl:value-of select="concat('string(../',$name,') &gt;= ''',$minimum,'''')"/>
+                                        <xsl:choose>
+                                            <xsl:when test="contains($minimum,'-date()')">
+                                                <xsl:value-of select="concat('string(../',$name,') &gt;= substring(local-date(),1,7)')"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:value-of select="concat('string(../',$name,') &gt;= ''',$minimum,'''')"/>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
                                     </xsl:if>
                                     <xsl:if test="$minimum != '' and $maximum != ''">
                                         <xsl:value-of select="' and '"/>
                                     </xsl:if>
                                     <xsl:if test="$maximum != ''">
-                                        <xsl:value-of select="concat('string(../',$name,') &lt;= ''',$maximum,'''')"/>
+                                        <xsl:choose>
+                                            <xsl:when test="contains($maximum,'-date()')">
+                                                <xsl:value-of select="concat('string(../',$name,') &lt;= substring(local-date(),1,7)')"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:value-of select="concat('string(../',$name,') &lt;= ''',$maximum,'''')"/>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
                                     </xsl:if>
                                     <xsl:value-of select="concat(') else (../',$name,'='''')')"/>
                                 </xsl:otherwise>
@@ -1506,7 +1520,7 @@
                     </xsl:variable>
                     <xsl:variable name="min" as="xs:integer">
                         <xsl:choose>
-                            <xsl:when test="contains(@minimum,'date')">
+                            <xsl:when test="contains(@minimum,'-date()')">
                                 <xsl:value-of select="year-from-date(current-date())"/>
                             </xsl:when>
                             <xsl:otherwise>
@@ -1516,7 +1530,7 @@
                     </xsl:variable>
                     <xsl:variable name="max" as="xs:integer">
                         <xsl:choose>
-                            <xsl:when test="contains(@maximum,'date')">
+                            <xsl:when test="contains(@maximum,'-date()')">
                                 <xsl:value-of select="year-from-date(current-date())"/>
                             </xsl:when>
                             <xsl:otherwise>
@@ -1791,6 +1805,9 @@
                         </xsl:if>
                     </xsl:otherwise>
                 </xsl:choose>
+                <xsl:if test="not($suffix = '')">
+                    <xsl:attribute name="suffix" select="$suffix"/>
+                </xsl:if>
             </xsl:if>
             <xsl:if test="$label != '' or $question-label!= ''">
                 <xsl:variable name="conditioning-variables" as="xs:string*">
@@ -1902,7 +1919,7 @@
                 </xsl:element>
             </xsl:for-each>
         </xsl:element>
-        <xsl:if test="not($suffix = '')">
+        <xsl:if test="not($suffix = '') and not(self::NumericDomain)">
             <xsl:element name="xhtml:span">
                 <xsl:attribute name="class" select="'suffixe'"/>
                 <xsl:copy-of select="$suffix" copy-namespaces="no"/>
@@ -2492,8 +2509,8 @@
                         <format id="Y" unit="Year">
                             <xsl:attribute name="minimum">
                                 <xsl:choose>
-                                    <xsl:when test="contains($minimum,'current-date')">
-                                        <xsl:value-of select="'year-from-date(current-date())'"/>
+                                    <xsl:when test="contains($minimum,'-date()')">
+                                        <xsl:value-of select="'year-from-date(xs:date(local-date()))'"/>
                                     </xsl:when>
                                     <xsl:when test="contains($minimum,'-')">
                                         <xsl:value-of select="substring-before($minimum,'-')"/>
@@ -2508,8 +2525,8 @@
                             </xsl:attribute>
                             <xsl:attribute name="maximum">
                                 <xsl:choose>
-                                    <xsl:when test="contains($maximum,'current-date')">
-                                        <xsl:value-of select="'year-from-date(current-date())'"/>
+                                    <xsl:when test="contains($maximum,'-date()')">
+                                        <xsl:value-of select="'year-from-date(xs:date(local-date()))'"/>
                                     </xsl:when>
                                     <xsl:when test="contains($maximum,'-')">
                                         <xsl:value-of select="substring-before($maximum,'-')"/>
@@ -2518,7 +2535,7 @@
                                         <xsl:value-of select="$maximum"/>
                                     </xsl:when>
                                     <xsl:otherwise>
-                                        <xsl:value-of select="'year-from-date(current-date())'"/>
+                                        <xsl:value-of select="'year-from-date(xs:date(local-date()))'"/>
                                     </xsl:otherwise>
                                 </xsl:choose>
                             </xsl:attribute>

--- a/src/main/resources/xslt/outputs/fr/models.xsl
+++ b/src/main/resources/xslt/outputs/fr/models.xsl
@@ -2297,7 +2297,10 @@
         </xsl:variable>
         <xsl:variable name="input-format">
             <xsl:choose>
-                <xsl:when test="$current-driver='DurationDomain' or $dateduration-format = 'YYYY-MM-DD' or upper-case($dateduration-format) = 'JJ/MM/AAAA'">
+                <xsl:when test="$dateduration-format = 'YYYY-MM-DD' or upper-case($dateduration-format) = 'JJ/MM/AAAA'">
+                    <xsl:value-of select="'xf:input'"/>
+                </xsl:when>
+                <xsl:when test="$current-driver='DurationDomain'">
                     <xsl:value-of select="'fr:number'"/>
                 </xsl:when>
                 <xsl:otherwise>

--- a/src/main/resources/xslt/outputs/fr/models.xsl
+++ b/src/main/resources/xslt/outputs/fr/models.xsl
@@ -2974,17 +2974,11 @@
                 <xsl:variable name="variable-representation" select="enofr:get-variable-representation($source-context,$current-variable)"/>
                 <xsl:choose>
                     <xsl:when test="$variable-representation = 'number' and contains($formula,concat($conditioning-variable-begin,$current-variable,$conditioning-variable-end))">
-                        <!-- former default formula for variableId -->
+                        <!-- former default formula for variableId : simplify before analyzing again -->
                         <xsl:analyze-string select="$formula" regex="^(.*)number\(if \({$conditioning-variable-begin}{$current-variable}{$conditioning-variable-end}=''\) then '0' else {$conditioning-variable-begin}{$current-variable}{$conditioning-variable-end}\)(.*)$">
                             <xsl:matching-substring>
                                 <xsl:call-template name="replaceVariablesInFormula">
-                                    <xsl:with-param name="formula" select="regex-group(1)"/>
-                                    <xsl:with-param name="variables" as="node()" select="$variables"/>
-                                    <xsl:with-param name="instance-ancestor" select="$instance-ancestor"/>
-                                </xsl:call-template>
-                                <xsl:value-of select="concat('(if (',$variable-business-name,'/string()='''') then 0 else ',$variable-business-name,')')"/>
-                                <xsl:call-template name="replaceVariablesInFormula">
-                                    <xsl:with-param name="formula" select="regex-group(2)"/>
+                                    <xsl:with-param name="formula" select="concat(regex-group(1),$conditioning-variable-begin,$current-variable,$conditioning-variable-end,regex-group(2))"/>
                                     <xsl:with-param name="variables" as="node()" select="$variables"/>
                                     <xsl:with-param name="instance-ancestor" select="$instance-ancestor"/>
                                 </xsl:call-template>

--- a/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
+++ b/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
@@ -689,4 +689,12 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
+
+    <xd:doc>
+        <xd:desc>no use of input enoddi:is-required : always false for Web collect</xd:desc>
+    </xd:doc>
+    <xsl:function name="enofr:is-required">
+        <xsl:param name="context" as="item()"/>
+        <xsl:sequence select="false()"/>
+    </xsl:function>
 </xsl:stylesheet>

--- a/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
+++ b/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
@@ -511,7 +511,7 @@
                 <xsl:if test="$maximum != ''">
                     <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/Before,' ')"/>
                     <xsl:choose>
-                        <xsl:when test="contains($maximum,'current-date()')">
+                        <xsl:when test="contains($maximum,'-date()')">
                             <xsl:value-of select="$labels-resource/Languages/Language[@xml:lang=$language]/Today"/>
                         </xsl:when>
                         <xsl:otherwise>
@@ -533,12 +533,12 @@
                     <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/And)"/>
                 </xsl:if>
                 <xsl:if test="$maximum != ''">
+                    <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/Before,' ')"/>
                     <xsl:choose>
-                        <xsl:when test="contains($maximum,'current-date()')">
+                        <xsl:when test="contains($maximum,'-date()')">
                             <xsl:value-of select="$labels-resource/Languages/Language[@xml:lang=$language]/Today"/>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/Before,' ')"/>
                             <xsl:value-of select="$labels-resource/Languages/Language[@xml:lang=$language]/DateTime/Months/*[position()=number(substring($maximum,6,2))]"/>
                             <xsl:value-of select="concat(' ',substring($maximum,1,4))"/>
                         </xsl:otherwise>
@@ -554,12 +554,13 @@
                     <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/And)"/>
                 </xsl:if>
                 <xsl:if test="$maximum != ''">
+                    <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/Before,' ')"/>
                     <xsl:choose>
-                        <xsl:when test="contains($maximum,'current-date()')">
+                        <xsl:when test="contains($maximum,'-date()')">
                             <xsl:value-of select="$labels-resource/Languages/Language[@xml:lang=$language]/Today"/>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:value-of select="concat(' ',$labels-resource/Languages/Language[@xml:lang=$language]/Before,' ',$maximum)"/>
+                            <xsl:value-of select="$maximum"/>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:if>

--- a/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
+++ b/src/main/resources/xslt/transformations/ddi2fr/ddi2fr-fixed.xsl
@@ -697,4 +697,21 @@
         <xsl:param name="context" as="item()"/>
         <xsl:sequence select="false()"/>
     </xsl:function>
+    
+    <xd:doc>
+        <xd:desc>ddi error message keeps warning for Web collect</xd:desc>
+    </xd:doc>
+    <xsl:function name="enofr:get-message-type">
+        <xsl:param name="context" as="item()"/>
+        <xsl:variable name="ddi-message" select="enoddi:get-message-type($context)"/>
+        
+        <xsl:choose>
+            <xsl:when test="$ddi-message = 'error'">
+                <xsl:value-of select="'warning'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$ddi-message"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
 </xsl:stylesheet>

--- a/src/main/resources/xslt/transformations/ddi2fr/functions.fods
+++ b/src/main/resources/xslt/transformations/ddi2fr/functions.fods
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>PT12H18M53S</meta:editing-duration><meta:editing-cycles>93</meta:editing-cycles><meta:generator>LibreOffice/5.4.6.2$Windows_X86_64 LibreOffice_project/4014ce260a04f1026ba855d3b8d91541c224eab8</meta:generator><dc:date>2019-09-13T17:29:22.897000000</dc:date><dc:creator>François Bulot</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="196" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>PT12H25M44S</meta:editing-duration><meta:editing-cycles>94</meta:editing-cycles><meta:generator>LibreOffice/5.4.6.2$Windows_X86_64 LibreOffice_project/4014ce260a04f1026ba855d3b8d91541c224eab8</meta:generator><dc:date>2019-10-09T15:34:40.779000000</dc:date><dc:creator>François Bulot</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="193" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaLeft" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaWidth" config:type="int">33709</config:config-item>
-   <config:config-item config:name="VisibleAreaHeight" config:type="int">32187</config:config-item>
+   <config:config-item config:name="VisibleAreaHeight" config:type="int">31608</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
-       <config:config-item config:name="CursorPositionX" config:type="int">4</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">38</config:config-item>
+       <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">6</config:config-item>
        <config:config-item config:name="HorizontalSplitMode" config:type="short">0</config:config-item>
        <config:config-item config:name="VerticalSplitMode" config:type="short">0</config:config-item>
        <config:config-item config:name="HorizontalSplitPosition" config:type="int">0</config:config-item>
@@ -23,7 +23,7 @@
        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
-       <config:config-item config:name="PositionBottom" config:type="int">18</config:config-item>
+       <config:config-item config:name="PositionBottom" config:type="int">0</config:config-item>
        <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
        <config:config-item config:name="ZoomValue" config:type="int">100</config:config-item>
        <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -598,7 +598,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2019-09-13">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="17:11:25.522000000">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2019-10-09">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="15:27:48.948000000">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -773,18 +773,6 @@
      </table:table-cell>
      <table:table-cell table:style-name="Default" office:value-type="string" calcext:value-type="string">
       <text:p>Linking output function enofr:get-readonly to input function enoddi:get-deactivatable-command.</text:p>
-     </table:table-cell>
-    </table:table-row>
-    <table:table-row table:style-name="ro2">
-     <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>enofr:is-required</text:p>
-     </table:table-cell>
-     <table:table-cell/>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
-      <text:p>enoddi:is-required</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="Default" office:value-type="string" calcext:value-type="string">
-      <text:p>Linking output function enofr:is-required to input function enoddi:is-required.</text:p>
      </table:table-cell>
     </table:table-row>
     <table:table-row table:style-name="ro2">
@@ -1460,7 +1448,7 @@
       <text:p>Linking output function enofr:get-cell-value-variables to input function enoddi:get-cell-value-variables</text:p>
      </table:table-cell>
     </table:table-row>
-    <table:table-row table:style-name="ro1" table:number-rows-repeated="1048513">
+    <table:table-row table:style-name="ro1" table:number-rows-repeated="1048514">
      <table:table-cell table:number-columns-repeated="4"/>
     </table:table-row>
     <table:table-row table:style-name="ro1">

--- a/src/main/resources/xslt/transformations/ddi2fr/functions.fods
+++ b/src/main/resources/xslt/transformations/ddi2fr/functions.fods
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>PT12H25M44S</meta:editing-duration><meta:editing-cycles>94</meta:editing-cycles><meta:generator>LibreOffice/5.4.6.2$Windows_X86_64 LibreOffice_project/4014ce260a04f1026ba855d3b8d91541c224eab8</meta:generator><dc:date>2019-10-09T15:34:40.779000000</dc:date><dc:creator>François Bulot</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="193" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>PT12H27M15S</meta:editing-duration><meta:editing-cycles>95</meta:editing-cycles><meta:generator>LibreOffice/5.4.6.2$Windows_X86_64 LibreOffice_project/4014ce260a04f1026ba855d3b8d91541c224eab8</meta:generator><dc:date>2019-10-09T15:36:12.128000000</dc:date><dc:creator>François Bulot</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="193" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
@@ -13,8 +13,8 @@
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
-       <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">6</config:config-item>
+       <config:config-item config:name="CursorPositionX" config:type="int">2</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">10</config:config-item>
        <config:config-item config:name="HorizontalSplitMode" config:type="short">0</config:config-item>
        <config:config-item config:name="VerticalSplitMode" config:type="short">0</config:config-item>
        <config:config-item config:name="HorizontalSplitPosition" config:type="int">0</config:config-item>
@@ -829,7 +829,7 @@
      </table:table-cell>
      <table:table-cell/>
      <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
-      <text:p>enoddi:get-message-type</text:p>
+      <text:p>enofr:get-message-type</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="Default" office:value-type="string" calcext:value-type="string">
       <text:p>Linking output function enofr:get-alert-level to input function enoddi:get-message-type.</text:p>

--- a/src/main/resources/xslt/util/ddi/ddi32toddi33.xsl
+++ b/src/main/resources/xslt/util/ddi/ddi32toddi33.xsl
@@ -190,11 +190,21 @@
                                     <!-- calculated variable -->
                                     <xsl:value-of select="$dereferenced-questionnaire//*[local-name()='GenerationInstruction'][*[local-name()='ID']/text()=current()/l32:VariableRepresentation/r32:ProcessingInstructionReference/r32:ID/text()]/local-name()"/>
                                 </xsl:when>
+                                <!-- external variable -->
                                 <xsl:when test="$dereferenced-questionnaire/*">
-                                    <!-- external variable -->
-                                    <xsl:value-of select="contains($dereferenced-questionnaire/text(),concat('¤',$variable-id,'¤'))
-                                                      or contains($dereferenced-questionnaire/text(),concat('ø',$variable-id,'ø'))
-                                                      or $dereferenced-questionnaire//*[local-name()='ID'] = $variable-id"/>
+                                    <xsl:variable name="variable-name" select="l32:VariableName/r32:String/text()"/>
+                                    <xsl:choose>
+                                        <xsl:when test="$dereferenced-questionnaire//text()[contains(.,concat('¤',$variable-name,'¤'))]">
+                                            <xsl:value-of select="'¤'"/>        
+                                        </xsl:when>
+                                        <xsl:when test="$dereferenced-questionnaire//text()[contains(.,concat('ø',$variable-name,'ø'))]">
+                                            <xsl:value-of select="'ø'"/>
+                                        </xsl:when>
+                                        <xsl:when test="$dereferenced-questionnaire//*[local-name()='SourceParameterReference' and *[local-name()='TypeOfObject' and text()='InParameter']]/*[local-name()='ID'] = $variable-name">
+                                            <xsl:value-of select="$variable-name"/>
+                                        </xsl:when>
+                                        <xsl:otherwise/>
+                                    </xsl:choose>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <!-- no dereferenced questionnaire : all variables are taken -->

--- a/src/main/resources/xslt/util/ddi/dereferencing.xsl
+++ b/src/main/resources/xslt/util/ddi/dereferencing.xsl
@@ -33,7 +33,6 @@
     <xsl:param name="fast-and-dangerous-mode" select="false()"/><!--set to false() if you don't know-->
     <xsl:param name="build-messages" select="true()"/><!--set to true() if you doubt of the result and false() if you are sure it will succeed -->
     <xsl:param name="build-DDI" select="true()"/><!--set to true() if you don't know-->
-    <xsl:strip-space elements="*"/>
 
     <xd:doc scope="stylesheet">
         <xd:desc>

--- a/src/test/resources/ddi-to-xform/out.xhtml
+++ b/src/test/resources/ddi-to-xform/out.xhtml
@@ -2766,9 +2766,9 @@
                               <xf:alert ref="$form-resources/SEASON_NUMBER/alert"/>
                            </fr:number>
                            <xf:input id="DATEFIRST-control"
-                                      name="DATEFIRST"
-                                      bind="DATEFIRST-bind"
-                                      class="question date">
+                                     name="DATEFIRST"
+                                     bind="DATEFIRST-bind"
+                                     class="question date">
                               <xf:label ref="replace($form-resources/DATEFIRST/label,'¤LAST_BROADCAST¤',instance('fr-form-instance')//LAST_BROADCAST)"
                                         mediatype="text/html"/>
                               <xf:hint ref="$form-resources/DATEFIRST/hint"/>

--- a/src/test/resources/ddi-to-xform/out.xhtml
+++ b/src/test/resources/ddi-to-xform/out.xhtml
@@ -264,7 +264,7 @@
                      ref="j3341528"
                      relevant="not( instance('fr-form-instance')//READY!= '1')">
                <xf:bind id="j3341528-d2-bind" name="j3341528-d2" ref="j3341528-d2"/>
-               <xf:bind id="CITY-bind" name="CITY" ref="CITY" required="true()"/>
+               <xf:bind id="CITY-bind" name="CITY" ref="CITY"/>
                <xf:bind id="MAYOR-bind" name="MAYOR" ref="MAYOR"/>
                <xf:bind id="STATE-bind" name="STATE" ref="STATE"/>
             </xf:bind>
@@ -445,7 +445,7 @@
                   <xf:constraint value="if(. castable as xs:float) then (xs:float(.)&lt;=100.0 and xs:float(.)&gt;=0.0 and matches(.,'^(0|[1-9][0-9]{0,1})(\.[0-9]{1,1})?$|^100(\.[0-0])?$')) else (.='')"/>
                </xf:bind>
                <xf:bind id="j4nwc63q-CI-0-bind" name="j4nwc63q-CI-0" ref="j4nwc63q-CI-0">
-                  <xf:constraint level="error"
+                  <xf:constraint level="warning"
                                  value="not((if (instance('fr-form-instance')//PERCENTAGE_EXPENSES11/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES11) + (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES21/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES21) + (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES31/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES31)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES41/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES41)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES51/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES51)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES61/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES61)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES71/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES71)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES81/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES81)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES91/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES91)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES101/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES101)!= 100)"/>
                </xf:bind>
                <xf:bind id="j6qejudb-bind" name="j6qejudb" ref="j6qejudb"/>
@@ -2560,6 +2560,7 @@
                </xf:bind>
                <xf:bind id="page-j4nw88h2-bind" name="j4nw88h2" ref="j4nw88h2">
                   <xf:calculate value="xxf:evaluate-bind-property('j4nw88h2-bind','relevant')"/>
+                  <xf:constraint value="(not((if (instance('fr-form-instance')//PERCENTAGE_EXPENSES11/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES11) + (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES21/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES21) + (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES31/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES31)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES41/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES41)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES51/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES51)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES61/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES61)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES71/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES71)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES81/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES81)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES91/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES91)+ (if (instance('fr-form-instance')//PERCENTAGE_EXPENSES101/string()='') then 0 else instance('fr-form-instance')//PERCENTAGE_EXPENSES101)!= 100))"/>
                </xf:bind>
                <xf:bind id="page-j6qfx9qe-bind" name="j6qfx9qe" ref="j6qfx9qe">
                   <xf:calculate value="xxf:evaluate-bind-property('j6qfx9qe-bind','relevant')"/>
@@ -3467,7 +3468,7 @@
                                    name="j4nwc63q-CI-0"
                                    bind="j4nwc63q-CI-0-bind">
                            <xf:alert ref="replace($form-resources/j4nwc63q-CI-0/alert,'¤jbcggtca-GOP¤',instance('fr-form-instance')//SUM_EXPENSES)"
-                                     level="error"/>
+                                     level="warning"/>
                         </xf:output>
                      </xhtml:div>
                      <xhtml:div class="submodule">

--- a/src/test/resources/ddi-to-xform/out.xhtml
+++ b/src/test/resources/ddi-to-xform/out.xhtml
@@ -252,7 +252,7 @@
                            name="DATEFIRST"
                            ref="DATEFIRST"
                            type="xf:date">
-                     <xf:constraint value="if (string(.) != '' and . castable as xs:date) then (. &gt;= xs:date('1900-01-01') and . &lt; current-date()) else (string(.) = '')"/>
+                     <xf:constraint value="if (string(.) != '' and . castable as xs:date) then (. &gt;= xs:date('1900-01-01') and . &lt;= xs:date(local-date())) else (string(.) = '')"/>
                   </xf:bind>
                   <xf:bind id="AUDIENCE_SHARE-bind" name="AUDIENCE_SHARE" ref="AUDIENCE_SHARE">
                      <xf:constraint value="if(. castable as xs:float) then (xs:float(.)&lt;=99.0 and xs:float(.)&gt;=0.0 and matches(.,'^(0|[1-9]|[1-8][0-9]{1}|9[0-8])(\.[0-9]{1,1})?$|^99(\.[0-0])?$')) else (.='')"/>
@@ -2765,17 +2765,15 @@
                               <xf:label ref="$form-resources/SEASON_NUMBER/label"/>
                               <xf:alert ref="$form-resources/SEASON_NUMBER/alert"/>
                            </fr:number>
-                           <fr:number id="DATEFIRST-control"
+                           <xf:input id="DATEFIRST-control"
                                       name="DATEFIRST"
                                       bind="DATEFIRST-bind"
-                                      xxf:fraction-digits="0"
-                                      xxf:non-negative="true()"
                                       class="question date">
                               <xf:label ref="replace($form-resources/DATEFIRST/label,'¤LAST_BROADCAST¤',instance('fr-form-instance')//LAST_BROADCAST)"
                                         mediatype="text/html"/>
                               <xf:hint ref="$form-resources/DATEFIRST/hint"/>
                               <xf:alert ref="$form-resources/DATEFIRST/alert"/>
-                           </fr:number>
+                           </xf:input>
                            <fr:number id="AUDIENCE_SHARE-control"
                                       name="AUDIENCE_SHARE"
                                       bind="AUDIENCE_SHARE-bind"
@@ -3296,13 +3294,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES11/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3320,13 +3318,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES21/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3351,13 +3349,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES31/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3375,13 +3373,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES41/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3399,13 +3397,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES51/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3430,13 +3428,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES61/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                               <xhtml:tr>
@@ -3454,13 +3452,13 @@
                                                class="number"
                                                xxf:maxlength="5"
                                                grouping-separator=" "
-                                               decimal-separator=",">
+                                               decimal-separator=","
+                                               suffix="%">
                                        <xf:alert ref="$form-resources/PERCENTAGE_EXPENSES71/alert"/>
                                        <xf:dispatch ev:event="DOMFocusOut xforms-value-changed"
                                                     name="DOMFocusOut"
                                                     target="j4nwc63q-CI-0-control"/>
                                     </fr:number>
-                                    <xhtml:span class="suffixe">%</xhtml:span>
                                  </xhtml:td>
                               </xhtml:tr>
                            </xhtml:tbody>


### PR DESCRIPTION
- standard date : xf:input, not fr:number
- current-date() is not allowed in XForms
- use of the attribute suffix of fr:number
- is-required must always be false and checks must always be warning for Web questionnaires
- add a special numeric formula : string(var) = ''
- dereferencing made space characters disappear
- ddi32toddi33 did not list the correct external variables in ant mode for surveys with several questionnaires