### PR TITLE
Ci/v3 remove lunatic cloning

### DIFF
--- a/.github/workflows/v3-build-docker.yml
+++ b/.github/workflows/v3-build-docker.yml
@@ -7,7 +7,6 @@ on:
       - v3.*
 
 env:
-  LUNATIC_BRANCH: dev-eno-v3
   POGUES_BRANCH: main
 
 jobs:
@@ -24,17 +23,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: Checkout Lunatic model repo
-        uses: actions/checkout@v3
-        with:
-          repository: InseeFr/Lunatic-Model
-          ref: ${{ env.LUNATIC_BRANCH }}
-          path: Lunatic-model
-
-      - name: Build Lunatic model
-        working-directory: ./Lunatic-model
-        run: mvn install -Djar.finalName="lunatic-model" -B -V --file pom.xml
 
       - name: Checkout Pogues model repo
         uses: actions/checkout@v3

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,12 @@ dependencyResolutionManagement {
 
     repositories {
         mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots"
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
         // Temporary config for private maven repository (for Pogues-Model and Lunatic-Model)
         maven { url System.properties['urlMavenRepo'] }
         // Temporary config if you choose to install Pogues-Model and Lunatic-Model locally


### PR DESCRIPTION
Depends on #626 

Now that Lunatic-Model is published in maven public central and snapshot repositories, there is no need to checkout Lunatic-Model repo and install it locally in the CI workflow!
