### PR TITLE
Dev fo update mail

### DIFF
--- a/questionnaires/esem-2020-a00/fo/m1/form/form.fo
+++ b/questionnaires/esem-2020-a00/fo/m1/form/form.fo
@@ -174,8 +174,7 @@
                 <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
       </fo:static-content>
-      <fo:flow flow-name="xsl-region-body">
-         <fo:block page-break-after="always"><!-- ZONE LOGOS --><fo:block-container absolute-position="absolute"
+      <fo:flow flow-name="xsl-region-body"><!-- PAGE COURRIER RECTO --><fo:block page-break-after="always"><!-- ZONE LOGOS --><fo:block-container absolute-position="absolute"
                                 left="5mm"
                                 top="2mm"
                                 width="180mm"
@@ -197,7 +196,9 @@
                                 overflow="hidden">
                <fo:block/>
             </fo:block-container>
-            <!-- ZONE DATAMATRIX ALLIAGE --><fo:block-container absolute-position="absolute"
+            <!-- ZONE DATAMATRIX ALLIAGE -->
+                #if($!{InitAccuseReception}!='' and $!{InitAccuseReception}!='oui')
+                <fo:block-container absolute-position="absolute"
                                 left="100mm"
                                 top="37.8mm"
                                 width="11.88mm"
@@ -218,13 +219,16 @@
                   </fo:instream-foreign-object>
                </fo:block>
             </fo:block-container>
-            <!-- ZONE ADRESSE --><fo:block-container absolute-position="absolute"
+                #end
+                
+                <!-- ZONE ADRESSE --><fo:block-container absolute-position="absolute"
                                 left="100mm"
                                 top="50mm"
                                 width="82mm"
                                 height="25.5mm"
                                 overflow="hidden"
-                                font-size="10pt">
+                                font-size="10pt"
+                                display-align="after">
                <fo:block font-family="Lucida Console">
                   <fo:inline-container margin="0mm">
                      <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -246,14 +250,23 @@
                                 font-size="10pt">
                <fo:block/>
             </fo:block-container>
+            <!-- ZONE DATAMATRIX MODE LIVRET --><fo:block-container absolute-position="absolute"
+                                right="182mm"
+                                top="237mm"
+                                width="16mm"
+                                height="16mm"
+                                overflow="hidden"
+                                font-size="10pt">
+               <fo:block/>
+            </fo:block-container>
             <!-- ZONE TITRE COURRIER --><fo:block-container absolute-position="absolute"
                                 left="1mm"
                                 top="38mm"
                                 width="78mm"
-                                height="6mm"
+                                height="100%"
                                 overflow="hidden"
                                 font-size="10pt">
-               <fo:block line-height="10pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
+               <fo:block line-height="12pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
             </fo:block-container>
             <!-- ZONE CONTACT --><fo:block-container absolute-position="absolute"
                                 left="1mm"
@@ -274,9 +287,9 @@
                </fo:block>
             </fo:block-container>
             <!-- ZONE COURRIER --><fo:block-container absolute-position="absolute"
-                                left="1mm"
+                                left="9mm"
                                 top="98mm"
-                                width="188mm"
+                                width="179mm"
                                 height="100%"
                                 overflow="hidden"
                                 text-align="justify"
@@ -287,17 +300,20 @@
                <fo:block margin-top="5mm" font-weight="bold">
                         Objet : Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference}
                     </fo:block>
-               <fo:block font-weight="bold">
-                        Ref. ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee} : ${BddIdentifiantUniteEnquetee})
+               <fo:block>
+                        Unité enquêtée : ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee} : ${BddIdentifiantUniteEnquetee})
                     </fo:block>
-               <fo:block margin-top="5mm" font-weight="bold">
+               <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
+                    </fo:block>
+               <fo:block margin-top="8mm" font-weight="bold">
                         Madame la Directrice, Monsieur le Directeur,
                     </fo:block>
                <fo:block margin-top="5mm">
                         Ma lettre de mise en demeure du ${BddDateEnvoiMiseEnDemeure} étant restée sans suite, je suis dans l’obligation aujourd’hui d’établir à votre encontre le constat suivant :
                     </fo:block>
                <fo:block margin-top="3mm">
-                        - de défaut de réponse à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference} ;
+                        - de défaut de réponse à l'<fo:inline font-weight="bold">enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference} </fo:inline>;
                     </fo:block>
                <fo:block>
                         - et d’absence de justification à ce défaut de réponse.
@@ -310,6 +326,13 @@
                         soit de répondre à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint,#end dans un délai de 15 jours. 
                         A l’expiration de ce délai, votre dossier sera soumis pour examen au <fo:inline font-weight="bold">Comité du contentieux</fo:inline> des enquêtes statistiques obligatoires 
                         du Conseil national de l’information statistique (Cnis), conformément à la loi*.
+                        Nous avons plus que jamais besoin de votre participation pour assurer la qualité des statistiques sur 2019. 
+                        Pour tenir compte de la crise sanitaire actuelle, l’Insee a redéfini ses priorités et adapté ses travaux. 
+                        Les délais de réponse à certaines enquêtes auprès des entreprises ont ainsi été allongés de plusieurs mois. 
+                        Nous sommes conscients des difficultés que la crise fait peser sur vous et de ses conséquences pendant les mois à venir. 
+                        Cependant, pour mieux évaluer son impact, il est particulièrement important de suivre l’activité économique en France. 
+                        Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019 dans chaque secteur, 
+                        et ainsi estimer précisément l’impact économique de la crise vécue aujourd’hui.
                     </fo:block>
                <fo:block margin-top="3mm">
                         S’il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre. 
@@ -326,9 +349,9 @@
                     </fo:block>
             </fo:block-container>
             <!-- ZONE NOTE DE BAS DE PAGE --><fo:block-container absolute-position="absolute"
-                                left="1mm"
-                                top="250mm"
-                                width="188mm"
+                                left="9mm"
+                                top="273mm"
+                                width="179mm"
                                 height="100%"
                                 overflow="hidden">
                <fo:block>
@@ -336,11 +359,11 @@
                     </fo:block>
             </fo:block-container>
          </fo:block>
-         <fo:block page-break-after="always">
+         <!-- PAGE COURRIER VERSO --><fo:block page-break-after="always">
             <fo:block/>
             <!-- ZONE NOTICE --><fo:block-container absolute-position="absolute"
                                 left="20mm"
-                                top="20mm"
+                                top="5mm"
                                 width="150mm"
                                 height="100%"
                                 overflow="hidden"
@@ -352,7 +375,7 @@
                <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet ?
                     </fo:block>
-               <fo:block margin-top="3.5mm">
+               <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique : <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt"> </fo:inline>entreprises.stat-<fo:inline font-size="0.1pt"> </fo:inline>publique.fr/</fo:inline>. 
@@ -373,7 +396,7 @@
                     </fo:block>
                <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique « Mot de passe oublié » du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique « Mot de passe oublié » du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -399,7 +422,7 @@
                                 border="solid black 0.5pt"
                                 padding="1mm">
                <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt"> </fo:inline>° 51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -416,14 +439,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt"> </fo:inline>° 78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt"> </fo:inline>° 78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
             </fo:block-container>
          </fo:block>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
@@ -1,289 +1,300 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
-    
-    <fo:layout-master-set>
-        
-        <fo:page-sequence-master master-name="accompagnementCOL">
-            <fo:repeatable-page-master-alternatives>
-                <fo:conditional-page-master-reference master-reference="accompagnementCOL-recto" odd-or-even="odd"/>
-                <fo:conditional-page-master-reference master-reference="accompagnementCOL-verso" odd-or-even="even"/>
-            </fo:repeatable-page-master-alternatives>
-        </fo:page-sequence-master>
-        
-        <fo:simple-page-master master-name="accompagnementCOL-recto" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
-            <fo:region-body region-name="xsl-region-body" margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
-            <fo:region-before region-name="xsl-region-before-courrier" display-align="before" extent="10mm" precedence="true"/>
-            <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
-            <fo:region-start extent="10mm" display-align="before"/>
-            <fo:region-end extent="10mm" display-align="before"/>
-        </fo:simple-page-master>
-        
-        <fo:simple-page-master master-name="accompagnementCOL-verso" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
-            <fo:region-body margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
-            <fo:region-before region-name="xsl-region-before-cover" display-align="before" extent="10mm" precedence="true"/>
-            <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
-            <fo:region-start extent="10mm" display-align="before"/>
-            <fo:region-end extent="10mm" display-align="before"/>
-        </fo:simple-page-master>
-        
-    </fo:layout-master-set>
+   
+   <fo:layout-master-set>
+      
+      <fo:page-sequence-master master-name="accompagnementCOL">
+         <fo:repeatable-page-master-alternatives>
+            <fo:conditional-page-master-reference master-reference="accompagnementCOL-recto" odd-or-even="odd"/>
+            <fo:conditional-page-master-reference master-reference="accompagnementCOL-verso" odd-or-even="even"/>
+         </fo:repeatable-page-master-alternatives>
+      </fo:page-sequence-master>
+      
+      <fo:simple-page-master master-name="accompagnementCOL-recto" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
+         <fo:region-body region-name="xsl-region-body" margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
+         <fo:region-before region-name="xsl-region-before-courrier" display-align="before" extent="10mm" precedence="true"/>
+         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
+         <fo:region-start extent="10mm" display-align="before"/>
+         <fo:region-end extent="10mm" display-align="before"/>
+      </fo:simple-page-master>
+      
+      <fo:simple-page-master master-name="accompagnementCOL-verso" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
+         <fo:region-body margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
+         <fo:region-before region-name="xsl-region-before-cover" display-align="before" extent="10mm" precedence="true"/>
+         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
+         <fo:region-start extent="10mm" display-align="before"/>
+         <fo:region-end extent="10mm" display-align="before"/>
+      </fo:simple-page-master>
+      
+   </fo:layout-master-set>
 
-    <fo:page-sequence font-family="Liberation Sans" font-size="8pt" master-reference="accompagnementCOL">
-        
-        <!-- ZONE LIGNE TECHNIQUE -->
-        <fo:static-content flow-name="xsl-region-before-courrier">
-            <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
-            </fo:block>
-        </fo:static-content>
-
-        <fo:flow flow-name="xsl-region-body">
+   <fo:page-sequence font-family="Liberation Sans" font-size="8pt" master-reference="accompagnementCOL">
+      
+      <!-- ZONE LIGNE TECHNIQUE -->
+      <fo:static-content flow-name="xsl-region-before-courrier">
+         <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
+            <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+         </fo:block>
+      </fo:static-content>
+      
+      <fo:flow flow-name="xsl-region-body">
+         
+         <!-- PAGE COURRIER RECTO -->
+         <fo:block page-break-after="always">
             
-            <fo:block page-break-after="always">
-                
-                <!-- ZONE LOGOS -->
-                <fo:block-container absolute-position="absolute" left="5mm" top="2mm" width="180mm" height="25mm">
-                    <fo:block>
-                        <fo:external-graphic src="logo_INSEE_M_SP.png" width="100%" height="100%" content-height="scale-to-fit" content-width="scale-to-fit" scaling="uniform"/>
-                    </fo:block>
-                </fo:block-container>
-                
-                <!-- ZONE RESERVE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="80mm" top="33mm" width="110mm" height="50mm" overflow="hidden">
-                    <fo:block/>
-                </fo:block-container>
-                
-                <!-- ZONE DATAMATRIX ALLIAGE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm" width="11.88mm" height="11.88mm" overflow="hidden">
-                    <fo:block>
-                        <fo:instream-foreign-object>
-                            <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" message="${Barcode}" orientation="0">
-                                <barcode:datamatrix>
-                                    <barcode:module-width>0.53mm</barcode:module-width>
-                                    <barcode:quiet-zone enabled="false">0mw</barcode:quiet-zone>
-                                    <barcode:min-symbol-size>22x22</barcode:min-symbol-size>
-                                    <barcode:max-symbol-size>22x22</barcode:max-symbol-size>
-                                </barcode:datamatrix>
-                            </barcode:barcode>
-                        </fo:instream-foreign-object>
-                    </fo:block>
-                </fo:block-container>
-                
-                <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
-                    <fo:block font-family="Lucida Console">
-                        <fo:inline-container margin="0mm">
-                            <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
-                            <fo:block line-height="10pt">$!{BddAdressePosteeL2}</fo:block>
-                            <fo:block line-height="10pt">${BddAdressePosteeL3}</fo:block>
-                            <fo:block line-height="10pt">$!{BddAdressePosteeL4}</fo:block>
-                            <fo:block line-height="10pt">$!{BddAdressePosteeL5}</fo:block>
-                            <fo:block line-height="10pt">${BddAdressePosteeL6}</fo:block>
-                            <fo:block line-height="10pt">${BddAdressePosteeL7}</fo:block>
-                        </fo:inline-container>
-                    </fo:block>
-                </fo:block-container>
-                
-                <!-- ZONE RESERVE INTEGRALITE -->
-                <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm" height="22mm" overflow="hidden" font-size="10pt">
-                    <fo:block/>
-                </fo:block-container>
-                
-                <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">ENVOI DE QUESTIONNAIRE PAPIER</fo:block>
-                </fo:block-container>
-                
-                <!-- ZONE CONTACT -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="100%" overflow="hidden">
-                    <fo:block margin-left="0.01mm" margin-right="0.01mm" border="black solid 0.5pt">
-                        <fo:inline-container>
-                            <fo:block font-weight="bold" margin-top="0.5mm">Pour nous contacter&#160;:</fo:block>
-                            <fo:block><fo:inline text-decoration="underline">Courriel</fo:inline>&#160;: #if($!{InitGestionnairesAdresseMessagerie})$!{InitGestionnairesAdresseMessagerie}#else${BddServiceCollecteurAdresseMessagerie}#end </fo:block>
-                            <fo:block>#if($!{InitNumeroSVI}||$!{InitGestionnaireTel})<fo:inline text-decoration="underline">Téléphone</fo:inline>&#160;: #end #if($!{InitNumeroSVI})09-69-32-97-47 #elseif($!{InitGestionnaireTel}) $!{InitGestionnaireTel}#end </fo:block>
-                            <fo:block>#if($!{InitNumeroSVI})<fo:inline text-decoration="underline">Code enquête</fo:inline>&#160;: $!{InitNumeroSVI}#end</fo:block>
-                        </fo:inline-container>
-                    </fo:block>
-                </fo:block-container>
-
-                <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
-                    <fo:block text-align="right" font-size="10pt">
-                        
-                    </fo:block>
-                    <fo:block margin-top="5mm" font-weight="bold">
-                        Objet&#160;: Votre demande de questionnaire pour l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
-                    </fo:block>
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
-	                </fo:block>
-                    
-                    <fo:block margin-top="3mm">
-                        #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
-                    </fo:block>
-                    <fo:block margin-top="3mm">
-                        Suite à votre demande, vous trouverez ci-joint le questionnaire papier de l’<fo:inline font-weight="bold">enquête#if(${BddFrequence}!='') ${BddFrequence}#end ${BddLibelleLong}.</fo:inline> 
-                    </fo:block>
-					<fo:block margin-top="3mm">
-					${BddObjectifsLongs}
+            <!-- ZONE LOGOS -->
+            <fo:block-container absolute-position="absolute" left="5mm" top="2mm" width="180mm" height="25mm">
+               <fo:block>
+                  <fo:external-graphic src="logo_INSEE_M_SP.png" width="100%" height="100%" content-height="scale-to-fit" content-width="scale-to-fit" scaling="uniform"/>
+               </fo:block>
+            </fo:block-container>
+            
+            <!-- ZONE RESERVE ADRESSE -->
+            <fo:block-container absolute-position="absolute" left="80mm" top="33mm" width="110mm" height="50mm" overflow="hidden">
+               <fo:block/>
+            </fo:block-container>
+            
+            <!-- ZONE DATAMATRIX ALLIAGE -->
+            <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm" width="11.88mm" height="11.88mm" overflow="hidden">
+               <fo:block>
+                  <fo:instream-foreign-object>
+                     <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" message="${Barcode}" orientation="0">
+                        <barcode:datamatrix>
+                           <barcode:module-width>0.53mm</barcode:module-width>
+                           <barcode:quiet-zone enabled="false">0mw</barcode:quiet-zone>
+                           <barcode:min-symbol-size>22x22</barcode:min-symbol-size>
+                           <barcode:max-symbol-size>22x22</barcode:max-symbol-size>
+                        </barcode:datamatrix>
+                     </barcode:barcode>
+                  </fo:instream-foreign-object>
+               </fo:block>
+            </fo:block-container>
+            
+            
+            <!-- ZONE ADRESSE -->
+            <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
+               <fo:block font-family="Lucida Console">
+                  <fo:inline-container margin="0mm">
+                     <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
+                     <fo:block line-height="10pt">$!{BddAdressePosteeL2}</fo:block>
+                     <fo:block line-height="10pt">${BddAdressePosteeL3}</fo:block>
+                     <fo:block line-height="10pt">$!{BddAdressePosteeL4}</fo:block>
+                     <fo:block line-height="10pt">$!{BddAdressePosteeL5}</fo:block>
+                     <fo:block line-height="10pt">${BddAdressePosteeL6}</fo:block>
+                     <fo:block line-height="10pt">${BddAdressePosteeL7}</fo:block>
+                  </fo:inline-container>
+               </fo:block>
+            </fo:block-container>
+            
+            <!-- ZONE RESERVE INTEGRALITE -->
+            <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm" height="22mm" overflow="hidden" font-size="10pt">
+               <fo:block/>
+            </fo:block-container>
+            
+            <!-- ZONE DATAMATRIX MODE LIVRET -->
+            <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+               <fo:block/>
+            </fo:block-container>           
+            
+            <!-- ZONE TITRE COURRIER -->
+            <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+               <fo:block line-height="12pt" font-weight="bold" text-align="center">ENVOI DE QUESTIONNAIRE PAPIER</fo:block>
+            </fo:block-container>
+            
+            <!-- ZONE CONTACT -->
+            <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="100%" overflow="hidden">
+               <fo:block margin-left="0.01mm" margin-right="0.01mm" border="black solid 0.5pt">
+                  <fo:inline-container>
+                     <fo:block font-weight="bold" margin-top="0.5mm">Pour nous contacter :</fo:block>
+                     <fo:block>
+                        <fo:inline text-decoration="underline">Courriel</fo:inline> : #if($!{InitGestionnairesAdresseMessagerie})$!{InitGestionnairesAdresseMessagerie}#else${BddServiceCollecteurAdresseMessagerie}#end </fo:block>
+                     <fo:block>#if($!{InitNumeroSVI}||$!{InitGestionnaireTel})<fo:inline text-decoration="underline">Téléphone</fo:inline> : #end #if($!{InitNumeroSVI})09-69-32-97-47 #elseif($!{InitGestionnaireTel}) $!{InitGestionnaireTel}#end </fo:block>
+                     <fo:block>#if($!{InitNumeroSVI})<fo:inline text-decoration="underline">Code enquête</fo:inline> : $!{InitNumeroSVI}#end</fo:block>
+                  </fo:inline-container>
+               </fo:block>
+            </fo:block-container>
+            
+            <!-- ZONE COURRIER -->
+            <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+               
+               <fo:block text-align="right" font-size="10pt"/>
+               
+               <fo:block margin-top="5mm" font-weight="bold">
+                  Objet&#160;: Votre demande de questionnaire pour l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end 
+                  ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
+               </fo:block>
+               <fo:block font-weight="bold">
+                  Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+	            </fo:block>
+               
+               <fo:block margin-top="3mm">
+                  #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
+               </fo:block>
+               <fo:block margin-top="3mm">
+                  Suite à votre demande, vous trouverez ci-joint le questionnaire papier de l’<fo:inline font-weight="bold">enquête#if(${BddFrequence}!='') ${BddFrequence}#end ${BddLibelleLong}</fo:inline>.
+               </fo:block>
+               <fo:block margin-top="3mm">
+                  ${BddObjectifsLongs}
 					</fo:block>
-                    <fo:block margin-top="3mm">
-                        Cette enquête#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete} par le Conseil national 
-                        de l’information statistique (Cnis). Conformément à la loi n° 51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique et ne sauraient en aucun
-                        cas être utilisées à des fins de contrôle fiscal ou de répression économique.
-                    </fo:block>
-                    <fo:block margin-top="3mm">
-                        Afin de permettre la prise en compte de la diversité des situations et d'assurer ainsi la qualité statistique des résultats, il est très important que vous répondiez à cette enquête soit par internet selon les modalités précisées au verso de cette feuille, soit en complétant le questionnaire joint.
-                    </fo:block>
-                    <fo:block margin-top="3mm">
-                     Je vous remercie de bien vouloir nous transmettre votre questionnaire, une fois rempli, dans les meilleurs délais. 
-                     Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.
-                            </fo:block>
-                    <fo:block margin-top="3mm">
-                        En vous remerciant par avance de votre collaboration, je vous prie de bien vouloir agréer,
-                        #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},
-                        #else Madame, Monsieur,#end l'assurance de ma considération distinguée.
-                    </fo:block>
-                    
-                    <fo:block margin-top="10mm" text-align="right">
-                        ${BddServiceCollecteurSignataireFonction}
-                    </fo:block>
-                    <fo:block text-align="right">
-                        ${BddServiceCollecteurSignataireNom}
-                    </fo:block>
-                            
-                </fo:block-container>
-
-                <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="250mm" width="188mm" height="100%" overflow="hidden">
-                    <fo:block/>
-                </fo:block-container>
-                
-            </fo:block>
+               <fo:block margin-top="3mm">
+                  Cette enquête#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete} par le Conseil national 
+                  de l’information statistique (Cnis). Conformément à la loi n°&#160;51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique et ne sauraient en aucun
+                  cas être utilisées à des fins de contrôle fiscal ou de répression économique.
+               </fo:block>
+               <fo:block margin-top="3mm">
+                  Afin de permettre la prise en compte de la diversité des situations et d'assurer ainsi la qualité statistique des résultats, 
+                  il est très important que vous répondiez à cette enquête soit par internet selon les modalités précisées au verso de cette feuille, soit en complétant le questionnaire joint.
+               </fo:block>
+               <fo:block margin-top="3mm">
+                  Je vous remercie de bien vouloir nous transmettre votre questionnaire, une fois rempli, dans les meilleurs délais. 
+                  Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.
+               </fo:block>
+               <fo:block margin-top="3mm">
+                  En vous remerciant par avance de votre collaboration, je vous prie de bien vouloir agréer,
+                  #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},
+                  #else Madame, Monsieur,#end l'assurance de ma considération distinguée.
+               </fo:block>
+               
+               <fo:block margin-top="10mm" text-align="right">
+                  ${BddServiceCollecteurSignataireFonction}
+               </fo:block>
+               <fo:block text-align="right">
+                  ${BddServiceCollecteurSignataireNom}
+               </fo:block>
+            </fo:block-container>
             
-            <fo:block page-break-after="always">
-                
-                <fo:block/>
-                
-                <!-- ZONE NOTICE -->
-                <fo:block-container absolute-position="absolute" left="20mm" top="20mm" width="150mm" height="100%" overflow="hidden"
-                                    font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
-                    
-                    <fo:block text-align="center" font-weight="bold" font-size="10pt">
-                        Comment répondre à l'enquête par internet&#160;?
-                    </fo:block>
-                    
-                    <fo:block margin-top="3.5mm">
-                        Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
-                        ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
-                        publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
-                        Cette adresse est à inscrire dans la barre de navigation de votre navigateur.
-                    </fo:block>
-                    
-                    <fo:block>
-                            
-                        #if($!{CalcMotDePasse}) 
-
-                        <fo:block margin-top="3.5mm">
-                            Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion, identifiant et mot de passe.
-                        </fo:block>
-
-                        <fo:block text-align="center" margin-top="1mm" margin-left="7mm" margin-right="7mm" border="black solid 0.5pt">
-                            <fo:inline-container>
-                                <fo:block margin-top="1.2mm">
-                                    Identifiant&#160;: ${BddIdentifiantContact}
-                                </fo:block>
-                            </fo:inline-container>
-                            <fo:inline-container>
-                                <fo:block margin-bottom="1.2mm">
-                                    Mot de passe&#160;: $!{CalcMotDePasse}
-                                </fo:block>
-                            </fo:inline-container>
-                        </fo:block>
-                                
-                        <fo:block>
-                            <fo:block margin-top="3.5mm">
-                                Le mot de passe étant à usage unique, vous devrez le changer lors de votre première connexion.
-                            </fo:block>
-                            <fo:block margin-top="3.5mm">
-                                Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
-                            </fo:block>
-                        </fo:block>
-
-                        #else
-                        
-                        <fo:block margin-top="3.5mm">
-                            Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion.
-                        </fo:block>
-                        <fo:block margin-top="3.5mm">
-                            Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
-                        </fo:block>
-                        <fo:block margin-top="3.5mm" font-weight="bold">
-                            Votre identifiant de connexion ${BddIdentifiantContact} reste inchangé.
-                        </fo:block>
-                        <fo:block margin-top="3.5mm">
-                            Le mot de passe précédemment communiqué par voie postale étant à usage unique, si vous vous êtes déjà authentifié sur le site de réponse à l'enquête, 
-                            vous avez dû le changer lors de votre première connexion.
-                        </fo:block>
-                        
-                        #end
-                        
-                    </fo:block>
-
-                    <fo:block margin-top="3.5mm">
-                        En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
-                    </fo:block>
-                    <fo:block margin-top="3.5mm">
-                        En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
-                        vous authentifier à nouveau, veuillez patienter quelques minutes au terme desquelles le compte sera automatiquement débloqué.
-                    </fo:block>
-                    <fo:block margin-top="3.5mm">
-                        Une fois authentifié, vous pourrez remplir votre questionnaire en toute sécurité dans un environnement protégé.
-                    </fo:block>
-                    <fo:block margin-top="3.5mm">
-                        Pour toutes questions techniques (accès au site de réponse en ligne, éléments de connexion, affichage du questionnaire, etc.), 
-                        vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
-                        réponse aux enquêtes entreprises de la Statistique publique.
-                    </fo:block>
-
-                </fo:block-container>
-                
-                <!-- ZONE CADRE LEGAL -->
-                <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
-                    
-                    <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
-                        en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
-                        Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
-                    </fo:block>
-                    <fo:block>
-                        #if(${BddCaractereObligatoire}=='oui')Cette enquête est obligatoire. En cas de défaut de réponse après mise en demeure dans le délai imparti ou de réponse sciemment inexacte, 
-                        les personnes physiques ou morales peuvent être l'objet d'une amende administrative prononcée par le ministre chargé de l'économie sur avis du 
-                        Conseil national de l'information statistique réuni en Comité du contentieux des enquêtes statistiques obligatoires dans les conditions fixées 
-                        par le décret prévu au II de l'article 1er bis de la loi du 7 juin 1951.#else<fo:inline font-size="0.1pt">&#160;</fo:inline>Cette enquête n’est pas obligatoire.#end
-                    </fo:block>
-                    <fo:block>
-                        Les réponses à ce questionnaire sont protégées par le secret statistique et destinées à ${BddArticleServiceProducteur}${BddNomServiceProducteur}. 
-                        Ces réponses ainsi que les données obtenues par appariement seront conservées pendant ${BddConservation} à compter de la fin de la collecte pour les besoins de l’enquête. 
-                        Elles seront archivées au-delà de cette durée. À tout moment, leur usage et leur accès seront strictement contrôlés et limités à l'élaboration de statistiques 
-                        ou à des travaux de recherche scientifique ou historique.
-                    </fo:block>
-                    <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
-                        aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
-                        d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
-                        Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
-                        Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
-                        et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
-                        ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
-                    </fo:block>
-                    
-                </fo:block-container>
+            <!-- ZONE NOTE DE BAS DE PAGE -->
+            <fo:block-container absolute-position="absolute" left="9mm" top="260mm" width="179mm" height="100%" overflow="hidden">
+               <fo:block/>
+            </fo:block-container>
             
-            </fo:block>
-
-        </fo:flow>
-    </fo:page-sequence>
+         </fo:block>
+         
+         <!-- PAGE COURRIER VERSO -->
+         <fo:block page-break-after="always">
+            
+            <fo:block/>
+            
+            <!-- ZONE NOTICE -->
+            <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
+                                font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
+               
+               <fo:block text-align="center" font-weight="bold" font-size="10pt">
+                  Comment répondre à l'enquête par internet&#160;?
+               </fo:block>
+               
+               <fo:block margin-top="5mm">
+                  Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
+                  ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
+                  publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
+                  Cette adresse est à inscrire dans la barre de navigation de votre navigateur.
+               </fo:block>
+               
+               <fo:block>
+                  
+                  #if($!{CalcMotDePasse})
+                  
+                  <fo:block margin-top="3.5mm">
+                     Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion, identifiant et mot de passe.
+                  </fo:block>
+                  
+                  <fo:block text-align="center" margin-top="1mm" margin-left="7mm" margin-right="7mm" border="black solid 0.5pt">
+                     <fo:inline-container>
+                        <fo:block margin-top="1.2mm">
+                           Identifiant&#160;: ${BddIdentifiantContact}
+                        </fo:block>
+                     </fo:inline-container>
+                     <fo:inline-container>
+                        <fo:block margin-bottom="1.2mm">
+                           Mot de passe&#160;: $!{CalcMotDePasse}
+                        </fo:block>
+                     </fo:inline-container>
+                  </fo:block>
+                  
+                  <fo:block>
+                     <fo:block margin-top="3.5mm">
+                        Le mot de passe étant à usage unique, vous devrez le changer lors de votre première connexion.
+                     </fo:block>
+                     <fo:block margin-top="3.5mm">
+                        Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
+                     </fo:block>
+                  </fo:block>
+                  
+                  #else
+                  
+                  <fo:block margin-top="3.5mm">
+                     Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion.
+                  </fo:block>
+                  <fo:block margin-top="3.5mm">
+                     Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
+                  </fo:block>
+                  <fo:block margin-top="3.5mm" font-weight="bold">
+                     Votre identifiant de connexion ${BddIdentifiantContact} reste inchangé.
+                  </fo:block>
+                  <fo:block margin-top="3.5mm">
+                     Le mot de passe précédemment communiqué par voie postale étant à usage unique, si vous vous êtes déjà authentifié sur le site de réponse à l'enquête, 
+                     vous avez dû le changer lors de votre première connexion.
+                  </fo:block>
+                  
+                  #end
+                  
+               </fo:block>
+               
+               <fo:block margin-top="3.5mm">
+                  En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
+                  de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
+               </fo:block>
+               <fo:block margin-top="3.5mm">
+                  En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
+                  vous authentifier à nouveau, veuillez patienter quelques minutes au terme desquelles le compte sera automatiquement débloqué.
+               </fo:block>
+               <fo:block margin-top="3.5mm">
+                  Une fois authentifié, vous pourrez remplir votre questionnaire en toute sécurité dans un environnement protégé.
+               </fo:block>
+               <fo:block margin-top="3.5mm">
+                  Pour toutes questions techniques (accès au site de réponse en ligne, éléments de connexion, affichage du questionnaire, etc.), 
+                  vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
+                  réponse aux enquêtes entreprises de la Statistique publique.
+               </fo:block>
+               
+            </fo:block-container>
+             
+            <!-- ZONE CADRE LEGAL -->
+            <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
+               
+               <fo:block>
+                  Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                  en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
+                  Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
+               </fo:block>
+               <fo:block>
+                  #if(${BddCaractereObligatoire}=='oui')Cette enquête est obligatoire. En cas de défaut de réponse après mise en demeure dans le délai imparti ou de réponse sciemment inexacte, 
+                  les personnes physiques ou morales peuvent être l'objet d'une amende administrative prononcée par le ministre chargé de l'économie sur avis du 
+                  Conseil national de l'information statistique réuni en Comité du contentieux des enquêtes statistiques obligatoires dans les conditions fixées 
+                  par le décret prévu au II de l'article 1er bis de la loi du 7 juin 1951.#else<fo:inline font-size="0.1pt">&#160;</fo:inline>Cette enquête n’est pas obligatoire.#end
+               </fo:block>
+               <fo:block>
+                  Les réponses à ce questionnaire sont protégées par le secret statistique et destinées à ${BddArticleServiceProducteur}${BddNomServiceProducteur}. 
+                  Ces réponses ainsi que les données obtenues par appariement seront conservées pendant ${BddConservation} à compter de la fin de la collecte pour les besoins de l’enquête. 
+                  Elles seront archivées au-delà de cette durée. À tout moment, leur usage et leur accès seront strictement contrôlés et limités à l'élaboration de statistiques 
+                  ou à des travaux de recherche scientifique ou historique.
+               </fo:block>
+               <fo:block>
+                  #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                  n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                  aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
+                  d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
+                  Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
+                  Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
+                  et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
+                  ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
+                  Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
+               </fo:block>
+               
+            </fo:block-container>
+            
+         </fo:block>
+         
+      </fo:flow>
+   </fo:page-sequence>
 </fo:root>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
@@ -1,64 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
-   
+
    <fo:layout-master-set>
-      
+
       <fo:page-sequence-master master-name="accompagnementCOL">
          <fo:repeatable-page-master-alternatives>
-            <fo:conditional-page-master-reference master-reference="accompagnementCOL-recto" odd-or-even="odd"/>
-            <fo:conditional-page-master-reference master-reference="accompagnementCOL-verso" odd-or-even="even"/>
+            <fo:conditional-page-master-reference master-reference="accompagnementCOL-recto"
+               odd-or-even="odd"/>
+            <fo:conditional-page-master-reference master-reference="accompagnementCOL-verso"
+               odd-or-even="even"/>
          </fo:repeatable-page-master-alternatives>
       </fo:page-sequence-master>
-      
-      <fo:simple-page-master master-name="accompagnementCOL-recto" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
-         <fo:region-body region-name="xsl-region-body" margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
-         <fo:region-before region-name="xsl-region-before-courrier" display-align="before" extent="10mm" precedence="true"/>
-         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
+
+      <fo:simple-page-master master-name="accompagnementCOL-recto" font-family="Liberation Sans"
+         font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
+         <fo:region-body region-name="xsl-region-body" margin-top="10mm" margin-bottom="10mm"
+            margin-right="10mm" margin-left="10mm" column-count="1"/>
+         <fo:region-before region-name="xsl-region-before-courrier" display-align="before"
+            extent="10mm" precedence="true"/>
+         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm"
+            precedence="true"/>
          <fo:region-start extent="10mm" display-align="before"/>
          <fo:region-end extent="10mm" display-align="before"/>
       </fo:simple-page-master>
-      
-      <fo:simple-page-master master-name="accompagnementCOL-verso" font-family="Liberation Sans" font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
-         <fo:region-body margin-top="10mm" margin-bottom="10mm" margin-right="10mm" margin-left="10mm" column-count="1"/>
-         <fo:region-before region-name="xsl-region-before-cover" display-align="before" extent="10mm" precedence="true"/>
-         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm" precedence="true"/>
+
+      <fo:simple-page-master master-name="accompagnementCOL-verso" font-family="Liberation Sans"
+         font-size="10pt" font-weight="normal" page-height="297mm" page-width="210mm">
+         <fo:region-body margin-top="10mm" margin-bottom="10mm" margin-right="10mm"
+            margin-left="10mm" column-count="1"/>
+         <fo:region-before region-name="xsl-region-before-cover" display-align="before"
+            extent="10mm" precedence="true"/>
+         <fo:region-after region-name="xsl-region-after-cover" display-align="before" extent="10mm"
+            precedence="true"/>
          <fo:region-start extent="10mm" display-align="before"/>
          <fo:region-end extent="10mm" display-align="before"/>
       </fo:simple-page-master>
-      
+
    </fo:layout-master-set>
 
-   <fo:page-sequence font-family="Liberation Sans" font-size="8pt" master-reference="accompagnementCOL">
-      
+   <fo:page-sequence font-family="Liberation Sans" font-size="8pt"
+      master-reference="accompagnementCOL">
+
       <!-- ZONE LIGNE TECHNIQUE -->
       <fo:static-content flow-name="xsl-region-before-courrier">
-         <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
+         <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm"
+            margin-bottom="10mm" color="white">
             <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
          </fo:block>
       </fo:static-content>
-      
+
       <fo:flow flow-name="xsl-region-body">
-         
+
          <!-- PAGE COURRIER RECTO -->
          <fo:block page-break-after="always">
-            
             <!-- ZONE LOGOS -->
-            <fo:block-container absolute-position="absolute" left="5mm" top="2mm" width="180mm" height="25mm">
+            <fo:block-container absolute-position="absolute" left="5mm" top="2mm" width="180mm"
+               height="25mm">
                <fo:block>
-                  <fo:external-graphic src="logo_INSEE_M_SP.png" width="100%" height="100%" content-height="scale-to-fit" content-width="scale-to-fit" scaling="uniform"/>
+                  <fo:external-graphic src="logo_INSEE_M_SP.png" width="100%" height="100%"
+                     content-height="scale-to-fit" content-width="scale-to-fit" scaling="uniform"/>
                </fo:block>
             </fo:block-container>
-            
             <!-- ZONE RESERVE ADRESSE -->
-            <fo:block-container absolute-position="absolute" left="80mm" top="33mm" width="110mm" height="50mm" overflow="hidden">
+            <fo:block-container absolute-position="absolute" left="80mm" top="33mm" width="110mm"
+               height="50mm" overflow="hidden">
                <fo:block/>
             </fo:block-container>
-            
             <!-- ZONE DATAMATRIX ALLIAGE -->
-            <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm" width="11.88mm" height="11.88mm" overflow="hidden">
+            <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm"
+               width="11.88mm" height="11.88mm" overflow="hidden">
                <fo:block>
                   <fo:instream-foreign-object>
-                     <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns" message="${Barcode}" orientation="0">
+                     <barcode:barcode xmlns:barcode="http://barcode4j.krysalis.org/ns"
+                        message="${Barcode}" orientation="0">
                         <barcode:datamatrix>
                            <barcode:module-width>0.53mm</barcode:module-width>
                            <barcode:quiet-zone enabled="false">0mw</barcode:quiet-zone>
@@ -69,10 +83,9 @@
                   </fo:instream-foreign-object>
                </fo:block>
             </fo:block-container>
-            
-            
             <!-- ZONE ADRESSE -->
-            <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
+            <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm"
+               height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                <fo:block font-family="Lucida Console">
                   <fo:inline-container margin="0mm">
                      <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -85,216 +98,212 @@
                   </fo:inline-container>
                </fo:block>
             </fo:block-container>
-            
             <!-- ZONE RESERVE INTEGRALITE -->
-            <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm" height="22mm" overflow="hidden" font-size="10pt">
+            <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm"
+               height="22mm" overflow="hidden" font-size="10pt">
                <fo:block/>
             </fo:block-container>
-            
             <!-- ZONE DATAMATRIX MODE LIVRET -->
-            <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+            <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm"
+               height="16mm" overflow="hidden" font-size="10pt">
                <fo:block/>
-            </fo:block-container>           
-            
-            <!-- ZONE TITRE COURRIER -->
-            <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
-               <fo:block line-height="12pt" font-weight="bold" text-align="center">ENVOI DE QUESTIONNAIRE PAPIER</fo:block>
             </fo:block-container>
-            
+            <!-- ZONE TITRE COURRIER -->
+            <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm"
+               height="100%" overflow="hidden" font-size="10pt">
+               <fo:block line-height="12pt" font-weight="bold" text-align="center">ENVOI DE
+                  QUESTIONNAIRE PAPIER</fo:block>
+            </fo:block-container>
             <!-- ZONE CONTACT -->
-            <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="100%" overflow="hidden">
+            <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm"
+               height="100%" overflow="hidden">
                <fo:block margin-left="0.01mm" margin-right="0.01mm" border="black solid 0.5pt">
                   <fo:inline-container>
-                     <fo:block font-weight="bold" margin-top="0.5mm">Pour nous contacter :</fo:block>
+                     <fo:block font-weight="bold" margin-top="0.5mm">Pour nous
+                        contacter :</fo:block>
                      <fo:block>
-                        <fo:inline text-decoration="underline">Courriel</fo:inline> : #if($!{InitGestionnairesAdresseMessagerie})$!{InitGestionnairesAdresseMessagerie}#else${BddServiceCollecteurAdresseMessagerie}#end </fo:block>
-                     <fo:block>#if($!{InitNumeroSVI}||$!{InitGestionnaireTel})<fo:inline text-decoration="underline">Téléphone</fo:inline> : #end #if($!{InitNumeroSVI})09-69-32-97-47 #elseif($!{InitGestionnaireTel}) $!{InitGestionnaireTel}#end </fo:block>
-                     <fo:block>#if($!{InitNumeroSVI})<fo:inline text-decoration="underline">Code enquête</fo:inline> : $!{InitNumeroSVI}#end</fo:block>
+                        <fo:inline text-decoration="underline">Courriel</fo:inline> :
+                        #if($!{InitGestionnairesAdresseMessagerie})$!{InitGestionnairesAdresseMessagerie}#else${BddServiceCollecteurAdresseMessagerie}#end </fo:block>
+                     <fo:block>#if($!{InitNumeroSVI}||$!{InitGestionnaireTel})<fo:inline
+                           text-decoration="underline">Téléphone</fo:inline> : #end
+                        #if($!{InitNumeroSVI})09-69-32-97-47 #elseif($!{InitGestionnaireTel})
+                        $!{InitGestionnaireTel}#end </fo:block>
+                     <fo:block>#if($!{InitNumeroSVI})<fo:inline text-decoration="underline">Code
+                           enquête</fo:inline> : $!{InitNumeroSVI}#end</fo:block>
                   </fo:inline-container>
                </fo:block>
             </fo:block-container>
-            
             <!-- ZONE COURRIER -->
-            <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
-               
+            <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm"
+               height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+
                <fo:block text-align="right" font-size="10pt"/>
-               
-               <fo:block margin-top="5mm" font-weight="bold">
-                  Objet&#160;: Votre demande de questionnaire pour l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end 
-                  ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
-               </fo:block>
-               <fo:block font-weight="bold">
-                  Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
-	            </fo:block>
-               
-               <fo:block margin-top="3mm">
-                  #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
-               </fo:block>
-               <fo:block margin-top="3mm">
-                  Suite à votre demande, vous trouverez ci-joint le questionnaire papier de l’<fo:inline font-weight="bold">enquête#if(${BddFrequence}!='') ${BddFrequence}#end ${BddLibelleLong}</fo:inline>.
-               </fo:block>
-               <fo:block margin-top="3mm">
-                  ${BddObjectifsLongs}
-					</fo:block>
-               <fo:block margin-top="3mm">
-                  Cette enquête#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete} par le Conseil national 
-                  de l’information statistique (Cnis). Conformément à la loi n°&#160;51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique et ne sauraient en aucun
-                  cas être utilisées à des fins de contrôle fiscal ou de répression économique.
-               </fo:block>
-               <fo:block margin-top="3mm">
-                  Afin de permettre la prise en compte de la diversité des situations et d'assurer ainsi la qualité statistique des résultats, 
-                  il est très important que vous répondiez à cette enquête soit par internet selon les modalités précisées au verso de cette feuille, soit en complétant le questionnaire joint.
-               </fo:block>
-               <fo:block margin-top="3mm">
-                  Je vous remercie de bien vouloir nous transmettre votre questionnaire, une fois rempli, dans les meilleurs délais. 
-                  Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.
-               </fo:block>
-               <fo:block margin-top="3mm">
-                  En vous remerciant par avance de votre collaboration, je vous prie de bien vouloir agréer,
-                  #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},
-                  #else Madame, Monsieur,#end l'assurance de ma considération distinguée.
-               </fo:block>
-               
+
+               <fo:block margin-top="5mm" font-weight="bold"> Objet&#160;: Votre demande de
+                  questionnaire pour l'enquête statistique#if((${BddFrequence}!='annuelle') and
+                  (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end
+                  ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and
+                  (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end
+                  ${BddAnneeReference} </fo:block>
+               <fo:block font-weight="bold"> Ref.&#160;${BddRaisonSociale} (Votre
+                  ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee}) </fo:block>
+
+               <fo:block margin-top="3mm"> #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite}
+                  $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame,
+                  Monsieur,#end </fo:block>
+               <fo:block margin-top="3mm"> Suite à votre demande, vous trouverez ci-joint le
+                  questionnaire papier de l’<fo:inline font-weight="bold"
+                     >enquête#if(${BddFrequence}!='') ${BddFrequence}#end
+                     ${BddLibelleLong}</fo:inline>. </fo:block>
+               <fo:block margin-top="3mm"> ${BddObjectifsLongs} </fo:block>
+               <fo:block margin-top="3mm"> Cette enquête#if(${BddCaractereObligatoire}=='oui') à
+                  caractère obligatoire#end est reconnue d'${BddStatutEnquete} par le Conseil
+                  national de l’information statistique (Cnis). Conformément à la loi n°&#160;51-711
+                  du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret
+                  statistique et ne sauraient en aucun cas être utilisées à des fins de contrôle
+                  fiscal ou de répression économique. </fo:block>
+               <fo:block margin-top="3mm"> Afin de permettre la prise en compte de la diversité des
+                  situations et d'assurer ainsi la qualité statistique des résultats, il est très
+                  important que vous répondiez à cette enquête soit par internet selon les modalités
+                  précisées au verso de cette feuille, soit en complétant le questionnaire joint. </fo:block>
+               <fo:block margin-top="3mm"> Je vous remercie de bien vouloir nous transmettre votre
+                  questionnaire, une fois rempli, dans les meilleurs délais. Notre service
+                  d'assistance se tient à votre disposition pour répondre à vos questions en cas de
+                  besoin. </fo:block>
+               <fo:block margin-top="3mm"> En vous remerciant par avance de votre collaboration, je
+                  vous prie de bien vouloir agréer, #if($!{BddNom} and
+                  $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur
+                  $!{BddNom}, #else Madame, Monsieur,#end l'assurance de ma considération
+                  distinguée. </fo:block>
+
                <fo:block margin-top="10mm" text-align="right">
-                  ${BddServiceCollecteurSignataireFonction}
-               </fo:block>
-               <fo:block text-align="right">
-                  ${BddServiceCollecteurSignataireNom}
-               </fo:block>
+                  ${BddServiceCollecteurSignataireFonction} </fo:block>
+               <fo:block text-align="right"> ${BddServiceCollecteurSignataireNom} </fo:block>
             </fo:block-container>
-            
             <!-- ZONE NOTE DE BAS DE PAGE -->
-            <fo:block-container absolute-position="absolute" left="9mm" top="260mm" width="179mm" height="100%" overflow="hidden">
+            <fo:block-container absolute-position="absolute" left="9mm" top="260mm" width="179mm"
+               height="100%" overflow="hidden">
                <fo:block/>
             </fo:block-container>
-            
          </fo:block>
-         
+
          <!-- PAGE COURRIER VERSO -->
          <fo:block page-break-after="always">
-            
             <fo:block/>
-            
             <!-- ZONE NOTICE -->
-            <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
-                                font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
-               
-               <fo:block text-align="center" font-weight="bold" font-size="10pt">
-                  Comment répondre à l'enquête par internet&#160;?
-               </fo:block>
-               
-               <fo:block margin-top="5mm">
-                  Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
-                  ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
-                  publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
-                  Cette adresse est à inscrire dans la barre de navigation de votre navigateur.
-               </fo:block>
-               
-               <fo:block>
-                  
-                  #if($!{CalcMotDePasse})
-                  
-                  <fo:block margin-top="3.5mm">
-                     Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion, identifiant et mot de passe.
-                  </fo:block>
-                  
-                  <fo:block text-align="center" margin-top="1mm" margin-left="7mm" margin-right="7mm" border="black solid 0.5pt">
+            <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm"
+               height="100%" overflow="hidden" font-family="Liberation Sans" font-size="9pt"
+               text-align="justify" border="black solid 0.5pt" padding="5mm">
+
+               <fo:block text-align="center" font-weight="bold" font-size="10pt"> Comment répondre à
+                  l'enquête par internet&#160;? </fo:block>
+
+               <fo:block margin-top="5mm"> Pour répondre à l'enquête
+                  statistique#if((${BddFrequence}!='annuelle') and
+                  (${BddFrequence}!='pluriannuelle')) ${BddFrequence}#end ${BddLibelleLong}, il
+                  convient de vous connecter sur le site sécurisé de réponse aux enquêtes
+                  entreprises de la Statistique publique&#160;: <fo:inline
+                     text-decoration="underline">http://<fo:inline font-size="0.1pt"
+                        >&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt"
+                        >&#160;</fo:inline>publique.fr/</fo:inline>. Cette adresse est à inscrire
+                  dans la barre de navigation de votre navigateur. </fo:block>
+
+               <fo:block> #if($!{CalcMotDePasse}) <fo:block margin-top="3.5mm"> Il vous suffit
+                     ensuite de vous authentifier à l’aide de vos éléments de connexion, identifiant
+                     et mot de passe. </fo:block>
+                  <fo:block text-align="center" margin-top="1mm" margin-left="7mm"
+                     margin-right="7mm" border="black solid 0.5pt">
                      <fo:inline-container>
-                        <fo:block margin-top="1.2mm">
-                           Identifiant&#160;: ${BddIdentifiantContact}
+                        <fo:block margin-top="1.2mm"> Identifiant&#160;: ${BddIdentifiantContact}
                         </fo:block>
                      </fo:inline-container>
                      <fo:inline-container>
-                        <fo:block margin-bottom="1.2mm">
-                           Mot de passe&#160;: $!{CalcMotDePasse}
+                        <fo:block margin-bottom="1.2mm"> Mot de passe&#160;: $!{CalcMotDePasse}
                         </fo:block>
                      </fo:inline-container>
                   </fo:block>
-                  
                   <fo:block>
-                     <fo:block margin-top="3.5mm">
-                        Le mot de passe étant à usage unique, vous devrez le changer lors de votre première connexion.
+                     <fo:block margin-top="3.5mm"> Le mot de passe étant à usage unique, vous devrez
+                        le changer lors de votre première connexion. </fo:block>
+                     <fo:block margin-top="3.5mm"> Lors de la saisie de vos éléments de connexion,
+                        merci de faire attention à bien respecter les minuscules et majuscules.
                      </fo:block>
-                     <fo:block margin-top="3.5mm">
-                        Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
-                     </fo:block>
-                  </fo:block>
-                  
-                  #else
-                  
-                  <fo:block margin-top="3.5mm">
-                     Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion.
-                  </fo:block>
-                  <fo:block margin-top="3.5mm">
-                     Lors de la saisie de vos éléments de connexion, merci de faire attention à bien respecter les minuscules et majuscules.
-                  </fo:block>
-                  <fo:block margin-top="3.5mm" font-weight="bold">
-                     Votre identifiant de connexion ${BddIdentifiantContact} reste inchangé.
-                  </fo:block>
-                  <fo:block margin-top="3.5mm">
-                     Le mot de passe précédemment communiqué par voie postale étant à usage unique, si vous vous êtes déjà authentifié sur le site de réponse à l'enquête, 
-                     vous avez dû le changer lors de votre première connexion.
-                  </fo:block>
-                  
-                  #end
-                  
-               </fo:block>
-               
-               <fo:block margin-top="3.5mm">
-                  En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                  de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
-               </fo:block>
-               <fo:block margin-top="3.5mm">
-                  En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
-                  vous authentifier à nouveau, veuillez patienter quelques minutes au terme desquelles le compte sera automatiquement débloqué.
-               </fo:block>
-               <fo:block margin-top="3.5mm">
-                  Une fois authentifié, vous pourrez remplir votre questionnaire en toute sécurité dans un environnement protégé.
-               </fo:block>
-               <fo:block margin-top="3.5mm">
-                  Pour toutes questions techniques (accès au site de réponse en ligne, éléments de connexion, affichage du questionnaire, etc.), 
-                  vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
-                  réponse aux enquêtes entreprises de la Statistique publique.
-               </fo:block>
-               
+                  </fo:block> #else <fo:block margin-top="3.5mm"> Il vous suffit ensuite de vous
+                     authentifier à l’aide de vos éléments de connexion. </fo:block>
+                  <fo:block margin-top="3.5mm"> Lors de la saisie de vos éléments de connexion,
+                     merci de faire attention à bien respecter les minuscules et majuscules. </fo:block>
+                  <fo:block margin-top="3.5mm" font-weight="bold"> Votre identifiant de connexion
+                     ${BddIdentifiantContact} reste inchangé. </fo:block>
+                  <fo:block margin-top="3.5mm"> Le mot de passe précédemment communiqué par voie
+                     postale étant à usage unique, si vous vous êtes déjà authentifié sur le site de
+                     réponse à l'enquête, vous avez dû le changer lors de votre première connexion.
+                  </fo:block> #end </fo:block>
+
+               <fo:block margin-top="3.5mm"> En cas de perte ou d'oubli de votre mot de passe, vous
+                  pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes
+                  entreprises de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;»
+                  du site <fo:inline font-weight="bold" text-decoration="underline"
+                     >http://entreprises.stat-publique.fr/</fo:inline> ). </fo:block>
+               <fo:block margin-top="3.5mm"> En cas de trop nombreuses tentatives
+                  d’authentification, votre compte peut être momentanément bloqué, pour des raisons
+                  de sécurité. Dans ce cas, avant de vous authentifier à nouveau, veuillez patienter
+                  quelques minutes au terme desquelles le compte sera automatiquement débloqué. </fo:block>
+               <fo:block margin-top="3.5mm"> Une fois authentifié, vous pourrez remplir votre
+                  questionnaire en toute sécurité dans un environnement protégé. </fo:block>
+               <fo:block margin-top="3.5mm"> Pour toutes questions techniques (accès au site de
+                  réponse en ligne, éléments de connexion, affichage du questionnaire, etc.), vous
+                  pouvez contacter notre service d'assistance technique à l'aide du formulaire
+                  disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de
+                  réponse aux enquêtes entreprises de la Statistique publique. </fo:block>
+
             </fo:block-container>
-             
             <!-- ZONE CADRE LEGAL -->
-            <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
-               
-               <fo:block>
-                  Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
-                  en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
-                  Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
-               </fo:block>
-               <fo:block>
-                  #if(${BddCaractereObligatoire}=='oui')Cette enquête est obligatoire. En cas de défaut de réponse après mise en demeure dans le délai imparti ou de réponse sciemment inexacte, 
-                  les personnes physiques ou morales peuvent être l'objet d'une amende administrative prononcée par le ministre chargé de l'économie sur avis du 
-                  Conseil national de l'information statistique réuni en Comité du contentieux des enquêtes statistiques obligatoires dans les conditions fixées 
-                  par le décret prévu au II de l'article 1er bis de la loi du 7 juin 1951.#else<fo:inline font-size="0.1pt">&#160;</fo:inline>Cette enquête n’est pas obligatoire.#end
-               </fo:block>
-               <fo:block>
-                  Les réponses à ce questionnaire sont protégées par le secret statistique et destinées à ${BddArticleServiceProducteur}${BddNomServiceProducteur}. 
-                  Ces réponses ainsi que les données obtenues par appariement seront conservées pendant ${BddConservation} à compter de la fin de la collecte pour les besoins de l’enquête. 
-                  Elles seront archivées au-delà de cette durée. À tout moment, leur usage et leur accès seront strictement contrôlés et limités à l'élaboration de statistiques 
-                  ou à des travaux de recherche scientifique ou historique.
-               </fo:block>
-               <fo:block>
-                  #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
-                  n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
-                  aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
-                  d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
-                  Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
-                  Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
-                  et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
-                  ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                  Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
-               </fo:block>
-               
+            <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm"
+               height="100%" overflow="hidden" font-size="7pt" text-align="justify"
+               border="solid black 0.5pt" padding="1mm">
+
+               <fo:block> Vu l'avis favorable du Conseil national de l'information statistique,
+                  cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de
+                     qualité statistique</fo:inline>, en application de la loi n<fo:inline
+                     font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur
+                  l'obligation, la coordination et le secret en matière de statistiques. Elle a
+                  obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année
+                  ${BddAnneeCollecte}. </fo:block>
+               <fo:block> #if(${BddCaractereObligatoire}=='oui')Cette enquête est obligatoire. En
+                  cas de défaut de réponse après mise en demeure dans le délai imparti ou de réponse
+                  sciemment inexacte, les personnes physiques ou morales peuvent être l'objet d'une
+                  amende administrative prononcée par le ministre chargé de l'économie sur avis du
+                  Conseil national de l'information statistique réuni en Comité du contentieux des
+                  enquêtes statistiques obligatoires dans les conditions fixées par le décret prévu
+                  au II de l'article 1er bis de la loi du 7 juin 1951.#else<fo:inline
+                     font-size="0.1pt">&#160;</fo:inline>Cette enquête n’est pas obligatoire.#end </fo:block>
+               <fo:block> Les réponses à ce questionnaire sont protégées par le secret statistique
+                  et destinées à ${BddArticleServiceProducteur}${BddNomServiceProducteur}. Ces
+                  réponses ainsi que les données obtenues par appariement seront conservées pendant
+                  ${BddConservation} à compter de la fin de la collecte pour les besoins de
+                  l’enquête. Elles seront archivées au-delà de cette durée. À tout moment, leur
+                  usage et leur accès seront strictement contrôlés et limités à l'élaboration de
+                  statistiques ou à des travaux de recherche scientifique ou historique. </fo:block>
+               <fo:block> #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril
+                  2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline
+                     font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à
+                  l'informatique, aux fichiers et aux libertés s'appliquent à la présente enquête.
+                  Pour les données à caractère personnel, un droit d'accès, de rectification,
+                  d’effacement ou de limitation de traitement peut être exercé pendant la période de
+                  conservation des données d’identification. Ces droits peuvent être exercés auprès
+                  de ${AdresseRetourL1} que vous pouvez contacter à l’adresse
+                  ${BddServiceCollecteurAdresseMessagerie}. Pour toute question relative au
+                  traitement de vos données, vous pouvez contacter le délégué à la protection des
+                  données des ministères économique et financier à l’adresse <fo:inline
+                     text-decoration="underline"
+                     >le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline>
+                  ou son correspondant à l’Insee : <fo:inline text-decoration="underline"
+                     >contact-rgpd@insee.fr</fo:inline>. Vous pouvez si vous l’estimez nécessaire
+                  adresser une réclamation à la Cnil.#end </fo:block>
+
             </fo:block-container>
-            
          </fo:block>
-         
+
       </fo:flow>
    </fo:page-sequence>
 </fo:root>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/accompagnementCOL.fo
@@ -45,7 +45,7 @@
       <fo:static-content flow-name="xsl-region-before-courrier">
          <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm"
             margin-bottom="10mm" color="white">
-            <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+            &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
          </fo:block>
       </fo:static-content>
 

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
@@ -148,7 +148,7 @@
                         Si vous venez de procéder à la transmission de votre réponse, je vous prie de ne pas tenir compte de ce courrier.
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        A défaut, <fo:inline font-weight="bold">je vous prie#if(${BddQuestionnaire}==0) de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>,#else
+                        A défaut, <fo:inline font-weight="bold">je vous prie</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>,#else
                         soit de répondre à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint,#end dans un délai de 15 jours. 
                         A l’expiration de ce délai, votre dossier sera soumis pour examen au <fo:inline font-weight="bold">Comité du contentieux</fo:inline> des enquêtes statistiques obligatoires 
                         du Conseil national de l’information statistique (Cnis), conformément à la loi*.

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
@@ -33,12 +33,13 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
+                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         
         <fo:flow flow-name="xsl-region-body">
             
+            <!-- PAGE COURRIER RECTO -->
             <fo:block page-break-after="always">
                 
                 <!-- ZONE LOGOS -->
@@ -54,6 +55,7 @@
                 </fo:block-container>
 
                 <!-- ZONE DATAMATRIX ALLIAGE -->
+                #if($!{InitAccuseReception}!='' and $!{InitAccuseReception}!='oui')
                 <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm" width="11.88mm" height="11.88mm" overflow="hidden">
                     <fo:block>
                         <fo:instream-foreign-object>
@@ -68,9 +70,10 @@
                         </fo:instream-foreign-object>
                     </fo:block>
                 </fo:block-container>
+                #end
                 
                 <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
+                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                     <fo:block font-family="Lucida Console">
                         <fo:inline-container margin="0mm">
                             <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -88,10 +91,15 @@
                 <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm" height="22mm" overflow="hidden" font-size="10pt">
                     <fo:block/>
                 </fo:block-container>
+                
+                <!-- ZONE DATAMATRIX MODE LIVRET -->
+                <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+                    <fo:block/>
+                </fo:block-container>  
 
                 <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
+                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+                    <fo:block line-height="12pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
                 </fo:block-container>
                 
                 <!-- ZONE CONTACT -->
@@ -107,7 +115,7 @@
                 </fo:block-container>
                 
                 <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+                <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
 
                     <fo:block text-align="right" font-size="10pt">
                         Paris, le ${DateEdition}
@@ -116,18 +124,22 @@
                     <fo:block margin-top="5mm" font-weight="bold">
                         Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference}
                     </fo:block>
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    <fo:block>
+                        Unité enquêtée&#160;: ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
                     </fo:block>
                     
-                    <fo:block margin-top="5mm" font-weight="bold">
+                    <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
+                    </fo:block>
+                    
+                    <fo:block margin-top="8mm" font-weight="bold">
                         Madame la Directrice, Monsieur le Directeur,
                     </fo:block>
                     <fo:block margin-top="5mm">
                         Ma lettre de mise en demeure du ${BddDateEnvoiMiseEnDemeure} étant restée sans suite, je suis dans l’obligation aujourd’hui d’établir à votre encontre le constat suivant&#160;:
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        - de défaut de réponse à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference}&#160;;
+                        - de défaut de réponse à l'<fo:inline font-weight="bold">enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference}&#160;</fo:inline>;
                     </fo:block>
                     <fo:block>
                         - et d’absence de justification à ce défaut de réponse.
@@ -136,10 +148,17 @@
                         Si vous venez de procéder à la transmission de votre réponse, je vous prie de ne pas tenir compte de ce courrier.
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        A défaut, <fo:inline font-weight="bold">je vous prie</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>,#else
+                        A défaut, <fo:inline font-weight="bold">je vous prie#if(${BddQuestionnaire}==0) de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>,#else
                         soit de répondre à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint,#end dans un délai de 15 jours. 
                         A l’expiration de ce délai, votre dossier sera soumis pour examen au <fo:inline font-weight="bold">Comité du contentieux</fo:inline> des enquêtes statistiques obligatoires 
                         du Conseil national de l’information statistique (Cnis), conformément à la loi*.
+                        Nous avons plus que jamais besoin de votre participation pour assurer la qualité des statistiques sur 2019. 
+                        Pour tenir compte de la crise sanitaire actuelle, l’Insee a redéfini ses priorités et adapté ses travaux. 
+                        Les délais de réponse à certaines enquêtes auprès des entreprises ont ainsi été allongés de plusieurs mois. 
+                        Nous sommes conscients des difficultés que la crise fait peser sur vous et de ses conséquences pendant les mois à venir. 
+                        Cependant, pour mieux évaluer son impact, il est particulièrement important de suivre l’activité économique en France. 
+                        Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019 dans chaque secteur, 
+                        et ainsi estimer précisément l’impact économique de la crise vécue aujourd’hui.
                     </fo:block>
                     <fo:block margin-top="3mm">
                         S’il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre. 
@@ -159,27 +178,28 @@
                 </fo:block-container>
                 
                 <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="250mm" width="188mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="9mm" top="273mm" width="179mm" height="100%" overflow="hidden">
                     <fo:block>
                         (*) Loi n°51-711 du 7 juin 1951 modifiée. Décret n° 2009-318 du 20 mars 2009.
                     </fo:block>
                 </fo:block-container>
-                              
+                
             </fo:block>
             
+            <!-- PAGE COURRIER VERSO -->
             <fo:block page-break-after="always">
                 
                 <fo:block/>
                 
                 <!-- ZONE NOTICE -->
-                <fo:block-container absolute-position="absolute" left="20mm" top="20mm" width="150mm" height="100%" overflow="hidden"
+                <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
                                     font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
-
+                    
                     <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet&#160;?
                     </fo:block>
 
-                    <fo:block margin-top="3.5mm">
+                    <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
@@ -200,7 +220,7 @@
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -214,14 +234,14 @@
                         vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
                         réponse aux enquêtes entreprises de la Statistique publique.
                     </fo:block>
-    
+                    
                 </fo:block-container>
                 
                 <!-- ZONE CADRE LEGAL -->
                 <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
                     
                     <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -238,14 +258,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                     <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
                     
                 </fo:block-container>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/cnrCOL.fo
@@ -33,7 +33,7 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
@@ -138,7 +138,7 @@
                         ${BddArticleServiceProducteur}${BddNomServiceProducteur} réalise l’<fo:inline font-weight="bold">enquête #if(${BddFrequence}!='')${BddFrequence}#end ${BddLibelleLong}.</fo:inline> ${BddObjectifsLongs}
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        Cette enquête<fo:inline font-weight="bold">#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete}</fo:inline> par le
+                        Cette enquête<fo:inline font-weight="bold">#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete}</fo:inline> par le 
                         Conseil national de l’information statistique (Cnis). Conformément à la loi n° 51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique 
                         et ne sauraient en aucun cas être utilisées à des fins de contrôle fiscal ou de répression économique.
                     </fo:block>
@@ -148,9 +148,9 @@
                         et il est important que nous puissions recueillir votre réponse afin que la diversité des caractéristiques des entreprises soit prise en compte.
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        <fo:inline font-weight="bold">Je vous invite donc #if(${BddQuestionnaire}==0) à répondre à cette enquête 
+                        <fo:inline font-weight="bold">Je vous invite donc</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">à répondre à cette enquête  
                         selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, 
-                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette
+                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette 
                         lettre.#else soit à répondre à cette enquête <fo:inline font-weight="bold">par internet selon les modalités précisées au verso de cette lettre</fo:inline>
                         soit à compléter le questionnaire joint.#end
                     </fo:block>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
@@ -33,12 +33,13 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
+                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         
         <fo:flow flow-name="xsl-region-body">
             
+            <!-- PAGE COURRIER RECTO -->
             <fo:block page-break-after="always">
                 
                 <!-- ZONE LOGOS -->
@@ -70,7 +71,7 @@
                 </fo:block-container>
                 
                 <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
+                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                     <fo:block font-family="Lucida Console">
                         <fo:inline-container margin="0mm">
                             <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -90,9 +91,14 @@
                 </fo:block-container>
                 
                 <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">ENTRÉE DANS L’ÉCHANTILLON</fo:block>
+                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+                    <fo:block line-height="12pt" font-weight="bold" text-align="center">ENTRÉE DANS L’ÉCHANTILLON</fo:block>
                 </fo:block-container>
+                
+                <!-- ZONE DATAMATRIX MODE LIVRET -->
+                <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+                    <fo:block/>
+                </fo:block-container>     
                 
                 <!-- ZONE CONTACT -->
                 <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="100%" overflow="hidden">
@@ -107,22 +113,24 @@
                 </fo:block-container>
 
                 <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
- 
+                <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+
                     <fo:block text-align="right" font-size="10pt">
                         Paris, le ${DateEdition}
                     </fo:block>
                     
                     <fo:block margin-top="5mm" font-weight="bold">
-                        Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) 
-                        ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
+                        Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
+                    </fo:block>
+                    <fo:block>
+                        Unité enquêtée&#160;: ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
                     </fo:block>
                     
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
                     </fo:block>
 
-                    <fo:block margin-top="3mm">
+                    <fo:block margin-top="8mm">
                         #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
                     </fo:block>
                
@@ -140,10 +148,11 @@
                         et il est important que nous puissions recueillir votre réponse afin que la diversité des caractéristiques des entreprises soit prise en compte.
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        <fo:inline font-weight="bold">Je vous invite donc</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">à remplir le questionnaire par internet 
+                        <fo:inline font-weight="bold">Je vous invite donc #if(${BddQuestionnaire}==0) à répondre à cette enquête 
                         selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, 
                         merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette
-                        lettre.#else soit à répondre à cette enquête  par internet selon les modalités précisées au verso de cette lettre soit à compléter le questionnaire joint.#end
+                        lettre.#else soit à répondre à cette enquête <fo:inline font-weight="bold">par internet selon les modalités précisées au verso de cette lettre</fo:inline>
+                        soit à compléter le questionnaire joint.#end
                     </fo:block>
                     <fo:block margin-top="3mm">
                         Je vous invite à nous transmettre votre questionnaire une fois rempli avant le <fo:inline font-weight="bold">${BddDateEcheance}</fo:inline>. 
@@ -169,25 +178,26 @@
                 </fo:block-container>
 
                 <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="250mm" width="188mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="9mm" top="260mm" width="179mm" height="100%" overflow="hidden">
                     <fo:block/>
                 </fo:block-container>
                 
             </fo:block>
             
+            <!-- PAGE COURRIER VERSO -->
             <fo:block page-break-after="always">
                 
                 <fo:block/>
                 
                 <!-- ZONE NOTICE -->
-                <fo:block-container absolute-position="absolute" left="20mm" top="20mm" width="150mm" height="100%" overflow="hidden"
+                <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
                                     font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
                         
                     <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet&#160;?
                     </fo:block>
                     
-                    <fo:block margin-top="3.5mm">
+                    <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
@@ -196,7 +206,7 @@
                     
                     <fo:block>
                         
-                        #if($!{CalcMotDePasse}) 
+                        #if($!{CalcMotDePasse})
                         
                         <fo:block margin-top="3.5mm">
                             Il vous suffit ensuite de vous authentifier à l’aide de vos éléments de connexion, identifiant et mot de passe.
@@ -246,7 +256,7 @@
                     
                     <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -259,7 +269,7 @@
                         Pour toutes questions techniques (accès au site de réponse en ligne, éléments de connexion, affichage du questionnaire, etc.), 
                         vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
                         réponse aux enquêtes entreprises de la Statistique publique.
-                    </fo:block>  
+                    </fo:block>
             
                 </fo:block-container>
                 
@@ -267,7 +277,7 @@
                 <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
                     
                     <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -284,14 +294,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                     <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
                     
                 </fo:block-container>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/entreeCOL.fo
@@ -33,7 +33,7 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/medCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/medCOL.fo
@@ -33,12 +33,13 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
+                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         
         <fo:flow flow-name="xsl-region-body">
             
+            <!-- PAGE COURRIER RECTO -->
             <fo:block page-break-after="always">
                 
                 <!-- ZONE LOGOS -->
@@ -54,6 +55,7 @@
                 </fo:block-container>                
                   
                 <!-- ZONE DATAMATRIX ALLIAGE -->
+                #if($!{InitAccuseReception}!='' and $!{InitAccuseReception}!='oui')
                 <fo:block-container absolute-position="absolute" left="100mm" top="37.8mm" width="11.88mm" height="11.88mm" overflow="hidden">
                     <fo:block>
                         <fo:instream-foreign-object>
@@ -68,9 +70,10 @@
                         </fo:instream-foreign-object>
                     </fo:block>
                 </fo:block-container>
+                #end
                 
                 <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
+                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                     <fo:block font-family="Lucida Console">
                         <fo:inline-container margin="0mm">
                             <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -87,11 +90,16 @@
                 <!-- ZONE RESERVE INTEGRALITE -->
                 <fo:block-container absolute-position="absolute" left="187mm" top="75mm" width="13mm" height="22mm" overflow="hidden" font-size="10pt">
                     <fo:block/>
-                </fo:block-container>             
+                </fo:block-container>
+                
+                <!-- ZONE DATAMATRIX MODE LIVRET -->
+                <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+                    <fo:block/>
+                </fo:block-container>
                 
                 <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">MISE EN DEMEURE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
+                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+                    <fo:block line-height="12pt" font-weight="bold" text-align="center">MISE EN DEMEURE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
                 </fo:block-container>                
                 
                 <!-- ZONE CONTACT -->
@@ -107,7 +115,7 @@
                 </fo:block-container>
 
                 <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+                <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
                             
                     <fo:block text-align="right" font-size="10pt">
                         Paris, le ${DateEdition}
@@ -116,9 +124,12 @@
                     <fo:block margin-top="5mm" font-weight="bold">
                         Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
                     </fo:block>
-
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    <fo:block>
+                        Unité enquêtée&#160;: ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    </fo:block>
+                    
+                    <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
                     </fo:block>
                     
                     <fo:block margin-top="5mm">
@@ -130,23 +141,24 @@
                         les délais accordés aux entreprises pour répondre à ses enquêtes. Nous sommes conscients des difficultés que la crise a fait peser sur vous et de ses conséquences 
                         appelées à perdurer encore quelque temps. Cependant, pour mieux évaluer l’impact de la crise, il est essentiel de suivre dans le détail l’activité économique en France.
                     </fo:block>
-                    
                     <fo:block margin-top="3mm">
-                        Malgré ma relance en date du ${BddDateEnvoiRappel}, et sauf erreur de ma part, votre réponse à l’<fo:inline font-weight="bold">enquête#if((${BddFrequence}!='annuelle') 
-                        and (${BddFrequence}!='pluriannuelle')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') 
-                        and (${BddFrequence}!='pluriannuelle')) ${BddPeriode}#end ${BddAnneeReference}</fo:inline> n’est pas encore parvenue à mes services. 
+                        #if(${BddDateEnvoiRappel}=="//")Sauf erreur de ma part,#else
+                        Malgré ma relance en date du ${BddDateEnvoiRappel}, et sauf erreur de ma part,#end votre réponse à l’<fo:inline font-weight="bold">enquête
+                        #if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}
+                        #if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}</fo:inline> n’est pas encore parvenue à mes services. 
                         Au cas où ce courrier se serait croisé avec votre réponse, je vous prie, bien entendu, de ne pas en tenir compte.
                     </fo:block>
                     <fo:block margin-top="3mm">
                         Dans le cas contraire, les dispositions légales* m’amènent à <fo:inline font-weight="bold">vous mettre en demeure</fo:inline> d’adresser votre réponse 
                         à mes services dans un délai de <fo:inline font-weight="bold">15 jours</fo:inline> à compter de la réception de la présente lettre, 
-                        ou de me faire connaître par écrit les motifs de cette absence de réponse. Je peux tout à fait comprendre que nous n’ayez pas été en mesure de répondre 
+                        ou de me faire connaître par écrit les motifs de cette absence de réponse.
+                        Je peux tout à fait comprendre que nous n’ayez pas été en mesure de répondre 
                         jusqu’à présent, compte tenu du contexte, mais votre réponse est essentielle pour garantir la qualité et la fiabilité des statistiques sur 2019. 
                         Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019 dans chaque secteur, et ainsi estimer 
                         précisément l’impact économique de la crise vécue aujourd’hui.
                     </fo:block>
-                    <fo:block margin-top="3mm"
-                        >En cas de défaut de réponse dans le délai imparti, la procédure contentieuse prévue par la loi vous serait appliquée 
+                    <fo:block margin-top="3mm">
+                        En cas de défaut de réponse dans le délai imparti, la procédure contentieuse prévue par la loi vous serait appliquée 
                         et je serais dans l’obligation d’établir un constat de non-réponse à votre encontre puis de soumettre votre dossier au 
                         <fo:inline font-weight="bold">Comité du contentieux</fo:inline> des enquêtes statistiques obligatoires du Conseil national de l’information statistique (Cnis), 
                         conformément à la loi de 1951 sur l’obligation en matière de statistique.
@@ -178,7 +190,7 @@
                 </fo:block-container>
                 
                 <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="265mm" width="188mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="9mm" top="273mm" width="179mm" height="100%" overflow="hidden">
                     <fo:block>
                         (*) Loi n°51-711 du 7 juin 1951 modifiée. Décret n° 2009-318 du 20 mars 2009.
                     </fo:block>
@@ -186,6 +198,7 @@
                 
             </fo:block>
             
+            <!-- PAGE COURRIER VERSO -->
             <fo:block page-break-after="always">
                 
                 <fo:block/>
@@ -198,7 +211,7 @@
                         Comment répondre à l'enquête par internet&#160;?
                     </fo:block>
                     
-                    <fo:block margin-top="3.5mm">
+                    <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
@@ -219,7 +232,7 @@
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -240,7 +253,7 @@
                 <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
                     
                     <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -257,14 +270,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                     <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
                     
                 </fo:block-container>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/medCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/medCOL.fo
@@ -33,7 +33,7 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
         

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
@@ -33,12 +33,13 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
+                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
 
         <fo:flow flow-name="xsl-region-body">
             
+            <!-- PAGE COURRIER RECTO -->
             <fo:block page-break-after="always">
                 
                 <!-- ZONE LOGOS -->
@@ -70,7 +71,7 @@
                 </fo:block-container>
                 
                 <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
+                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                     <fo:block font-family="Lucida Console">
                         <fo:inline-container margin="0mm">
                             <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -89,13 +90,18 @@
                     <fo:block/>
                 </fo:block-container>
                 
+                <!-- ZONE DATAMATRIX MODE LIVRET -->
+                <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+                    <fo:block/>
+                </fo:block-container>   
+                
                 <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">OUVERTURE DE COLLECTE</fo:block>
+                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+                    <fo:block line-height="12pt" font-weight="bold" text-align="center">OUVERTURE DE COLLECTE</fo:block>
                 </fo:block-container>
                 
                 <!-- ZONE CONTACT -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="1mm" top="50.5mm" width="78mm" height="36.7mm" overflow="hidden">
                     <fo:block margin-left="0.01mm" margin-right="0.01mm" border="black solid 0.5pt">
                         <fo:inline-container>
                             <fo:block font-weight="bold" margin-top="0.5mm">Pour nous contacter&#160;:</fo:block>
@@ -107,7 +113,7 @@
                 </fo:block-container>
 
                 <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+                <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
                             
                     <fo:block text-align="right" font-size="10pt">
                         Paris, le ${DateEdition}
@@ -116,17 +122,34 @@
                     <fo:block margin-top="5mm" font-weight="bold">
                         Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
                     </fo:block>
-
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    <fo:block>
+                        Unité enquêtée&#160;: ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
                     </fo:block>
                     
                     <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
+                    </fo:block>
+                    
+                    <fo:block margin-top="8mm">
                         #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
                     </fo:block>
                     <fo:block margin-top="3mm">
                         ${BddArticleServiceProducteur}${BddNomServiceProducteur} réalise l’<fo:inline font-weight="bold">enquête#if(${BddFrequence}!='') ${BddFrequence}#end ${BddLibelleLong}.</fo:inline> ${BddObjectifsLongs}
                     </fo:block>
+                    
+                    <!--
+                    <fo:block margin-top="3mm">
+                        Pour tenir compte de la crise sanitaire actuelle, l’Insee a redéfini ses priorités et adapté ses travaux. 
+                        Certaines enquêtes auprès des entreprises avaient ainsi été reportées et les délais de réponse allongés. 
+                        Nous sommes conscients des difficultés que la crise fait peser sur vous et de ses conséquences pendant les mois à venir. 
+                        Cependant, pour mieux évaluer son impact, il est particulièrement important de suivre l’activité économique en France ; 
+                        c’est pourquoi l’Insee va poursuivre la diffusion de certains indicateurs et lance aujourd’hui l'<fo:inline font-weight="bold">enquête#if(${BddFrequence}!='') ${BddFrequence}#end ${BddLibelleLong}</fo:inline>.
+                    </fo:block>
+                    <fo:block margin-top="3mm">
+                        ${BddObjectifsLongs}
+                    </fo:block>
+                    -->
+                    
                     <fo:block margin-top="3mm">
                         Cette enquête<fo:inline font-weight="bold">#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete}</fo:inline> par le Conseil national 
                         de l’information statistique (Cnis). Conformément à la loi n° 51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique et ne sauraient en aucun
@@ -135,15 +158,26 @@
                     <fo:block margin-top="3mm">
                         Afin de permettre la prise en compte de la diversité des situations et assurer ainsi la qualité statistique des résultats, il est très important que vous répondiez à cette enquête.
                     </fo:block>
+                    
+                    <!--
                     <fo:block margin-top="3mm">
-                        <fo:inline font-weight="bold">Je vous invite donc</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">à remplir le questionnaire par internet 
-                         selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, 
-                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre.#else soit à répondre à cette enquête 
+                        #if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!=''))
+                        Nous avons plus que jamais besoin de votre participation pour assurer la qualité des indicateurs conjoncturels et ainsi continuer à suivre les évolutions de l’activité économique à court terme.#else
+                        Nous avons plus que jamais besoin de votre participation pour assurer la qualité des statistiques sur 2019. 
+                        Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019, 
+                        et ainsi estimer précisément l’impact économique de la crise vécue aujourd’hui.#end Si vous êtes en mesure de répondre à cette enquête, nous vous en serons donc extrêmement reconnaissants.
+                    </fo:block>
+                    -->
+                    
+                    <fo:block margin-top="3mm">
+                        <fo:inline font-weight="bold">Je vous invite donc#if(${BddQuestionnaire}==0) à remplir le questionnaire par internet 
+                        selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, 
+                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre.
+                        Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoin.#else soit à répondre à cette enquête 
                         par internet selon les modalités précisées au verso de cette lettre soit à compléter le questionnaire joint.#end
                     </fo:block>
                     <fo:block margin-top="3mm">
                         Je vous remercie de bien vouloir transmettre votre questionnaire une fois rempli avant le <fo:inline font-weight="bold">${BddDateEcheance}</fo:inline>. 
-                        Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.
                     </fo:block>
                     <fo:block margin-top="3mm">
                         Des renseignements relatifs à l'enquête et à son calendrier sont disponibles sur le site internet du Cnis&#160;: <fo:inline text-decoration="underline">${BddURLCnis}</fo:inline>. #if($!{BddURLDiffusion})
@@ -165,25 +199,26 @@
                 </fo:block-container>
 
                 <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="250mm" width="188mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="9mm" top="260mm" width="179mm" height="100%" overflow="hidden">
                     <fo:block/>
                 </fo:block-container>
                 
             </fo:block>
             
+            <!-- PAGE COURRIER VERSO -->
             <fo:block page-break-after="always">
                 
                 <fo:block/>
                 
                 <!-- ZONE NOTICE -->
-                <fo:block-container absolute-position="absolute" left="20mm" top="20mm" width="150mm" height="100%" overflow="hidden"
+                <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
                                     font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
                     
                     <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet&#160;?
                     </fo:block>
                     
-                    <fo:block margin-top="3.5mm">
+                    <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
@@ -242,7 +277,7 @@
 
                     <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -263,7 +298,7 @@
                 <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
                     
                     <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -280,14 +315,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                     <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
                     
                 </fo:block-container>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
@@ -170,9 +170,9 @@
                     -->
                     
                     <fo:block margin-top="3mm">
-                        <fo:inline font-weight="bold">Je vous invite donc#if(${BddQuestionnaire}==0) à remplir le questionnaire par internet 
+                        <fo:inline font-weight="bold">Je vous invite donc</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">à remplir le questionnaire par internet 
                         selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, 
-                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre.
+                        merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre. 
                         Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoin.#else soit à répondre à cette enquête 
                         par internet selon les modalités précisées au verso de cette lettre soit à compléter le questionnaire joint.#end
                     </fo:block>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/ouvertureCOL.fo
@@ -33,7 +33,7 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
 

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
@@ -168,10 +168,11 @@
                         Si vous êtes en mesure de répondre à cette enquête, nous vous en serions donc extrêmement reconnaissants.
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        Dans ce cas, <fo:inline font-weight="bold">je vous prie#if(${BddQuestionnaire}==0) de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>. 
-                        S'il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l'en-tête de cette lettre, 
-                        en privilégiant le contact par courriel. Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoin.#else soit de répondre à cette enquête par internet selon 
-                        les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint. Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.#end
+                        Dans ce cas, <fo:inline font-weight="bold">je vous prie</fo:inline>#if(${BddQuestionnaire}==0) <fo:inline font-weight="bold">de remplir le questionnaire par internet 
+                        selon les modalités précisées au verso de cette lettre</fo:inline>. S'il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance 
+                        dont les coordonnées figurent dans l'en-tête de cette lettre, en privilégiant le contact par courriel. Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoin.#else soit de répondre 
+                        à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint. Notre service d'assistance se tient à votre disposition 
+                        pour répondre à vos questions en cas de besoin.#end
                     </fo:block>
                     -->
                     
@@ -179,7 +180,7 @@
                         ${BddObjectifsLongs}
                     </fo:block>
                     <fo:block margin-top="3mm">
-                        Je vous rappelle que cette enquête#if(${BddCaractereObligatoire}=='oui')<fo:inline font-weight="bold"> à caractère obligatoire#end est reconnue d'${BddStatutEnquete}</fo:inline> par le 
+                        Je vous rappelle que cette enquête<fo:inline font-weight="bold">#if(${BddCaractereObligatoire}=='oui') à caractère obligatoire#end est reconnue d'${BddStatutEnquete}</fo:inline> par le 
                         Conseil national de l'information statistique (Cnis). Conformément à la loi n° 51-711 du 7 juin 1951 modifiée, les données recueillies sont couvertes par le secret statistique 
                         et ne sauraient en aucun cas être utilisées à des fins de contrôle fiscal ou de répression économique.
                     </fo:block>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
@@ -33,12 +33,13 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
+                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
 
         <fo:flow flow-name="xsl-region-body">
             
+            <!-- PAGE COURRIER RECTO -->
             <fo:block page-break-after="always">
                 
                 <!-- ZONE LOGOS -->
@@ -70,7 +71,7 @@
                 </fo:block-container>
                 
                 <!-- ZONE ADRESSE -->
-                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt">
+                <fo:block-container absolute-position="absolute" left="100mm" top="50mm" width="82mm" height="25.5mm" overflow="hidden" font-size="10pt" display-align="after">
                     <fo:block font-family="Lucida Console">
                         <fo:inline-container margin="0mm">
                             <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -89,9 +90,14 @@
                     <fo:block/>
                 </fo:block-container>
                 
+                <!-- ZONE DATAMATRIX MODE LIVRET -->
+                <fo:block-container absolute-position="absolute" right="182mm" top="237mm" width="16mm" height="16mm" overflow="hidden" font-size="10pt">
+                    <fo:block/>
+                </fo:block-container>        
+                
                 <!-- ZONE TITRE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="6mm" overflow="hidden" font-size="10pt">
-                    <fo:block line-height="10pt" font-weight="bold" text-align="center">#if($!{BddTitreRelance}) $!{BddTitreRelance}#else RAPPEL #end</fo:block>
+                <fo:block-container absolute-position="absolute" left="1mm" top="38mm" width="78mm" height="100%" overflow="hidden" font-size="10pt">
+                    <fo:block line-height="12pt" font-weight="bold" text-align="center">#if($!{BddTitreRelance}) $!{BddTitreRelance}#else RAPPEL #end</fo:block>
                 </fo:block-container>
 
                 <!-- ZONE CONTACT -->
@@ -107,7 +113,7 @@
                 </fo:block-container>
     
                 <!-- ZONE COURRIER -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="98mm" width="188mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
+                <fo:block-container absolute-position="absolute" left="9mm" top="98mm" width="179mm" height="100%" overflow="hidden" text-align="justify" font-size="9pt">
                             
                     <fo:block text-align="right" font-size="10pt">
                         Paris, le ${DateEdition}
@@ -116,19 +122,32 @@
                     <fo:block margin-top="5mm" font-weight="bold">
                         Objet&#160;: Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}
                     </fo:block>
-
-                    <fo:block font-weight="bold">
-                        Ref.&#160;${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    <fo:block>
+                        Unité enquêtée&#160;: ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee}&#160;: ${BddIdentifiantUniteEnquetee})
+                    </fo:block>
+                    
+                    <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
                     </fo:block>
                     
                     <fo:block margin-top="3mm">
                         #if($!{BddNom} and $!{BddCivilite})$!{BddCivilite} $!{BddNom}, #elseif($!{BddNom}) Madame ou Monsieur $!{BddNom},#else Madame, Monsieur,#end
                     </fo:block>
                     
+                    <!--
+                    <fo:block margin-top="3mm">
+                        Pour tenir compte de la crise sanitaire actuelle, l’Insee a redéfini ses priorités et adapté ses travaux. 
+                        Certaines enquêtes auprès des entreprises avaient ainsi été reportées et les délais de réponse allongés. 
+                        Nous sommes conscients des difficultés que la crise fait peser sur vous et de ses conséquences pendant les mois à venir. 
+                        Cependant, pour mieux évaluer son impact, il est particulièrement important de suivre l’activité économique en France ; 
+                        c’est pourquoi l’Insee va poursuivre la diffusion de certains indicateurs.
+                    </fo:block>
+                    -->
+                    
                     <fo:block margin-top="3mm">
                         Sauf erreur de ma part, mes services n’ont pas encore reçu votre réponse à l’<fo:inline font-weight="bold">enquête#if((${BddFrequence}!='annuelle') 
-                        and (${BddFrequence}!='pluriannuelle')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle')
-                        and (${BddFrequence}!='pluriannuelle')) ${BddPeriode}#end ${BddAnneeReference}</fo:inline>. 
+                        and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong}#if((${BddFrequence}!='annuelle')
+                        and (${BddFrequence}!='pluriannuelle') and (${BddPeriode}!='')) ${BddPeriode}#end ${BddAnneeReference}</fo:inline>. 
                         Si, toutefois, vous venez de procéder à cet envoi, je vous prie de ne pas tenir compte de ce rappel.
                     </fo:block>
                     <fo:block margin-top="3mm">
@@ -137,8 +156,25 @@
                         selon les modalités précisées au verso de cette lettre</fo:inline>. S’il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance 
                         dont les coordonnées figurent dans l’en-tête de cette lettre. Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoins.#else soit de répondre 
                         à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint. Notre service d'assistance se tient à votre disposition 
-                        pour répondre à vos questions en cas de besoins.#end
+                        pour répondre à vos questions en cas de besoin.#end
                     </fo:block>
+                    
+                    <!--
+                    <fo:block margin-top="3mm">
+                        Dans le cas contraire, je regrette qu’il ne vous ait pas été possible de nous répondre. 
+                        #if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) Nous avons plus que jamais besoin de votre participation pour assurer la qualité des indicateurs 
+                        conjoncturels et ainsi continuer à suivre les évolutions de l’activité économique à court terme.#else Nous avons plus que jamais besoin de votre participation pour assurer la qualité des statistiques sur 2019. 
+                        Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019, et ainsi estimer précisément l’impact économique de la crise vécue aujourd’hui.#end 
+                        Si vous êtes en mesure de répondre à cette enquête, nous vous en serions donc extrêmement reconnaissants.
+                    </fo:block>
+                    <fo:block margin-top="3mm">
+                        Dans ce cas, <fo:inline font-weight="bold">je vous prie#if(${BddQuestionnaire}==0) de remplir le questionnaire par internet selon les modalités précisées au verso de cette lettre</fo:inline>. 
+                        S'il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l'en-tête de cette lettre, 
+                        en privilégiant le contact par courriel. Ce dernier se tient également à votre disposition pour répondre à vos questions en cas de besoin.#else soit de répondre à cette enquête par internet selon 
+                        les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint. Notre service d'assistance se tient à votre disposition pour répondre à vos questions en cas de besoin.#end
+                    </fo:block>
+                    -->
+                    
                     <fo:block margin-top="3mm">
                         ${BddObjectifsLongs}
                     </fo:block>
@@ -167,25 +203,26 @@
                 </fo:block-container>
 
                 <!-- ZONE NOTE DE BAS DE PAGE -->
-                <fo:block-container absolute-position="absolute" left="1mm" top="250mm" width="188mm" height="100%" overflow="hidden">
+                <fo:block-container absolute-position="absolute" left="9mm" top="273mm" width="179mm" height="100%" overflow="hidden">
                     <fo:block/>
                 </fo:block-container>
                 
             </fo:block>
             
+            <!-- PAGE COURRIER VERSO -->
             <fo:block page-break-after="always">
                 
                 <fo:block/>
                 
                 <!-- ZONE NOTICE -->
-                <fo:block-container absolute-position="absolute" left="20mm" top="20mm" width="150mm" height="100%" overflow="hidden"
+                <fo:block-container absolute-position="absolute" left="20mm" top="5mm" width="150mm" height="100%" overflow="hidden"
                                     font-family="Liberation Sans" font-size="9pt" text-align="justify" border="black solid 0.5pt" padding="5mm">
                         
                     <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet&#160;?
                     </fo:block>
                     
-                    <fo:block margin-top="3.5mm">
+                    <fo:block margin-top="8mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique&#160;: <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt">&#160;</fo:inline>entreprises.stat-<fo:inline font-size="0.1pt">&#160;</fo:inline>publique.fr/</fo:inline>. 
@@ -206,7 +243,7 @@
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique «&#160;Mot de passe oublié&#160;» du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                     <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -220,14 +257,14 @@
                         vous pouvez contacter notre service d'assistance technique à l'aide du formulaire disponible dans la rubrique «&#160;Contacter l'assistance&#160;» sur le site de 
                         réponse aux enquêtes entreprises de la Statistique publique.
                     </fo:block>
-
+                    
                 </fo:block-container>
                 
                 <!-- ZONE CADRE LEGAL -->
                 <fo:block-container absolute-position="absolute" left="5mm" top="210mm" width="180mm" height="100%" overflow="hidden" font-size="7pt" text-align="justify" border="solid black 0.5pt" padding="1mm">
                     
                     <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -244,14 +281,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                     <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt">&#160;</fo:inline>°&#160;78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
                     
                 </fo:block-container>

--- a/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
+++ b/src/main/resources/xslt/post-processing/fo/accompanying-mails/relanceCOL.fo
@@ -33,7 +33,7 @@
         <!-- ZONE LIGNE TECHNIQUE -->
         <fo:static-content flow-name="xsl-region-before-courrier">
             <fo:block position="absolute" margin-top="5mm" margin-left="10mm" margin-right="10mm" margin-bottom="10mm" color="white">
-                <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
+                &lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;&lt;![CDATA[#]]&gt;DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
         </fo:static-content>
 

--- a/src/test/resources/params/in-to-out/business/form.fo
+++ b/src/test/resources/params/in-to-out/business/form.fo
@@ -174,8 +174,7 @@
                 <![CDATA[#]]><![CDATA[#]]><![CDATA[#]]>DS${NumeroDocument}col${data-IdEdition}
             </fo:block>
       </fo:static-content>
-      <fo:flow flow-name="xsl-region-body">
-         <fo:block page-break-after="always"><!-- ZONE LOGOS --><fo:block-container absolute-position="absolute"
+      <fo:flow flow-name="xsl-region-body"><!-- PAGE COURRIER RECTO --><fo:block page-break-after="always"><!-- ZONE LOGOS --><fo:block-container absolute-position="absolute"
                                 left="5mm"
                                 top="2mm"
                                 width="180mm"
@@ -197,7 +196,9 @@
                                 overflow="hidden">
                <fo:block/>
             </fo:block-container>
-            <!-- ZONE DATAMATRIX ALLIAGE --><fo:block-container absolute-position="absolute"
+            <!-- ZONE DATAMATRIX ALLIAGE -->
+                #if($!{InitAccuseReception}!='' and $!{InitAccuseReception}!='oui')
+                <fo:block-container absolute-position="absolute"
                                 left="100mm"
                                 top="37.8mm"
                                 width="11.88mm"
@@ -218,13 +219,16 @@
                   </fo:instream-foreign-object>
                </fo:block>
             </fo:block-container>
+                #end
+                
             <!-- ZONE ADRESSE --><fo:block-container absolute-position="absolute"
                                 left="100mm"
                                 top="50mm"
                                 width="82mm"
                                 height="25.5mm"
                                 overflow="hidden"
-                                font-size="10pt">
+                                font-size="10pt"
+                                display-align="after">
                <fo:block font-family="Lucida Console">
                   <fo:inline-container margin="0mm">
                      <fo:block line-height="10pt">${BddAdressePosteeL1}</fo:block>
@@ -246,14 +250,23 @@
                                 font-size="10pt">
                <fo:block/>
             </fo:block-container>
+            <!-- ZONE DATAMATRIX MODE LIVRET --><fo:block-container absolute-position="absolute"
+                                right="182mm"
+                                top="237mm"
+                                width="16mm"
+                                height="16mm"
+                                overflow="hidden"
+                                font-size="10pt">
+               <fo:block/>
+            </fo:block-container>
             <!-- ZONE TITRE COURRIER --><fo:block-container absolute-position="absolute"
                                 left="1mm"
                                 top="38mm"
                                 width="78mm"
-                                height="6mm"
+                                height="100%"
                                 overflow="hidden"
                                 font-size="10pt">
-               <fo:block line-height="10pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
+               <fo:block line-height="12pt" font-weight="bold" text-align="center">CONSTAT DE NON-RÉPONSE #if($!{InitAccuseReception}=='oui')avec accusé de réception#end</fo:block>
             </fo:block-container>
             <!-- ZONE CONTACT --><fo:block-container absolute-position="absolute"
                                 left="1mm"
@@ -274,9 +287,9 @@
                </fo:block>
             </fo:block-container>
             <!-- ZONE COURRIER --><fo:block-container absolute-position="absolute"
-                                left="1mm"
+                                left="9mm"
                                 top="98mm"
-                                width="188mm"
+                                width="179mm"
                                 height="100%"
                                 overflow="hidden"
                                 text-align="justify"
@@ -287,17 +300,20 @@
                <fo:block margin-top="5mm" font-weight="bold">
                         Objet : Enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference}
                     </fo:block>
-               <fo:block font-weight="bold">
-                        Ref. ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee} : ${BddIdentifiantUniteEnquetee})
+               <fo:block>
+                        Unité enquêtée : ${BddRaisonSociale} (Votre ${BddLabelUniteEnquetee} : ${BddIdentifiantUniteEnquetee})
                     </fo:block>
-               <fo:block margin-top="5mm" font-weight="bold">
+               <fo:block margin-top="3mm">
+                        Identifiant de connexion : <fo:inline font-weight="bold">${BddIdentifiantContact}</fo:inline> (voir modalités au verso de ce courrier)
+                    </fo:block>
+               <fo:block margin-top="8mm" font-weight="bold">
                         Madame la Directrice, Monsieur le Directeur,
                     </fo:block>
                <fo:block margin-top="5mm">
                         Ma lettre de mise en demeure du ${BddDateEnvoiMiseEnDemeure} étant restée sans suite, je suis dans l’obligation aujourd’hui d’établir à votre encontre le constat suivant :
                     </fo:block>
                <fo:block margin-top="3mm">
-                        - de défaut de réponse à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference} ;
+                        - de défaut de réponse à l'<fo:inline font-weight="bold">enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle') and (${BddFrequence}!='')) ${BddFrequence}#end ${BddLibelleLong} ${BddAnneeReference} </fo:inline>;
                     </fo:block>
                <fo:block>
                         - et d’absence de justification à ce défaut de réponse.
@@ -310,6 +326,13 @@
                         soit de répondre à cette enquête par internet selon les modalités précisées au verso de cette lettre soit de compléter le questionnaire joint,#end dans un délai de 15 jours. 
                         A l’expiration de ce délai, votre dossier sera soumis pour examen au <fo:inline font-weight="bold">Comité du contentieux</fo:inline> des enquêtes statistiques obligatoires 
                         du Conseil national de l’information statistique (Cnis), conformément à la loi*.
+                        Nous avons plus que jamais besoin de votre participation pour assurer la qualité des statistiques sur 2019. 
+                        Pour tenir compte de la crise sanitaire actuelle, l’Insee a redéfini ses priorités et adapté ses travaux. 
+                        Les délais de réponse à certaines enquêtes auprès des entreprises ont ainsi été allongés de plusieurs mois. 
+                        Nous sommes conscients des difficultés que la crise fait peser sur vous et de ses conséquences pendant les mois à venir. 
+                        Cependant, pour mieux évaluer son impact, il est particulièrement important de suivre l’activité économique en France. 
+                        Ceci permettra de disposer d’un point de référence solide pour calculer des évolutions correctes entre 2020 et 2019 dans chaque secteur, 
+                        et ainsi estimer précisément l’impact économique de la crise vécue aujourd’hui.
                     </fo:block>
                <fo:block margin-top="3mm">
                         S’il vous est matériellement impossible de répondre en ligne, merci de bien vouloir prendre contact avec notre service d'assistance dont les coordonnées figurent dans l’en-tête de cette lettre. 
@@ -326,9 +349,9 @@
                     </fo:block>
             </fo:block-container>
             <!-- ZONE NOTE DE BAS DE PAGE --><fo:block-container absolute-position="absolute"
-                                left="1mm"
-                                top="250mm"
-                                width="188mm"
+                                left="9mm"
+                                top="273mm"
+                                width="179mm"
                                 height="100%"
                                 overflow="hidden">
                <fo:block>
@@ -336,11 +359,11 @@
                     </fo:block>
             </fo:block-container>
          </fo:block>
-         <fo:block page-break-after="always">
+         <!-- PAGE COURRIER VERSO --><fo:block page-break-after="always">
             <fo:block/>
             <!-- ZONE NOTICE --><fo:block-container absolute-position="absolute"
                                 left="20mm"
-                                top="20mm"
+                                top="5mm"
                                 width="150mm"
                                 height="100%"
                                 overflow="hidden"
@@ -352,7 +375,7 @@
                <fo:block text-align="center" font-weight="bold" font-size="10pt">
                         Comment répondre à l'enquête par internet ?
                     </fo:block>
-               <fo:block margin-top="3.5mm">
+               <fo:block margin-top="5mm">
                         Pour répondre à l'enquête statistique#if((${BddFrequence}!='annuelle') and (${BddFrequence}!='pluriannuelle'))
                         ${BddFrequence}#end ${BddLibelleLong}, il convient de vous connecter sur le site sécurisé de réponse aux enquêtes entreprises de la Statistique 
                         publique : <fo:inline text-decoration="underline">http://<fo:inline font-size="0.1pt"> </fo:inline>entreprises.stat-<fo:inline font-size="0.1pt"> </fo:inline>publique.fr/</fo:inline>. 
@@ -373,7 +396,7 @@
                     </fo:block>
                <fo:block margin-top="3.5mm">
                         En cas de perte ou d'oubli de votre mot de passe, vous pouvez demander son renouvellement en ligne sur le site de réponse aux enquêtes entreprises 
-                        de la Statistique publique (rubrique « Mot de passe oublié » du site <fo:inline text-decoration="underline">http://entreprises.stat-publique.fr/ </fo:inline>).
+                        de la Statistique publique (rubrique « Mot de passe oublié » du site <fo:inline font-weight="bold" text-decoration="underline">http://entreprises.stat-publique.fr/</fo:inline> ).
                     </fo:block>
                <fo:block margin-top="3.5mm">
                         En cas de trop nombreuses tentatives d’authentification, votre compte peut être momentanément  bloqué, pour des raisons de sécurité. Dans ce cas, avant de 
@@ -399,7 +422,7 @@
                                 border="solid black 0.5pt"
                                 padding="1mm">
                <fo:block>
-                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête <fo:inline font-weight="bold">est reconnue d'intérêt général et de qualité statistique</fo:inline>, 
+                        Vu l'avis favorable du Conseil national de l'information statistique, cette enquête est <fo:inline font-weight="bold">reconnue d'intérêt général et de qualité statistique</fo:inline>, 
                         en application de la loi n<fo:inline font-size="0.1pt"> </fo:inline>° 51-711 du 7 juin 1951 sur l'obligation, la coordination et le secret en matière de statistiques. 
                         Elle a obtenu le visa n°${BddNumeroVisa} du ${BddMinistereTutelle}, valable pour l'année ${BddAnneeCollecte}.
                     </fo:block>
@@ -416,14 +439,15 @@
                         ou à des travaux de recherche scientifique ou historique.
                     </fo:block>
                <fo:block>
-                        Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi n<fo:inline font-size="0.1pt"> </fo:inline>° 78-17 du 6 janvier 1978 relative à l'informatique, 
+                        #if(${BddDonneesPerso}=='oui')Le règlement général 2016/679 du 27 avril 2016 sur la protection des données (RGPD) ainsi que la loi 
+                        n<fo:inline font-size="0.1pt"> </fo:inline>° 78-17 du 6 janvier 1978 relative à l'informatique, 
                         aux fichiers et aux libertés s'appliquent à la présente enquête. Pour les données à caractère personnel, un droit d'accès, de rectification, 
                         d’effacement ou de limitation de traitement peut être exercé pendant la période de conservation des données d’identification. 
                         Ces droits peuvent être exercés auprès de ${AdresseRetourL1} que vous pouvez contacter à l’adresse ${BddServiceCollecteurAdresseMessagerie}. 
                         Pour toute question relative au traitement de vos données, vous pouvez contacter le délégué à la protection des données des ministères économique 
                         et financier à l’adresse <fo:inline text-decoration="underline">le-delegue-a-la-protection-des-donnees-personnelles@finances.gouv.fr</fo:inline> 
                         ou son correspondant à l’Insee : <fo:inline text-decoration="underline">contact-rgpd@insee.fr</fo:inline>. 
-                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.
+                        Vous pouvez si vous l’estimez nécessaire adresser une réclamation à la Cnil.#end
                     </fo:block>
             </fo:block-container>
          </fo:block>


### PR DESCRIPTION
Pour les prochains envois, il faudrait mettre à jour les modèles de courriers simples "fusionnés" avec les questionnaires.
Cela concerne l'adresse postale. La Poste demande pour une meilleure prise en compte des courriers par leurs automates que les adresses soient "plaquées" vers le bas de la zone adresse.
Les modèles de courriers simples utilisés ici n'ont pas cette propriété. Et donc les adresses sont "plaquées" vers le haut (tout près du Barcode).
On risque donc d'avoir un retour de la Poste si on continue à plaquer les adresses vers le haut…
