### PR TITLE
Hotfix saxon 9.9.1-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
-	<version>2.2.5-hotfix-saxon_9_9</version>
+	<version>2.2.6</version>
 	<packaging>jar</packaging>
 
 	<name>Eno – Questionnaire generator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
-	<version>2.2.5</version>
+	<version>2.2.5-hotfix-saxon_9_9</version>
 	<packaging>jar</packaging>
 
 	<name>Eno – Questionnaire generator</name>
@@ -48,7 +48,7 @@
 	<properties>
 		<guice.version>4.1.0</guice.version>
 		<commons-io.version>2.5</commons-io.version>
-		<saxon.version>9.7.0-8</saxon.version>
+		<saxon.version>9.9.1-8</saxon.version>
 		<fop.version>2.2</fop.version>
 		<xalan.version>2.7.1</xalan.version>
 		<slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
Bumping the Saxon version to 9.9.1-8 : needed since the big dependencies upgrade (w/ Saxon 10.5) is not yet ready to deploy.