### PR TITLE
add a child sequence for loops that don't have a filter on their occurrences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>eno-core</artifactId>
 
 
-	<version>2.4.3</version>
+	<version>2.4.4</version>
 
 
 	<packaging>jar</packaging>

--- a/src/main/resources/xslt/outputs/ddi/models.xsl
+++ b/src/main/resources/xslt/outputs/ddi/models.xsl
@@ -923,12 +923,25 @@
                     </d:ControlConstructReference>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
-                        <xsl:with-param name="driver" select="." tunnel="yes"/>
-                    </xsl:apply-templates>
+                    <d:ControlConstructReference>
+                        <r:Agency><xsl:value-of select="$agency"/></r:Agency>
+                        <r:ID><xsl:value-of select="concat(enoddi33:get-id($source-context),'-SEQ')"/></r:ID>
+                        <r:Version><xsl:value-of select="enoddi33:get-version($source-context)"/></r:Version>
+                        <r:TypeOfObject>Sequence</r:TypeOfObject>
+                    </d:ControlConstructReference>
                 </xsl:otherwise>
             </xsl:choose>
         </d:Loop>
+        <xsl:if test="not(enoddi33:get-loop-filter($source-context) != '')">
+            <d:Sequence>
+                <r:Agency><xsl:value-of select="$agency"/></r:Agency>
+                <r:ID><xsl:value-of select="concat(enoddi33:get-id($source-context),'-SEQ')"/></r:ID>
+                <r:Version><xsl:value-of select="enoddi33:get-version($source-context)"/></r:Version>
+                <xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
+                    <xsl:with-param name="driver" select="." tunnel="yes"/>
+                </xsl:apply-templates>
+            </d:Sequence>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="StatementItem" match="driver-StatementItem//Instruction[not(ancestor::driver-InterviewerInstructionReference)]" mode="model">

--- a/src/main/resources/xslt/outputs/ddi/models.xsl
+++ b/src/main/resources/xslt/outputs/ddi/models.xsl
@@ -1224,21 +1224,21 @@
             <r:Version><xsl:value-of select="enoddi33:get-version($source-context)"/></r:Version>
             <xsl:for-each select="$related-questions//Question">
                 <xsl:if test="not(preceding-sibling::Question[@id = current()/@id])">
-                    <d:SourceQuestion>
+                    <d:InputQuestionReference>
                         <r:Agency><xsl:value-of select="$agency"/></r:Agency>
                         <r:ID><xsl:value-of select="@id"/></r:ID>
                         <r:Version><xsl:value-of select="enoddi33:get-version($source-context)"/></r:Version>
                         <r:TypeOfObject><xsl:value-of select="@type"/></r:TypeOfObject>
-                    </d:SourceQuestion>
+                    </d:InputQuestionReference>
                 </xsl:if>
             </xsl:for-each>
             <xsl:for-each select="$related-variables">
-                <d:SourceVariable>
+                <d:InputVariableReference>
                     <r:Agency><xsl:value-of select="$agency"/></r:Agency>
                     <r:ID><xsl:value-of select="enoddi33:get-id(.)"/></r:ID>
                     <r:Version><xsl:value-of select="enoddi33:get-version($source-context)"/></r:Version>
                     <r:TypeOfObject>Variable</r:TypeOfObject>
-                </d:SourceVariable>
+                </d:InputVariableReference>
             </xsl:for-each>
             <xsl:apply-templates select="eno:child-fields($source-context)" mode="source">
                 <xsl:with-param name="driver" select="." tunnel="yes"/>

--- a/src/main/resources/xslt/pre-processing/ddi/dereferencing.xsl
+++ b/src/main/resources/xslt/pre-processing/ddi/dereferencing.xsl
@@ -67,6 +67,8 @@
         <dereferencing:reference-name name="r:TargetParameterReference"/>
         <dereferencing:reference-name name="r:BasedOnReference"/>
         <dereferencing:reference-name name="r:ExternalURLReference"/>
+        <dereferencing:reference-name name="d:InputQuestionReference"/>
+        <dereferencing:reference-name name="d:InputVariableReference"/>
         <!-- Celle-ci, je doute -->
         <dereferencing:reference-name name="r:ProcessingInstructionReference"/>
     </xsl:variable>

--- a/src/test/resources/pogues-xml-to-ddi/out.xml
+++ b/src/test/resources/pogues-xml-to-ddi/out.xml
@@ -15237,54 +15237,54 @@
             <r:Agency>fr.insee</r:Agency>
             <r:ID>jbcggtca-GI</r:ID>
             <r:Version>1</r:Version>
-            <d:SourceQuestion>
+            <d:InputQuestionReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>j4nwc63q</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </d:SourceQuestion>
-            <d:SourceVariable>
+            </d:InputQuestionReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnt6wl</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnnrzt</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnizqp</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnq58i</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnol5q</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnrvw8</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
-            <d:SourceVariable>
+            </d:InputVariableReference>
+            <d:InputVariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>kbrnxlbs</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
-            </d:SourceVariable>
+            </d:InputVariableReference>
             <r:CommandCode>
                <r:Command>
                   <r:ProgramLanguage>xpath</r:ProgramLanguage>

--- a/src/test/resources/pogues-xml-to-ddi/out.xml
+++ b/src/test/resources/pogues-xml-to-ddi/out.xml
@@ -906,11 +906,22 @@
             </d:StepValue>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>kiq5u8d5</r:ID>
+               <r:ID>kiq7bjam-SEQ</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Sequence</r:TypeOfObject>
             </d:ControlConstructReference>
          </d:Loop>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>kiq7bjam-SEQ</r:ID>
+            <r:Version>1</r:Version>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>kiq5u8d5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
          <d:Loop>
             <r:Agency>fr.insee</r:Agency>
             <r:ID>kiq7cbgo</r:ID>
@@ -920,11 +931,22 @@
             </d:ConstructName>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>kiq5xw5p</r:ID>
+               <r:ID>kiq7cbgo-SEQ</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Sequence</r:TypeOfObject>
             </d:ControlConstructReference>
          </d:Loop>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>kiq7cbgo-SEQ</r:ID>
+            <r:Version>1</r:Version>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>kiq5xw5p</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
          <d:IfThenElse>
             <r:Agency>fr.insee</r:Agency>
             <r:ID>j6p6my1d-a-j6p0np9q</r:ID>


### PR DESCRIPTION
The added Sequence has no "d:TypeOfSequence". It makes it invisible to eno-v2, since it is not linked to a Driver.

Tested with ddi2lunatic on ENL : 0 difference on generation.
