### PR TITLE
No slf4j impl in Eno library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/" # Location of package manifests
+    target-branch: "dev-java-tests"
     schedule:
       interval: "daily"

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<version>${log4j-slf4j.version}</version>
-			<scope>compile</scope>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- Jaxb -->
@@ -264,6 +264,7 @@
 									<value>INFO</value>
 								</property>
 							</systemProperties>
+							<classpathScope>test</classpathScope>
 
 						</configuration>
 					</execution>


### PR DESCRIPTION
Eno-core is a library used by other applications and shouldn't depend over an slf4j implementation (every app has to provide its own slf4j impl). The propose of this PR is to remove the dependency over log4j-slf4j-impl artifact in the library eno-core. The dependency over log4j-slf4j-impl is not transitive any more and is only internally for tests and process classes phase (exec-maven-plugin)