### PR TITLE
In ddi2lunatic-xml-fixed, adding the recursive-replace step for tooltips

### DIFF
--- a/src/main/resources/xslt/transformations/ddi2lunatic-xml/ddi2lunatic-xml-fixed.xsl
+++ b/src/main/resources/xslt/transformations/ddi2lunatic-xml/ddi2lunatic-xml-fixed.xsl
@@ -294,7 +294,7 @@
         <xsl:variable name="listChar" select="$properties//JSEncoding/char"/>
         <xsl:analyze-string select="$label" regex="(\[([^\]]+)\])\(\. &quot;([^&quot;]+)&quot;\)">
             <xsl:matching-substring>
-                <xsl:value-of select="concat(regex-group(1),'(. ''',regex-group(3),''')')"/>
+                <xsl:value-of select="concat(regex-group(1),'(. ''',enolunatic:recursive-replace(regex-group(3),$listChar),''')')"/>
             </xsl:matching-substring>
             <xsl:non-matching-substring>
                 <!-- replace special JS character by their encoded value-->


### PR DESCRIPTION
In ddi2lunatic-xml-fixed, adding the recursive-replace step for content of tooltips that allows to replace the ' symbol (U+0027) by ’ (U+2019) -> needed for correct interpretation by VTL/orchestrators