### PR TITLE
Dev sprintlunatic

### DIFF
--- a/src/main/resources/xslt/outputs/lunatic-xml/models.xsl
+++ b/src/main/resources/xslt/outputs/lunatic-xml/models.xsl
@@ -1009,7 +1009,7 @@
 		<xsl:param name="source-context" as="item()" tunnel="yes"/>
 		<xsl:param name="languages" tunnel="yes"/>
 
-		<xsl:if test="$control">
+		<xsl:if test="$controlParam">
 			<xsl:variable name="id" select="enolunatic:get-name($source-context)"/>
 			<xsl:variable name="control" select="enolunatic:get-constraint($source-context)"/>
 			<xsl:variable name="errorMessage" select="enolunatic:get-vtl-label($source-context, $languages[1])"/>

--- a/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
+++ b/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
@@ -24,11 +24,12 @@
     <!-- This variable retrieves all the dependencies (variables) used in filters
     Useful later to check if calculated variables are used in filters-->
     <xsl:variable name="variablesInFilter">
-        <xsl:for-each select="$root//h:conditionFilter/h:bindingDependencies">
+        <xsl:for-each select="$root//h:conditionFilter/h:dependencies">
             <xsl:value-of select="concat(.,' ')"/>
         </xsl:for-each>
-        <xsl:for-each select="$root//h:components/h:loopDependencies">
-            <xsl:value-of select="concat(.,' ')"/>
+        <xsl:for-each select="$root//h:components/h:lines">
+            <xsl:value-of select="concat(@min,' ')"/>
+            <xsl:value-of select="concat(@max,' ')"/>
         </xsl:for-each>
     </xsl:variable>
 

--- a/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
+++ b/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
@@ -21,6 +21,19 @@
     
     <xsl:variable name="root" select="root(.)"/>
     
+    
+    <!-- This variable retrieves all the dependencies (variables) used somewhere in components
+    Useful later to check if calculated variables are used somewhere in the questionnaire-->
+    <xsl:variable name="variablesUsed">
+        <xsl:for-each select="$root//h:components//h:dependencies">
+            <xsl:value-of select="concat(.,' ')"/>
+        </xsl:for-each>
+        <xsl:for-each select="$root//h:components/h:lines">
+            <xsl:value-of select="concat(@min,' ')"/>
+            <xsl:value-of select="concat(@max,' ')"/>
+        </xsl:for-each>
+    </xsl:variable>
+    
     <!-- This variable retrieves all the dependencies (variables) used in filters
     Useful later to check if calculated variables are used in filters-->
     <xsl:variable name="variablesInFilter">
@@ -358,10 +371,12 @@
     <xsl:template match="h:variables[@variableType='CALCULATED']">
         <xsl:variable name="varName" select="h:name"/>
         <xsl:variable name="searchTerm" select="concat('[\W]', $varName, '[\W]')"/>
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-            <inFilter><xsl:value-of select="enolunatic:is-used-in-filter($varName,'',$variablesInFilter,$searchTerm)"/></inFilter>
-        </xsl:copy>
+        <xsl:if test="enolunatic:is-var-used-in-list-of-dependencies($varName,'',$variablesUsed,$searchTerm)='true' or contains($varName,'FILTER_RESULT')">
+            <xsl:copy>
+                <xsl:apply-templates select="@*|node()"/>
+                <inFilter><xsl:value-of select="enolunatic:is-var-used-in-list-of-dependencies($varName,'',$variablesInFilter,$searchTerm)"/></inFilter>
+            </xsl:copy>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="enolunatic:addVariableCollected">
@@ -447,8 +462,49 @@
         <bindingDependencies><xsl:value-of select="$name"/></bindingDependencies>
     </xsl:template>
     
-    <!-- This function checks if the variable given in parameter is used as part of a filter (by itself or by another calculated variable using it) -->
-    <xsl:function name="enolunatic:is-used-in-filter">
+    
+    <!-- This function checks if the variable given in parameter is used as part of a given list of dependencies (by itself or by another calculated variable using it) -->
+    <xsl:function name="enolunatic:is-var-used-in-list-of-dependencies">
+        <xsl:param name="varName"/>
+        <xsl:param name="varList"/>
+        <xsl:param name="dependenciesToSearch"/>
+        <xsl:param name="termToSearch"/>
+        <xsl:choose>
+            <xsl:when test="matches($dependenciesToSearch, $termToSearch)">
+                <xsl:value-of select="'true'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="callingVars">
+                    <xsl:value-of select="enolunatic:get-vars-using-var($varName)"/>
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="$callingVars != '' or $varList != ''">
+                        <xsl:variable name="listToFeed" select="normalize-space(concat($varList,' ',$callingVars))"/>
+                        <xsl:variable name="newVar">
+                            <xsl:choose>
+                                <xsl:when test="contains($listToFeed,' ')">
+                                    <xsl:value-of select="substring-before($listToFeed,' ')"/> 
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$listToFeed"/> 
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:variable>
+                        <xsl:variable name="newSearch" select="concat('[\W]', $newVar, '[\W]')"/>
+                        <xsl:value-of select="enolunatic:is-var-used-in-list-of-dependencies($newVar,normalize-space(replace($listToFeed,$newVar,'')),$dependenciesToSearch,$newSearch)"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="'false'"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    
+    
+<!--    <!-\- This function checks if the variable given in parameter is used as part of a filter (by itself or by another calculated variable using it) -\->
+    <xsl:function name="enolunatic:is-var-used-in-filter">
         <xsl:param name="varName"/>
         <xsl:param name="varList"/>
         <xsl:param name="toSearchFilter"/>
@@ -475,7 +531,7 @@
                             </xsl:choose>
                         </xsl:variable>
                         <xsl:variable name="newSearch" select="concat('[\W]', $newVar, '[\W]')"/>
-                        <xsl:value-of select="enolunatic:is-used-in-filter($newVar,normalize-space(replace($listToFeed,$newVar,'')),$toSearchFilter,$newSearch)"/>
+                        <xsl:value-of select="enolunatic:is-var-used-in-filter($newVar,normalize-space(replace($listToFeed,$newVar,'')),$toSearchFilter,$newSearch)"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:value-of select="'false'"/>
@@ -483,7 +539,7 @@
                 </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:function>
+    </xsl:function>-->
     
     <!-- This function returns for the (calculated) variable given in parameter all the names of other calculated variables using it -->
     <xsl:function name="enolunatic:get-vars-using-var">

--- a/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
+++ b/src/main/resources/xslt/post-processing/lunatic-xml/sort-components.xsl
@@ -20,6 +20,17 @@
     </xd:doc>
     
     <xsl:variable name="root" select="root(.)"/>
+    
+    <!-- This variable retrieves all the dependencies (variables) used in filters
+    Useful later to check if calculated variables are used in filters-->
+    <xsl:variable name="variablesInFilter">
+        <xsl:for-each select="$root//h:conditionFilter/h:bindingDependencies">
+            <xsl:value-of select="concat(.,' ')"/>
+        </xsl:for-each>
+        <xsl:for-each select="$root//h:components/h:loopDependencies">
+            <xsl:value-of select="concat(.,' ')"/>
+        </xsl:for-each>
+    </xsl:variable>
 
     <xsl:template match="@*|node()">
         <xsl:copy>
@@ -342,6 +353,15 @@
             </xsl:call-template>
         </xsl:copy>
     </xsl:template>
+    
+    <xsl:template match="h:variables[@variableType='CALCULATED']">
+        <xsl:variable name="varName" select="h:name"/>
+        <xsl:variable name="searchTerm" select="concat('[\W]', $varName, '[\W]')"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+            <inFilter><xsl:value-of select="enolunatic:is-used-in-filter($varName,'',$variablesInFilter,$searchTerm)"/></inFilter>
+        </xsl:copy>
+    </xsl:template>
 
     <xsl:template name="enolunatic:addVariableCollected">
         <xsl:param name="responseName"/>
@@ -425,4 +445,54 @@
         <xsl:param name="name"/>
         <bindingDependencies><xsl:value-of select="$name"/></bindingDependencies>
     </xsl:template>
+    
+    <!-- This function checks if the variable given in parameter is used as part of a filter (by itself or by another calculated variable using it) -->
+    <xsl:function name="enolunatic:is-used-in-filter">
+        <xsl:param name="varName"/>
+        <xsl:param name="varList"/>
+        <xsl:param name="toSearchFilter"/>
+        <xsl:param name="toSearch"/>
+        <xsl:choose>
+            <xsl:when test="matches($toSearchFilter, $toSearch)">
+                <xsl:value-of select="'true'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="callingVars">
+                    <xsl:value-of select="enolunatic:get-vars-using-var($varName)"/>
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="$callingVars != '' or $varList != ''">
+                        <xsl:variable name="listToFeed" select="normalize-space(concat($varList,' ',$callingVars))"/>
+                        <xsl:variable name="newVar">
+                            <xsl:choose>
+                                <xsl:when test="contains($listToFeed,' ')">
+                                    <xsl:value-of select="substring-before($listToFeed,' ')"/> 
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$listToFeed"/> 
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:variable>
+                        <xsl:variable name="newSearch" select="concat('[\W]', $newVar, '[\W]')"/>
+                        <xsl:value-of select="enolunatic:is-used-in-filter($newVar,normalize-space(replace($listToFeed,$newVar,'')),$toSearchFilter,$newSearch)"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="'false'"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    <!-- This function returns for the (calculated) variable given in parameter all the names of other calculated variables using it -->
+    <xsl:function name="enolunatic:get-vars-using-var">
+        <xsl:param name="varName"/>
+        <xsl:for-each select="$root//h:variables[@variableType='CALCULATED']">
+            <xsl:variable name="node" select="."/>
+            <xsl:if test="$node/h:bindingDependencies=$varName">
+                <xsl:sequence select="$node/h:name"/>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:function>
+    
 </xsl:stylesheet>

--- a/src/main/resources/xslt/transformations/ddi2lunatic-xml/ddi2lunatic-xml-fixed.xsl
+++ b/src/main/resources/xslt/transformations/ddi2lunatic-xml/ddi2lunatic-xml-fixed.xsl
@@ -99,7 +99,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
-    <xsl:variable name="control" as="xs:boolean">
+    <xsl:variable name="controlParam" as="xs:boolean">
         <xsl:choose>
             <xsl:when test="$parameters//Control != ''">
                 <xsl:value-of select="$parameters//Control"/>

--- a/src/test/resources/params/in-to-out/default/form.xml
+++ b/src/test/resources/params/in-to-out/default/form.xml
@@ -2523,89 +2523,107 @@
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_COMMENT</name>
       <expression>true</expression>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_READY</name>
       <expression>true</expression>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_PRODUCER</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_SEASON_NUMBER</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_DATEFIRST</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_AUDIENCE_SHARE</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_CITY</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_MAYOR</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_STATE</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_PET</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_ICE_FLAVOUR</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_NUCLEAR_CHARACTER</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_BIRTH_CHARACTER</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_PERCENTAGE_EXPENSES</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_CLOWNING</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_TRAVEL</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_FAVOURITE_CHARACTERS</name>
       <expression>(not(cast(READY,integer) &lt;&gt;  1) )</expression>
       <bindingDependencies>READY</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>FILTER_RESULT_SURVEY_COMMENT</name>
       <expression>true</expression>
+      <inFilter>false</inFilter>
    </variables>
    <variables variableType="CALCULATED" xsi:type="VariableType">
       <name>SUM_EXPENSES</name>
@@ -2620,5 +2638,6 @@
       <bindingDependencies>PERCENTAGE_EXPENSES81</bindingDependencies>
       <bindingDependencies>PERCENTAGE_EXPENSES91</bindingDependencies>
       <bindingDependencies>PERCENTAGE_EXPENSES101</bindingDependencies>
+      <inFilter>false</inFilter>
    </variables>
 </Questionnaire>


### PR DESCRIPTION
Changelog :

- Adding support of the "Control" parameter (in lunatic-xml parameters fed to Eno) : if false, controls are not added to the resulting questionnaire. 
- Adding a field inFilter, specifying if a calculated variable is used for a filter or a loop condition. A function is-used-in-filter supports this feature by, for a given variable, searching up for its possible use in a condition (in all variables that may call it) for a given variable
