### PR TITLE
bug : external variables lost from loops

### DIFF
--- a/src/main/resources/xslt/outputs/xforms/models.xsl
+++ b/src/main/resources/xslt/outputs/xforms/models.xsl
@@ -356,6 +356,9 @@
         <xsl:element name="{enoxforms:get-container-name($source-context)}">
             <xsl:element name="{enoxforms:get-name($source-context)}">
                 <xsl:attribute name="occurrence-id"/>
+                <xsl:apply-templates select="enoxforms:get-external-variables($source-context)" mode="source">
+                    <xsl:with-param name="driver" select="eno:append-empty-element('Instance', .)" tunnel="yes"/>
+                </xsl:apply-templates>
                 <xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
                     <xsl:with-param name="driver" select="eno:append-empty-element('Instance', .)" tunnel="yes"/>
                 </xsl:apply-templates>

--- a/src/main/resources/xslt/outputs/xforms/models.xsl
+++ b/src/main/resources/xslt/outputs/xforms/models.xsl
@@ -264,6 +264,9 @@
         <xsl:element name="{enoxforms:get-container-name($source-context)}">
             <xsl:element name="{$name}">
                 <xsl:attribute name="occurrence-id" select="concat($name,'-1')"/>
+                <xsl:apply-templates select="enoxforms:get-external-variables($source-context)" mode="source">
+                    <xsl:with-param name="driver" select="." tunnel="yes"/>
+                </xsl:apply-templates>
                 <xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
                     <xsl:with-param name="driver" select="." tunnel="yes"/>
                 </xsl:apply-templates>


### PR DESCRIPTION
Regression due to : https://github.com/InseeFr/Eno/pull/280

external variables were forgotten for loops in :
- instance
- model for new occurrences (lost for dynamic arrays too)