### PR TITLE
fix: actually write label types in Lunatic

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
@@ -31,6 +31,7 @@ public class CalculatedExpression extends EnoObject {
     public static CalculatedExpression defaultExpression() {
         CalculatedExpression res = new CalculatedExpression();
         res.setValue("true");
+        res.setType(Constant.LUNATIC_LABEL_VTL);
         return res;
     }
 
@@ -41,8 +42,8 @@ public class CalculatedExpression extends EnoObject {
 
     /** For now, Lunatic type in label objects does not come from metadata, but is hardcoded here in Eno.
      * See labels documentation. */
-    @Lunatic(contextType = LabelType.class, field = "setType('"+ Constant.LUNATIC_LABEL_VTL+"')")
-    String type;
+    @Lunatic(contextType = LabelType.class, field = "setType(#param)")
+    String type = Constant.LUNATIC_LABEL_VTL;
 
     /** In DDI, the expression contains variable references instead of variables names.
      * This list contains the references of these variables. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
@@ -18,8 +18,8 @@ import java.util.List;
 
 import static fr.insee.eno.core.annotations.Contexts.Context;
 
-/** Class that could be used to refactor calculated expressions' mapping.
- * Unused yet since the Lunatic mapper doesn't allow to dig into a complex object without creating a new instance. */
+/** Class used to for the mapping of calculated expressions that can be found in objects like
+ * calculated variables, controls, filters. */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
@@ -24,7 +24,7 @@ public class DynamicLabel extends EnoObject {
 
     /** For now, Lunatic type in label objects does not come from metadata, but is hardcoded here in Eno.
      * See labels documentation. */
-    @Lunatic(contextType = LabelType.class, field = "setType('"+ Constant.LUNATIC_LABEL_VTL_MD+"')")
-    String type;
+    @Lunatic(contextType = LabelType.class, field = "setType(#param)")
+    String type = Constant.LUNATIC_LABEL_VTL_MD;
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
@@ -23,7 +23,7 @@ public class Label extends EnoObject {
 
     /** For now, Lunatic type in label objects does not come from metadata, but is hardcoded here in Eno.
      * See labels documentation. */
-    @Lunatic(contextType = fr.insee.lunatic.model.flat.LabelType.class, field = "setType('"+ Constant.LUNATIC_LABEL_VTL_MD+"')")
-    String type;
+    @Lunatic(contextType = fr.insee.lunatic.model.flat.LabelType.class, field = "setType(#param)")
+    String type = Constant.LUNATIC_LABEL_VTL_MD;
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/QuestionnaireLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/QuestionnaireLabel.java
@@ -24,7 +24,7 @@ public class QuestionnaireLabel extends EnoObject {
 
     /** For now, Lunatic type does not come from metadata, but is hardcoded here in Eno.
      * See labels documentation. */
-    @Lunatic(contextType = LabelType.class, field = "setType('"+Constant.LUNATIC_LABEL_VTL_MD+"')")
-    String type;
+    @Lunatic(contextType = LabelType.class, field = "setType(#param)")
+    String type = Constant.LUNATIC_LABEL_VTL_MD;
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mappers/lunatic/LabelTests.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mappers/lunatic/LabelTests.java
@@ -1,0 +1,63 @@
+package fr.insee.eno.core.mappers.lunatic;
+
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.calculated.CalculatedExpression;
+import fr.insee.eno.core.model.label.DynamicLabel;
+import fr.insee.eno.core.model.label.Label;
+import fr.insee.eno.core.model.label.QuestionnaireLabel;
+import fr.insee.lunatic.model.flat.LabelType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LabelTests {
+
+    @Test
+    void basicLabel_type() {
+        //
+        Label enoLabel = new Label();
+        LabelType lunaticLabel = new LabelType();
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
+        //
+        assertEquals("VTL|MD", lunaticLabel.getType());
+    }
+
+    @Test
+    void dynamicLabel_type() {
+        //
+        DynamicLabel enoLabel = new DynamicLabel();
+        LabelType lunaticLabel = new LabelType();
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
+        //
+        assertEquals("VTL|MD", lunaticLabel.getType());
+    }
+
+    @Test
+    void questionnaireLabel_type() {
+        //
+        QuestionnaireLabel enoLabel = new QuestionnaireLabel();
+        LabelType lunaticLabel = new LabelType();
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
+        //
+        assertEquals("VTL|MD", lunaticLabel.getType());
+    }
+
+    @Test
+    void calculatedExpression_type() {
+        //
+        CalculatedExpression enoCalculatedExpression = new CalculatedExpression();
+        LabelType lunaticLabel = new LabelType();
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapEnoObject(enoCalculatedExpression, lunaticLabel);
+        //
+        assertEquals("VTL", lunaticLabel.getType());
+    }
+
+}


### PR DESCRIPTION
I thought implementation was done for Lunatic labels' "type" property, however there was null values in the result.

To be fixed (+add tests) in this branch.