### PR TITLE
feat: V3 services in legacy endpoints

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/DDIToLunatic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/DDIToLunatic.java
@@ -21,8 +21,8 @@ public class DDIToLunatic {
 
     private DDIToLunatic() {}
 
-    public static String transform(InputStream ddiInputStream, EnoParameters enoParameters)
-            throws IOException, DDIParsingException, LunaticSerializationException {
+    public static Questionnaire transform(InputStream ddiInputStream, EnoParameters enoParameters)
+            throws IOException, DDIParsingException {
         //
         DDIInstanceDocument ddiInstanceDocument = DDIParser.parse(ddiInputStream);
         //
@@ -40,7 +40,19 @@ public class DDIToLunatic {
         LunaticProcessing lunaticProcessing = new LunaticProcessing(enoParameters);
         lunaticProcessing.applyProcessing(lunaticQuestionnaire, enoQuestionnaire);
         //
+        return lunaticQuestionnaire;
+    }
+
+    public static String transformToJson(InputStream ddiInputStream, EnoParameters enoParameters)
+            throws IOException, DDIParsingException, LunaticSerializationException {
+        Questionnaire lunaticQuestionnaire = transform(ddiInputStream, enoParameters);
         return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
+    }
+
+    public static String transformToXml(InputStream ddiInputStream, EnoParameters enoParameters)
+            throws IOException, DDIParsingException, LunaticSerializationException {
+        Questionnaire lunaticQuestionnaire = transform(ddiInputStream, enoParameters);
+        return LunaticSerializer.serializeToXml(lunaticQuestionnaire);
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/output/LunaticSerializer.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/output/LunaticSerializer.java
@@ -2,6 +2,7 @@ package fr.insee.eno.core.output;
 
 import fr.insee.eno.core.exceptions.business.LunaticSerializationException;
 import fr.insee.lunatic.conversion.JSONSerializer;
+import fr.insee.lunatic.conversion.XMLSerializer;
 import fr.insee.lunatic.model.flat.Questionnaire;
 
 import javax.xml.bind.JAXBException;
@@ -11,10 +12,17 @@ public class LunaticSerializer {
 
     private LunaticSerializer() {}
 
-    public static String serializeToJson(Questionnaire lunaticQuestionnaire) throws LunaticSerializationException {
-        JSONSerializer jsonSerializer = new JSONSerializer();
+    /**
+     * Define interface here since Lunatic-Model does not provide an interface for serializers.
+     */
+    private interface ILunaticSerializer {
+        String serialize(Questionnaire lunaticQuestionnaire) throws JAXBException, UnsupportedEncodingException;
+    }
+
+    private static String serialize(Questionnaire lunaticQuestionnaire, ILunaticSerializer serializer)
+            throws LunaticSerializationException {
         try {
-            return jsonSerializer.serialize(lunaticQuestionnaire);
+            return serializer.serialize(lunaticQuestionnaire);
         } catch (JAXBException e) {
             throw new LunaticSerializationException(
                     "Lunatic questionnaire given cannot be serialized.", e);
@@ -22,6 +30,16 @@ public class LunaticSerializer {
             throw new LunaticSerializationException(
                     "Encoding exception encountered while trying to serialize Lunatic questionnaire.", e);
         }
+    }
+
+    public static String serializeToJson(Questionnaire lunaticQuestionnaire) throws LunaticSerializationException {
+        JSONSerializer jsonSerializer = new JSONSerializer();
+        return serialize(lunaticQuestionnaire, jsonSerializer::serialize);
+    }
+
+    public static String serializeToXml(Questionnaire lunaticQuestionnaire) throws LunaticSerializationException {
+        XMLSerializer xmlSerializer = new XMLSerializer();
+        return serialize(lunaticQuestionnaire, xmlSerializer::serialize);
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/EnoParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/EnoParameters.java
@@ -2,9 +2,11 @@ package fr.insee.eno.core.parameter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.insee.eno.core.annotations.Format;
 import fr.insee.eno.core.model.mode.Mode;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,6 +17,7 @@ import static fr.insee.eno.core.model.mode.Mode.*;
 
 @Getter
 @Setter
+@Slf4j
 public class EnoParameters {
 
     public enum Context {HOUSEHOLD, BUSINESS, DEFAULT}
@@ -50,17 +53,25 @@ public class EnoParameters {
     private LunaticPaginationMode lunaticPaginationMode;
 
     public static EnoParameters parse(InputStream parametersInputStream) throws IOException {
+        log.info("Parsing Eno parameters from input stream");
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.readValue(parametersInputStream, EnoParameters.class);
     }
 
     public static String serialize(EnoParameters enoParameters) throws JsonProcessingException {
+        log.info("Serializing parameters file");
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(enoParameters);
     }
 
     public EnoParameters() {
         defaultParameters();
+    }
+
+    public EnoParameters(Context context, Format outFormat) {
+        log.info("Parameters with context {} and out format {}", context, outFormat);
+        defaultParameters(); // TODO: default values in function of context & out format
+        this.context = context;
     }
 
     private void defaultParameters() {

--- a/eno-core/src/test/java/fr/insee/eno/core/demo/DDIToLunaticTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/demo/DDIToLunaticTest.java
@@ -32,7 +32,7 @@ class DDIToLunaticTest {
             enoParameters.setSelectedModes(List.of(Mode.CAPI, Mode.CATI));
 
             //
-            String result = DDIToLunatic.transform(ddiInputStream, enoParameters);
+            String result = DDIToLunatic.transformToJson(ddiInputStream, enoParameters);
 
             //
             //Files.writeString(Path.of("src/test/resources/out/lunatic/" + fileName + ".json"), result);
@@ -42,7 +42,7 @@ class DDIToLunaticTest {
     @Test
     void ddiToLunatic_pairwise() {
         assertDoesNotThrow(() -> {
-            String result = DDIToLunatic.transform(
+            String result = DDIToLunatic.transformToJson(
                     this.getClass().getClassLoader().getResourceAsStream("pairwise/form-ddi-household-links.xml"),
                     new EnoParameters());
 

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/DDIToLunaticController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/DDIToLunaticController.java
@@ -1,12 +1,9 @@
 package fr.insee.eno.ws.controller;
 
 import fr.insee.eno.core.parameter.EnoParameters;
-import fr.insee.eno.ws.service.DDIToLunaticService;
-import fr.insee.eno.ws.service.ParameterService;
+import fr.insee.eno.ws.controller.utils.V3ControllerUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.CacheControl;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
@@ -16,23 +13,14 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-import java.io.SequenceInputStream;
-
 @Tag(name = "V3 Transformations", description = "Temporary endpoints that will be recast in existing endpoints.")
 @RestController
 @RequestMapping("/v3/questionnaire")
 public class DDIToLunaticController {
 
-    // TODO: integrate the V3 services into the existing controllers
-
-    public static final String LUNATIC_OUT_FILE_NAME = "lunatic-form.json";
-
-    private final DDIToLunaticService ddiToLunaticService;
-    private final ParameterService parameterService;
-
-    public DDIToLunaticController(DDIToLunaticService ddiToLunaticService, ParameterService parameterService) {
-        this.ddiToLunaticService = ddiToLunaticService;
-        this.parameterService = parameterService;
+    private final V3ControllerUtils controllerUtils;
+    public DDIToLunaticController(V3ControllerUtils controllerUtils) {
+        this.controllerUtils = controllerUtils;
     }
 
     @Operation(
@@ -44,7 +32,7 @@ public class DDIToLunaticController {
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Mono<ResponseEntity<String>> ddiToLunatic(
             @RequestPart("ddiFile") Mono<FilePart> ddiFile) {
-        return transformDDI(ddiFile, new EnoParameters());
+        return controllerUtils.ddiToLunaticJson(ddiFile, new EnoParameters());
     }
 
     @Operation(
@@ -57,31 +45,7 @@ public class DDIToLunaticController {
     public Mono<ResponseEntity<String>> ddiToLunatic(
             @RequestPart("ddiFile") Mono<FilePart> ddiFile,
             @RequestPart("parameterFile") Mono<FilePart> parametersFile) {
-        return parametersFile.flatMap(filePart -> filePart.content()
-                            .map(dataBuffer -> dataBuffer.asInputStream(true))
-                            .reduce(SequenceInputStream::new))
-                    .flatMap(parameterService::parse)
-                    .flatMap(enoParameters -> transformDDI(ddiFile, enoParameters));
-    }
-
-    // TODO: replace Mono<FilePart> parametersFile with EnoParameters argument
-    // TODO: implement API friendly endpoints that return json/xml instead of octet stream
-
-    private Mono<ResponseEntity<String>> transformDDI(Mono<FilePart> ddiFile, EnoParameters enoParameters) {
-        //
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename="+LUNATIC_OUT_FILE_NAME);
-        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-        //
-        return ddiFile.flatMap(filePart -> filePart.content()
-                        .map(dataBuffer -> dataBuffer.asInputStream(true))
-                        .reduce(SequenceInputStream::new))
-                .flatMap(inputStream -> ddiToLunaticService.transform(inputStream, enoParameters))
-                .map(result -> ResponseEntity
-                        .ok()
-                        .cacheControl(CacheControl.noCache())
-                        .headers(headers)
-                        .body(result));
+        return controllerUtils.ddiToLunaticJson(ddiFile, parametersFile);
     }
 
 }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationController.java
@@ -1,11 +1,16 @@
 package fr.insee.eno.ws.controller;
 
+import fr.insee.eno.core.annotations.Format;
+import fr.insee.eno.core.model.mode.Mode;
+import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.legacy.parameters.*;
 import fr.insee.eno.ws.PassePlat;
+import fr.insee.eno.ws.controller.utils.V3ControllerUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -17,12 +22,13 @@ import reactor.core.publisher.Mono;
 @Controller
 @RequestMapping("/questionnaire")
 @Slf4j
-@SuppressWarnings("unused")
 public class GenerationController {
 
+	private final V3ControllerUtils controllerUtils;
 	private final PassePlat passePlat;
 
-	public GenerationController(PassePlat passePlat) {
+	public GenerationController(V3ControllerUtils controllerUtils, PassePlat passePlat) {
+		this.controllerUtils = controllerUtils;
 		this.passePlat = passePlat;
 	}
 
@@ -32,6 +38,7 @@ public class GenerationController {
 					"and the specificTreatment file (optional). To use it, you have to upload all necessary files.")
 	@PostMapping(value = "in-2-out",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@SuppressWarnings("unused")
 	public Mono<Void> generate(
 			@RequestPart(value="in") Mono<FilePart> in,
 			@RequestPart(value="params") Mono<FilePart> params,
@@ -48,6 +55,7 @@ public class GenerationController {
 			description = "Generate a XSL-FO questionnaire from a DDI questionnaire using the FO parameters given.")
 	@PostMapping(value = "ddi-2-fo",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@SuppressWarnings("unused")
 	public Mono<Void> generateFOQuestionnaire(
 			@RequestPart(value="in") Mono<FilePart> in,
 			@RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
@@ -73,6 +81,7 @@ public class GenerationController {
 					"For css parameters, separate style sheet by ','")
 	@PostMapping(value = "ddi-2-xforms",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@SuppressWarnings("unused")
 	public Mono<Void> generateXformsQuestionnaire(
 			@RequestPart(value="in") Mono<FilePart> in,
 			@RequestPart(value="metadata", required=false) Mono<FilePart> metadata,
@@ -96,16 +105,17 @@ public class GenerationController {
 	}
 
 	@Operation(
-			summary = "Generation of Lunatic json questionnaire.",
-			description = "Generate a Lunatic json (flat) questionnaire from a DDI questionnaire " +
+			summary = "[V3] Generation of Lunatic json questionnaire.",
+			description = "**This endpoint uses Eno v3**. " +
+					"Generate a Lunatic json (flat) questionnaire from a DDI questionnaire " +
 					"using the parameters given.")
 	@PostMapping(value = "ddi-2-lunatic-json/{mode}",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public Mono<Void> generateLunaticJsonQuestionnaire(
-			@RequestPart(value="in") Mono<FilePart> in,
+	public Mono<ResponseEntity<String>> generateLunaticJsonQuestionnaire(
+			@RequestPart(value="in") Mono<FilePart> ddiFile,
 			@RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
 			@PathVariable Mode mode,
-			@RequestParam(value="context") Context context,
+			@RequestParam(value="context") EnoParameters.Context context,
 			@RequestParam(value="IdentificationQuestion", required=false) boolean identificationQuestion,
 			@RequestParam(value="ResponseTimeQuestion", required=false) boolean endQuestionResponseTime,
 			@RequestParam(value="CommentQuestion", required=false) boolean endQuestionCommentQuestion,
@@ -118,9 +128,52 @@ public class GenerationController {
 			@RequestParam(value="SeqNum") boolean seqNum,
 			@RequestParam(value="PreQuestSymbol") boolean preQuestSymbol,
 			@RequestParam(value="Pagination", required=false, defaultValue="NONE") Pagination pagination,
-			@RequestParam(value="includeUnusedCalculatedVariables") boolean unusedVars,
-			ServerHttpRequest request, ServerHttpResponse response) {
-		return passePlat.passePlatPost(request, response);
+			@RequestParam(value="includeUnusedCalculatedVariables") boolean unusedVars) {
+		//
+		if (specificTreatment != null) {
+			log.warn("Specific treatments has changed in Eno v3. File given will be ignored.");
+		}
+		//
+		EnoParameters parameters = new EnoParameters(context, Format.LUNATIC);
+		parameters.getSelectedModes().clear();
+		parameters.getSelectedModes().add(mode);
+		parameters.setIdentificationQuestion(identificationQuestion);
+		parameters.setResponseTimeQuestion(endQuestionResponseTime);
+		parameters.setIdentificationQuestion(endQuestionCommentQuestion);
+		if (parsingXpathVTL)
+			log.info("Parsing XpathVTL parameter is ignored.");
+		parameters.setFilterDescription(filterDescription);
+		if (filterDescription)
+			log.info("'Filter description' feature is not supported yet.");
+		parameters.setMissingVariables(missingVar);
+		if (missingVar)
+			log.info("'MISSING' variables is not implemented yet.");
+		parameters.setFilterResult(addFilterResult);
+		if (addFilterResult)
+			log.info("'FILTER_RESULT' variables is not supported yet.");
+		parameters.setControls(control);
+		if (control)
+			log.info("Generated format controls is not supported yet.");
+		switch (questNum) {
+			case ALL -> parameters.setQuestionNumberingMode(EnoParameters.QuestionNumberingMode.ALL);
+			case MODULE -> parameters.setQuestionNumberingMode(EnoParameters.QuestionNumberingMode.SEQUENCE);
+			case NO_NUMBER -> parameters.setQuestionNumberingMode(EnoParameters.QuestionNumberingMode.NONE);
+		}
+		parameters.setSequenceNumbering(seqNum);
+		parameters.setArrowCharInQuestions(preQuestSymbol);
+		switch (pagination) {
+			case NONE -> parameters.setLunaticPaginationMode(EnoParameters.LunaticPaginationMode.NONE);
+			case SEQUENCE -> parameters.setLunaticPaginationMode(EnoParameters.LunaticPaginationMode.SEQUENCE);
+			case SUBSEQUENCE -> {
+				parameters.setLunaticPaginationMode(EnoParameters.LunaticPaginationMode.NONE);
+				log.info("Lunatic 'SUBSEQUENCE' pagination is not supported. Pagination has been set to 'NONE'.");
+			}
+			case QUESTION -> parameters.setLunaticPaginationMode(EnoParameters.LunaticPaginationMode.QUESTION);
+		}
+		parameters.setUnusedVariables(unusedVars);
+		log.info("'Unused variables' feature is not implemented in Eno v3.");
+		//
+		return controllerUtils.ddiToLunaticJson(ddiFile, parameters);
 	}
 
 	@Operation(
@@ -128,6 +181,7 @@ public class GenerationController {
 			description = "Generate a DDI questionnaire from a Pogues xml questionnaire.")
 	@PostMapping(value="poguesxml-2-ddi",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@SuppressWarnings("unused")
 	public Mono<Void> generateDDIQuestionnaire(
 			@RequestPart(value="in") Mono<FilePart> in,
 			ServerHttpRequest request, ServerHttpResponse response) {
@@ -139,6 +193,7 @@ public class GenerationController {
 			description = "Generates a FODT (Open Document file) questionnaire from a DDI questionnaire.")
 	@PostMapping(value="ddi-2-fodt",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@SuppressWarnings("unused")
 	public Mono<Void> generateODTQuestionnaire(
 			@RequestPart(value="in") Mono<FilePart> in,
 			@RequestParam(value="QuestNum") BrowsingEnum questNum,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/IntegrationHouseholdController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/IntegrationHouseholdController.java
@@ -1,14 +1,13 @@
 package fr.insee.eno.ws.controller;
 
-import fr.insee.eno.legacy.parameters.Mode;
-import fr.insee.eno.ws.PassePlat;
+import fr.insee.eno.core.model.mode.Mode;
+import fr.insee.eno.ws.controller.utils.V3ControllerUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,29 +19,38 @@ import reactor.core.publisher.Mono;
 @Controller
 @RequestMapping("/integration-business")
 @Slf4j
-@SuppressWarnings("unused")
 public class IntegrationHouseholdController {
 
-    private final PassePlat passePlat;
+    private final V3ControllerUtils controllerUtils;
 
-    public IntegrationHouseholdController(PassePlat passePlat) {
-        this.passePlat = passePlat;
+    public IntegrationHouseholdController(V3ControllerUtils controllerUtils) {
+        this.controllerUtils = controllerUtils;
     }
 
     @Operation(
-            summary = "Integration of questionnaire according to params, metadata and specificTreatment.",
-            description= "Generate a questionnaire for integration with default pipeline: using the " +
-                    "parameters file (required), metadata file (required) and the specificTreatment file (optional). " +
-                    "To use it, you have to upload all necessary files.")
+            summary = "[V3] Integration of questionnaire according to mode, parameters, and specificTreatment.",
+            description= "**This endpoint uses Eno v3**. " +
+                    "Generate a Lunatic questionnaire for integration, using the collection mode given, " +
+                    "the parameters file (required), and the specificTreatment file (optional).")
     @PostMapping(value = "ddi-2-lunatic-json/{mode}",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public Mono<Void> generateLunaticJson(
+    public Mono<ResponseEntity<String>> generateLunaticJson(
             @PathVariable Mode mode,
-            @RequestPart(value="in") Mono<FilePart> in,
-            @RequestPart(value="params") Mono<FilePart> params,
-            @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
-            ServerHttpRequest request, ServerHttpResponse response) {
-        return passePlat.passePlatPost(request, response);
+            @RequestPart(value="in") Mono<FilePart> ddiFile,
+            @RequestPart(value="params") Mono<FilePart> parametersFile,
+            @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment) {
+        //
+        if (specificTreatment != null) {
+            log.warn("Specific treatments has changed in Eno v3. File given will be ignored.");
+        }
+        //
+        return controllerUtils.readParametersFile(parametersFile)
+                .flatMap(enoParameters -> {
+                    enoParameters.getSelectedModes().clear();
+                    enoParameters.getSelectedModes().add(mode);
+                    return Mono.just(enoParameters);
+                })
+                .flatMap(enoParameters -> controllerUtils.ddiToLunaticJson(ddiFile, enoParameters));
     }
 
 }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/SimpleGenerationController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/SimpleGenerationController.java
@@ -1,13 +1,17 @@
 package fr.insee.eno.ws.controller;
 
+import fr.insee.eno.core.annotations.Format;
+import fr.insee.eno.core.model.mode.Mode;
+import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.legacy.parameters.CaptureEnum;
 import fr.insee.eno.legacy.parameters.Context;
-import fr.insee.eno.legacy.parameters.Mode;
 import fr.insee.eno.ws.PassePlat;
+import fr.insee.eno.ws.controller.utils.V3ControllerUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -19,12 +23,13 @@ import reactor.core.publisher.Mono;
 @Controller
 @RequestMapping("/questionnaire")
 @Slf4j
-@SuppressWarnings("unused")
 public class SimpleGenerationController {
 
+    private final V3ControllerUtils controllerUtils;
     private final PassePlat passePlat;
 
-    public SimpleGenerationController(PassePlat passePlat) {
+    public SimpleGenerationController(V3ControllerUtils controllerUtils, PassePlat passePlat) {
+        this.controllerUtils = controllerUtils;
         this.passePlat = passePlat;
     }
 
@@ -35,6 +40,7 @@ public class SimpleGenerationController {
                     "See it using the end point: `/parameter/{context}/FO/default`")
     @PostMapping(value = "{context}/fo",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @SuppressWarnings("unused")
     public Mono<Void> generateFOQuestionnaire(
             @RequestPart(value="in") Mono<FilePart> in,
             @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
@@ -52,6 +58,7 @@ public class SimpleGenerationController {
                     "See it using the end point: `/parameter/{context}/XFORMS/default`")
     @PostMapping(value = "{context}/xforms",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @SuppressWarnings("unused")
     public Mono<Void> generateXformsQuestionnaire(
             @RequestPart(value="in") Mono<FilePart> in,
             @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
@@ -61,36 +68,50 @@ public class SimpleGenerationController {
     }
 
     @Operation(
-            summary = "Generation of Lunatic xml questionnaire according to the context.",
-            description = "Generate a Lunatic xml questionnaire from a DDI questionnaire " +
-                    "using the default Lunatic parameters according to the study unit. " +
-                    "See it using the end point: `/parameter/{context}/LUNATIC_XML/default`")
+            summary = "[V3] Generation of Lunatic xml questionnaire according to the context.",
+            description = "**This endpoint uses Eno V3.** " +
+                    "Generate a Lunatic xml **flat** questionnaire from a DDI questionnaire " +
+                    "using the default Lunatic parameters in function of context. " +
+                    "*Warning: in legacy version, this endpoint used to deliver Lunatic xml **hierarchical** " +
+                    "questionnaires (to be confirmed).*" +
+                    "To see these parameters, you can use the endpoint: `/v3/parameter/{context}/LUNATIC/default`")
     @PostMapping(value = "{context}/lunatic-xml/{mode}",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public Mono<Void> generateLunaticXmlQuestionnaire(
-            @RequestPart(value="in") Mono<FilePart> in,
-            @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
-            @PathVariable Context context,
-            @PathVariable Mode mode,
-            ServerHttpRequest request, ServerHttpResponse response) {
-        return passePlat.passePlatPost(request, response);
+    public Mono<ResponseEntity<String>> generateLunaticXmlQuestionnaire(
+            @RequestPart(value="in") Mono<FilePart> ddiFile,
+            @PathVariable EnoParameters.Context context,
+            @PathVariable Mode mode) {
+        //
+        EnoParameters enoParameters = new EnoParameters(context, Format.LUNATIC);
+        enoParameters.getSelectedModes().clear();
+        enoParameters.getSelectedModes().add(mode);
+        //
+        return controllerUtils.ddiToLunaticXml(ddiFile, enoParameters);
     }
 
     @Operation(
-            summary = "Generation of Lunatic json flat questionnaire according to the context.",
-            description = "Generate a Lunatic json flat questionnaire from a DDI questionnaire " +
-                    "using the default Lunatic parameters according to the study unit. " +
-                    "See it using the end point : `/parameter/default`" +
-                    "The params *parsingXpathVTL* must be 'true' (default value) if controls language is pseudo-xpath.")
+            summary = "[V3] Generation of Lunatic json flat questionnaire according to the context.",
+            description = "**This endpoint uses Eno V3.** " +
+                    "Generate a Lunatic json flat questionnaire from a DDI questionnaire " +
+                    "using the default Lunatic parameters in function of context. " +
+                    "To see these parameters, you can use the endpoint: `/v3/parameter/{context}/LUNATIC/default`")
     @PostMapping(value = "{context}/lunatic-json/{mode}",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public Mono<Void> generateLunaticJsonQuestionnaire(
-            @RequestPart(value="in") Mono<FilePart> in,
+    public Mono<ResponseEntity<String>> generateLunaticJsonQuestionnaire(
+            @RequestPart(value="in") Mono<FilePart> ddiFile,
             @RequestPart(value="specificTreatment", required=false) Mono<FilePart> specificTreatment,
-            @PathVariable Context context,
-            @PathVariable Mode mode,
-            ServerHttpRequest request, ServerHttpResponse response) {
-        return passePlat.passePlatPost(request, response);
+            @PathVariable EnoParameters.Context context,
+            @PathVariable Mode mode) {
+        //
+        if (specificTreatment != null) {
+            log.warn("Specific treatments has changed in Eno v3. File given will be ignored.");
+        }
+        //
+        EnoParameters enoParameters = new EnoParameters(context, Format.LUNATIC);
+        enoParameters.getSelectedModes().clear();
+        enoParameters.getSelectedModes().add(mode);
+        //
+        return controllerUtils.ddiToLunaticJson(ddiFile, enoParameters);
     }
 
     @Operation(
@@ -100,6 +121,7 @@ public class SimpleGenerationController {
                     "See it using the end point : `/parameter/{context}/FODT/default`")
     @PostMapping(value = "{context}/fodt",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @SuppressWarnings("unused")
     public Mono<Void> generateFODTQuestionnaire(
             @RequestPart(value="in") Mono<FilePart> in,
             @PathVariable Context context,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/V3ParameterController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/V3ParameterController.java
@@ -1,13 +1,16 @@
 package fr.insee.eno.ws.controller;
 
+import fr.insee.eno.core.annotations.Format;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.ws.controller.utils.HeadersUtils;
 import fr.insee.eno.ws.service.ParameterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.CacheControl;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
@@ -26,20 +29,31 @@ public class V3ParameterController {
     }
 
     @Operation(
-            summary="Get V3 default parameters.",
-            description="Return default parameters file, to be used in V3 endpoints that require a parameter file.")
+            summary = "Get V3 all default parameters.",
+            description = "Return V3 parameters file containing all default values.")
     @GetMapping(value = "default", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public Mono<ResponseEntity<String>> v3DefaultParameters() {
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename="+PARAMETERS_V3_FILE_NAME);
-        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-
         return parameterService.defaultParams()
                 .map(params -> ResponseEntity
                         .ok()
                         .cacheControl(CacheControl.noCache())
-                        .headers(headers)
+                        .headers(HeadersUtils.with(PARAMETERS_V3_FILE_NAME))
+                        .body(params));
+    }
+
+    @Operation(
+            summary = "Get V3 default parameters with context.",
+            description = "Return default parameters file in function of context given, " +
+                    "to be used in V3 endpoints that require a parameter file.")
+    @GetMapping(value = "{context}/{outFormat}/default", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public Mono<ResponseEntity<String>> v3DefaultParameters(
+            @PathVariable EnoParameters.Context context,
+            @PathVariable Format outFormat) {
+        return parameterService.defaultParams(context, outFormat)
+                .map(params -> ResponseEntity
+                        .ok()
+                        .cacheControl(CacheControl.noCache())
+                        .headers(HeadersUtils.with(PARAMETERS_V3_FILE_NAME))
                         .body(params));
     }
 

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/HeadersUtils.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/HeadersUtils.java
@@ -1,0 +1,16 @@
+package fr.insee.eno.ws.controller.utils;
+
+import org.springframework.http.MediaType;
+
+import org.springframework.http.HttpHeaders;
+
+public class HeadersUtils {
+
+    public static HttpHeaders with(String fileName) {
+        HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.set(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION, "attachment; filename="+fileName);
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        return headers;
+    }
+
+}

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/V3ControllerUtils.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/V3ControllerUtils.java
@@ -1,0 +1,73 @@
+package fr.insee.eno.ws.controller.utils;
+
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.ws.service.DDIToLunaticService;
+import fr.insee.eno.ws.service.ParameterService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.io.SequenceInputStream;
+
+/** Class to factorize code in v3 controllers' methods. */
+@Component
+public class V3ControllerUtils {
+
+    public static final String LUNATIC_JSON_FILE_NAME = "lunatic-form.json";
+    public static final String LUNATIC_XML_FILE_NAME = "lunatic-form.xml";
+
+    private final DDIToLunaticService ddiToLunaticService;
+    private final ParameterService parameterService;
+
+    public V3ControllerUtils(DDIToLunaticService ddiToLunaticService, ParameterService parameterService) {
+        this.ddiToLunaticService = ddiToLunaticService;
+        this.parameterService = parameterService;
+    }
+
+    // TODO: replace Mono<FilePart> parametersFile with EnoParameters argument (automatic deserialization)
+    // TODO: implement API friendly endpoints that return json/xml instead of octet stream
+
+    public Mono<EnoParameters> readParametersFile(Mono<FilePart> parametersFile) {
+        return parametersFile.flatMap(filePart -> filePart.content()
+                        .map(dataBuffer -> dataBuffer.asInputStream(true))
+                        .reduce(SequenceInputStream::new))
+                .flatMap(parameterService::parse);
+    }
+
+    public Mono<ResponseEntity<String>> ddiToLunaticJson(Mono<FilePart> ddiFile, Mono<FilePart> parametersFile) {
+        return readParametersFile(parametersFile)
+                .flatMap(enoParameters -> ddiToLunaticJson(ddiFile, enoParameters));
+    }
+
+    public Mono<ResponseEntity<String>> ddiToLunaticJson(Mono<FilePart> ddiFile, EnoParameters enoParameters) {
+        return ddiFile.flatMap(filePart -> filePart.content()
+                        .map(dataBuffer -> dataBuffer.asInputStream(true))
+                        .reduce(SequenceInputStream::new))
+                .flatMap(inputStream -> ddiToLunaticService.transformToJson(inputStream, enoParameters))
+                .map(result -> ResponseEntity
+                        .ok()
+                        .cacheControl(CacheControl.noCache())
+                        .headers(HeadersUtils.with(LUNATIC_JSON_FILE_NAME))
+                        .body(result));
+    }
+
+    public Mono<ResponseEntity<String>> ddiToLunaticXml(Mono<FilePart> ddiFile, Mono<FilePart> parametersFile) {
+        return readParametersFile(parametersFile)
+                .flatMap(enoParameters -> ddiToLunaticXml(ddiFile, enoParameters));
+    }
+
+    public Mono<ResponseEntity<String>> ddiToLunaticXml(Mono<FilePart> ddiFile, EnoParameters enoParameters) {
+        return ddiFile.flatMap(filePart -> filePart.content()
+                        .map(dataBuffer -> dataBuffer.asInputStream(true))
+                        .reduce(SequenceInputStream::new))
+                .flatMap(inputStream -> ddiToLunaticService.transformToXml(inputStream, enoParameters))
+                .map(result -> ResponseEntity
+                        .ok()
+                        .cacheControl(CacheControl.noCache())
+                        .headers(HeadersUtils.with(LUNATIC_XML_FILE_NAME))
+                        .body(result));
+    }
+
+}

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToLunaticService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToLunaticService.java
@@ -2,6 +2,7 @@ package fr.insee.eno.ws.service;
 
 import fr.insee.eno.core.DDIToLunatic;
 import fr.insee.eno.core.parameter.EnoParameters;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -10,9 +11,18 @@ import java.io.InputStream;
 @Service
 public class DDIToLunaticService {
 
-    public Mono<String> transform(InputStream ddiInputStream, EnoParameters parameterInputStream) {
+    public Mono<String> transformToJson(InputStream ddiInputStream, EnoParameters parameterInputStream) {
         try {
-            return Mono.just(DDIToLunatic.transform(ddiInputStream, parameterInputStream));
+            return Mono.just(DDIToLunatic.transformToJson(ddiInputStream, parameterInputStream));
+        } catch (Exception e) {
+            return Mono.error(e);
+        }
+    }
+
+    /** Temporary service while Eno legacy WS is still in use. */
+    public Mono<String> transformToXml(InputStream ddiInputStream, EnoParameters parameterInputStream) {
+        try {
+            return Mono.just(DDIToLunatic.transformToXml(ddiInputStream, parameterInputStream));
         } catch (Exception e) {
             return Mono.error(e);
         }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.ws.service;
 
+import fr.insee.eno.core.annotations.Format;
 import fr.insee.eno.core.parameter.EnoParameters;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -20,6 +21,14 @@ public class ParameterService {
     public Mono<String> defaultParams() {
         try {
             return Mono.just(EnoParameters.serialize(new EnoParameters()));
+        } catch (Exception e) {
+            return Mono.error(e);
+        }
+    }
+
+    public Mono<String> defaultParams(EnoParameters.Context context, Format format) {
+        try {
+            return Mono.just(EnoParameters.serialize(new EnoParameters(context, format)));
         } catch (Exception e) {
             return Mono.error(e);
         }


### PR DESCRIPTION
#563 

Eno API now uses V3 services for all (four) "DDI to Lunatic" endpoints 🎉 

- Some refactor in `core` to output Lunatic json or xml
- Replace redirection by v3 service call in DDI to Lunatic controllers

The V3 web-service should be ready to be used in combination with Pogues 🥳 
