### PR TITLE
Dev md2xhtml links mailto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
 
-	<version>2.2.9</version>
+	<version>2.2.9-dev-md2xhtml-links_mailto</version>
 
 	<packaging>jar</packaging>
 

--- a/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
+++ b/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
@@ -255,30 +255,46 @@
             - regexp(3) is the sub-sequence ([^\)]+ if regexp(2) has matched, for the text associated to the link,
             - regexp(4) is the sub-sequence ([^&quot;]+) if regexp(2) has matched, for the url associated to the link.
         -->
-        <xsl:analyze-string select="$expression" regex="(xhtml:br)|(\[([^\]]+)\]\(\. &quot;([^&quot;]+)&quot;\)){{1}}">
-             <xsl:matching-substring>
-                 <xsl:choose>
-                     <!-- Breakline case -->
-                     <xsl:when test="regex-group(1)">
-                         <xsl:element name="xhtml:br"/>
-                     </xsl:when>
-                     <!-- Link case -->
-                     <xsl:when test="regex-group(2)">
-                         <xsl:element name="xhtml:a">
-                             <xsl:attribute name="href" select="concat('. &quot;',regex-group(4),'&quot;')"/>
-                             <xsl:copy-of select="regex-group(3)"/>
-                         </xsl:element>
-                     </xsl:when>
-                 </xsl:choose>
-                 <!--<xsl:call-template name="parse-elements">
+        <xsl:template name="parse-elements">
+            <xsl:param name="expression"/>
+            <xsl:param name="first" select="true()"/>
+            <!--
+            Defining a regexp where :
+            - regexp(1) is the sequence \n if encountered, for breaklines,
+            - regexp(2) is the sequence [.*](.*) if encountered, for links.
+            - regexp(3) is the sub-sequence ([^\)]+ if regexp(2) has matched, for the text associated to the link,
+            - regexp(4) is the sub-sequence ([^&quot;]+) if regexp(2) has matched, for the url associated to the link.
+        -->
+            <xsl:analyze-string select="$expression" regex="(xhtml:br)|(\[([^\]]+)\]\(\. &quot;([^&quot;]+)&quot;\)){{1}}|(\[([^\]]+)\]\(([^\)]+)\))">
+                <xsl:matching-substring>
+                    <xsl:choose>
+                        <!-- Breakline case -->
+                        <xsl:when test="regex-group(1)">
+                            <xsl:element name="xhtml:br"/>
+                        </xsl:when>
+                        <!-- Link case -->
+                        <xsl:when test="regex-group(2)">
+                            <xsl:element name="xhtml:a">
+                                <xsl:attribute name="href" select="concat('. &quot;',regex-group(4),'&quot;')"/>
+                                <xsl:copy-of select="regex-group(3)"/>
+                            </xsl:element>
+                        </xsl:when>
+                        <xsl:when test="regex-group(5)">
+                            <xsl:element name="xhtml:a">
+                                <xsl:attribute name="href" select="regex-group(7)"/>
+                                <xsl:copy-of select="regex-group(6)"/>
+                            </xsl:element>
+                        </xsl:when>
+                    </xsl:choose>
+                    <!--<xsl:call-template name="parse-elements">
                      <xsl:with-param name="expression" select="regex-group(4)"/>
                      <xsl:with-param name="first" select="$first"/>
                  </xsl:call-template>-->
-             </xsl:matching-substring>
-             <xsl:non-matching-substring>
-                 <xsl:copy-of select="."/>
-             </xsl:non-matching-substring>
-         </xsl:analyze-string>
-    </xsl:template>
+                </xsl:matching-substring>
+                <xsl:non-matching-substring>
+                    <xsl:copy-of select="."/>
+                </xsl:non-matching-substring>
+            </xsl:analyze-string>
+        </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
+++ b/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
@@ -58,7 +58,7 @@
     </xsl:template>
 
     <!-- Parsing is done on the text nodes for the default mode only -->
-    <xsl:template match="text()[matches(normalize-space(replace(.,'&amp;#xd;', 'xhtml:br')),'[*]|xhtml:br|\[.*\]\(\. &quot;.*&quot;\)')]">
+    <xsl:template match="text()[matches(normalize-space(replace(.,'&amp;#xd;', 'xhtml:br')),'[*]|xhtml:br|\[.*\]\(\. &quot;.*&quot;\)|(\[([^\]]+)\]\(([^\)]+)\))')]">
         <xhtml:p>
             <xsl:call-template name="parse-tags">
               <xsl:with-param name="expression" select="normalize-space(replace(.,'&amp;#xd;', 'xhtml:br'))"/>

--- a/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
+++ b/src/main/resources/xslt/pre-processing/ddi/md2xhtml.xsl
@@ -245,56 +245,47 @@
         </xsl:analyze-string>
     </xsl:template>
 
+
     <xsl:template name="parse-elements">
         <xsl:param name="expression"/>
         <xsl:param name="first" select="true()"/>
         <!--
             Defining a regexp where :
             - regexp(1) is the sequence \n if encountered, for breaklines,
-            - regexp(2) is the sequence [.*](\. ".*") if encountered, for links.
-            - regexp(3) is the sub-sequence ([^\)]+ if regexp(2) has matched, for the text associated to the link,
-            - regexp(4) is the sub-sequence ([^&quot;]+) if regexp(2) has matched, for the url associated to the link.
-        -->
-        <xsl:template name="parse-elements">
-            <xsl:param name="expression"/>
-            <xsl:param name="first" select="true()"/>
-            <!--
-            Defining a regexp where :
-            - regexp(1) is the sequence \n if encountered, for breaklines,
             - regexp(2) is the sequence [.*](.*) if encountered, for links.
             - regexp(3) is the sub-sequence ([^\)]+ if regexp(2) has matched, for the text associated to the link,
             - regexp(4) is the sub-sequence ([^&quot;]+) if regexp(2) has matched, for the url associated to the link.
         -->
-            <xsl:analyze-string select="$expression" regex="(xhtml:br)|(\[([^\]]+)\]\(\. &quot;([^&quot;]+)&quot;\)){{1}}|(\[([^\]]+)\]\(([^\)]+)\))">
-                <xsl:matching-substring>
-                    <xsl:choose>
-                        <!-- Breakline case -->
-                        <xsl:when test="regex-group(1)">
-                            <xsl:element name="xhtml:br"/>
-                        </xsl:when>
-                        <!-- Link case -->
-                        <xsl:when test="regex-group(2)">
-                            <xsl:element name="xhtml:a">
-                                <xsl:attribute name="href" select="concat('. &quot;',regex-group(4),'&quot;')"/>
-                                <xsl:copy-of select="regex-group(3)"/>
-                            </xsl:element>
-                        </xsl:when>
-                        <xsl:when test="regex-group(5)">
-                            <xsl:element name="xhtml:a">
-                                <xsl:attribute name="href" select="regex-group(7)"/>
-                                <xsl:copy-of select="regex-group(6)"/>
-                            </xsl:element>
-                        </xsl:when>
-                    </xsl:choose>
-                    <!--<xsl:call-template name="parse-elements">
-                     <xsl:with-param name="expression" select="regex-group(4)"/>
-                     <xsl:with-param name="first" select="$first"/>
-                 </xsl:call-template>-->
-                </xsl:matching-substring>
-                <xsl:non-matching-substring>
-                    <xsl:copy-of select="."/>
-                </xsl:non-matching-substring>
-            </xsl:analyze-string>
-        </xsl:template>
+        <xsl:analyze-string select="$expression" regex="(xhtml:br)|(\[([^\]]+)\]\(\. &quot;([^&quot;]+)&quot;\)){{1}}|(\[([^\]]+)\]\(([^\)]+)\))">
+            <xsl:matching-substring>
+                <xsl:choose>
+                    <!-- Breakline case -->
+                    <xsl:when test="regex-group(1)">
+                        <xsl:element name="xhtml:br"/>
+                    </xsl:when>
+                    <!-- Link case -->
+                    <xsl:when test="regex-group(2)">
+                        <xsl:element name="xhtml:a">
+                            <xsl:attribute name="href" select="concat('. &quot;',regex-group(4),'&quot;')"/>
+                            <xsl:copy-of select="regex-group(3)"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test="regex-group(5)">
+                        <xsl:element name="xhtml:a">
+                            <xsl:attribute name="href" select="regex-group(7)"/>
+                            <xsl:copy-of select="regex-group(6)"/>
+                        </xsl:element>
+                    </xsl:when>
+                </xsl:choose>
+                <!--<xsl:call-template name="parse-elements">
+                    <xsl:with-param name="expression" select="regex-group(4)"/>
+                    <xsl:with-param name="first" select="$first"/>
+                    </xsl:call-template>-->
+            </xsl:matching-substring>
+            <xsl:non-matching-substring>
+                <xsl:copy-of select="."/>
+            </xsl:non-matching-substring>
+        </xsl:analyze-string>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/resources/xslt/pre-processing/ddi/tweak-xhtml-for-ddi.xsl
+++ b/src/main/resources/xslt/pre-processing/ddi/tweak-xhtml-for-ddi.xsl
@@ -12,10 +12,10 @@
         All other elements not matching this syntax is simply copied untouched.               
     -->
     
-    
+    <!--  Using xsl:key DOES NOT SEEM TO WORK, as it recognizes every xhtml:a/href that I input...Thus I'd rather use "matches" in the xpath condition  -->
     <!-- Defining what is an xhtml:a 'footnote'. -->
-   <!-- <xsl:key name="is-footnote" match="xhtml:a" use="if(@href) then(matches(@href,'^\.\s\\&quot;.+\\&quot;')) else(false())"/>-->
-    <xsl:key name="is-footnote" match="xhtml:a" use="if(@href) then(matches(@href,'^\.\s&quot;.+&quot;')) else(false())"/>
+    <!-- <xsl:key name="is-footnote" match="xhtml:a" use="if(@href) then(matches(@href,'^\.\s\\&quot;.+\\&quot;')) else(false())"/>-->
+    <!--    <xsl:key name="is-footnote" match="xhtml:a" use="if(@href) then(matches(@href,'^\.\s&quot;.+&quot;')) else(false())"/>-->
     
     <!-- Standard identity pattern. -->
     <xsl:template match="*">
@@ -24,27 +24,27 @@
             <xsl:apply-templates select="node()"/>
         </xsl:copy>
     </xsl:template>
-
+    
     <xsl:template match="text()">
         <xsl:value-of select="."/>
     </xsl:template>
-
+    
     <!-- Keep comment and pi as well. -->
     <xsl:template match="comment() | processing-instruction()">
         <xsl:copy-of select="."/>
     </xsl:template>
-
+    
     <!-- xhtml:a 'footnote' will have a generic href and its content outputted just before. -->
-    <xsl:template match="xhtml:a[key('is-footnote',true())]">
+    <xsl:template match="xhtml:a[matches(@href,'^\.\s&quot;.+&quot;')]">
         <!-- Output its content -->
         <xsl:value-of select="."/>
         <xsl:element name="xhtml:a">
             <!-- Building an href=#ftn{index}, index is based on the number of xhtml:a footnote -->
             <xsl:attribute name="href"
-                select="concat('#ftn', 1 + count(preceding::xhtml:a[key('is-footnote',true())]))"/>
+                select="concat('#ftn', 1 + count(preceding::xhtml:a[matches(@href,'^\.\s&quot;.+&quot;')]))"/>
         </xsl:element>
     </xsl:template>
-
+    
     <!-- For each xhtml:a 'footnote', an Instruction needs to be generated. -->
     <xsl:template match="d:InterviewerInstructionScheme">
         <!-- First all the Scheme is processed. -->
@@ -52,7 +52,7 @@
             <xsl:copy-of select="@*"/>
             <xsl:apply-templates select="node()"/>
             <!-- Then an instruction is generated for each xhmtl:a "footnote". -->
-            <xsl:for-each select="//xhtml:a[key('is-footnote',true())]">
+            <xsl:for-each select="//xhtml:a[matches(@href,'^\.\s&quot;.+&quot;')]">
                 <!-- Calculating the variables needed. -->
                 <!-- For r:Agency, r:Version and xml:lang, the closest ancestor whith equivalent is used -->
                 <xsl:variable name="agency" select="ancestor-or-self::*[r:Agency][1]/r:Agency"/>
@@ -60,7 +60,7 @@
                 <xsl:variable name="lang" select="ancestor-or-self::*[@xml:lang][1]/@xml:lang"/>
                 <!-- The id is build with the pattern ftn{index}, index is based on the number of xhtml:a 'footnote'. -->
                 <xsl:variable name="id"
-                    select="concat('ftn', 1 + count(preceding::xhtml:a[key('is-footnote',true())]))"/>
+                    select="concat('ftn', 1 + count(preceding::xhtml:a[matches(@href,'^\.\s&quot;.+&quot;')]))"/>
                 <d:Instruction>
                     <r:Agency>
                         <xsl:value-of select="$agency"/>
@@ -94,5 +94,5 @@
             </xsl:for-each>
         </xsl:copy>
     </xsl:template>
-
+    
 </xsl:stylesheet>


### PR DESCRIPTION
 Adding support of links for markdown to xhtml :

- ddi pre-processing md2xhtml : adding support of markdown links (only specific cases were supported so far)
- ddi pre-processing tweak-xhtml-for-ddi : not using xsl:key (does not work) but matches in conditions for footnote pattern recognition