### PR TITLE
Compile XSL from ods at the right phase of maven lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 				<version>1.2.1</version>
 				<executions>
 					<execution>
-						<phase>package</phase>
+						<phase>process-classes</phase>
 						<goals>
 							<goal>java</goal>
 						</goals>


### PR DESCRIPTION
In the pom.xml the execution of FodsToXSLCompileris set to run at package phase in maven lyfecycle but should run after compilation and before tests so at process-classes phase in order the tests success. 