### PR TITLE
Adding support of filtered loops in pogues-xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
-	<version>2.2.2</version>
+	<version>2.2.2-hotfix-ddi-filtering_loop</version>
 	<packaging>jar</packaging>
 
 	<name>Eno – Questionnaire generator</name>

--- a/src/main/resources/xslt/pre-processing/pogues-xml/goto-2-if-then-else.xsl
+++ b/src/main/resources/xslt/pre-processing/pogues-xml/goto-2-if-then-else.xsl
@@ -60,7 +60,7 @@
                 <xsl:if test="local-name(.)='Child' or local-name(.)='Questionnaire' or local-name()='IfThenElse' or local-name()='Loop'">
                     <poguesGoto:idElement id="{./@id}" position="{position()}">
                         <poguesGoto:childrenId>
-                            <xsl:for-each select="pogues:Child | pogues:IfThenElse | pogues:Loop | pogues:IfTrue/pogues:Child | pogues:IfTrue/pogues:IfThenElse">
+                            <xsl:for-each select="pogues:Child | pogues:IfThenElse | pogues:Loop | pogues:IfTrue/pogues:Child | pogues:IfTrue/pogues:Loop | pogues:IfTrue/pogues:IfThenElse">
                                 <poguesGoto:childId>
                                     <xsl:value-of select="./@id"/>
                                 </poguesGoto:childId>


### PR DESCRIPTION
When creating child position list, the case pogues:IfTrue/pogues:Loop was forgotten in the for-each. Just needed to add it so that an IfTrue would correctly point to the Loop

