### PR TITLE
Refactor/v3 code lists

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -2,6 +2,7 @@ package fr.insee.eno.core.model;
 
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
+import fr.insee.eno.core.model.code.CodeList;
 import fr.insee.eno.core.model.declaration.Declaration;
 import fr.insee.eno.core.model.label.QuestionnaireLabel;
 import fr.insee.eno.core.model.navigation.Control;
@@ -101,5 +102,8 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
     @DDI("getResourcePackageArray(0).getQuestionSchemeArray(0).getQuestionGridList()")
     @Lunatic("getComponents()")
     private final List<MultipleResponseQuestion> multipleResponseQuestions = new ArrayList<>();
+
+    @DDI("getResourcePackageArray(0).getCodeListSchemeArray(0).getCodeListList()")
+    List<CodeList> codeLists = new ArrayList<>();
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/code/CodeList.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/code/CodeList.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Context(format = Format.DDI, type = CodeListType.class)
 public class CodeList extends EnoIdentifiableObject {
 
-    @DDI("getLabelArray(0).getContentArray(0).getStringValue()")
+    @DDI("!getLabelList().isEmpty() ? getLabelArray(0).getContentArray(0).getStringValue() : null")
     String name;
 
     @DDI("getCodeList()")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/MultipleChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/MultipleChoiceQuestion.java
@@ -44,7 +44,7 @@ public abstract class MultipleChoiceQuestion extends MultipleResponseQuestion {
          */
         @DDI("getOutParameterList()")
         @Lunatic("getResponses()")
-        List<CodeResponse> codeList = new ArrayList<>();
+        List<CodeResponse> codeResponses = new ArrayList<>();
 
         /** Lunatic component type property.
          * This should be inserted by Lunatic-Model serializer later on. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/MultipleChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/MultipleChoiceQuestion.java
@@ -45,6 +45,7 @@ public abstract class MultipleChoiceQuestion extends MultipleResponseQuestion {
         @DDI("getOutParameterList()")
         @Lunatic("getResponses()")
         List<CodeResponse> codeResponses = new ArrayList<>();
+        // TODO: refactor the mapping of these using code lists somehow maybe
 
         /** Lunatic component type property.
          * This should be inserted by Lunatic-Model serializer later on. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/TableCell.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/TableCell.java
@@ -1,14 +1,12 @@
 package fr.insee.eno.core.model.question;
 
 import datacollection33.GridResponseDomainInMixedType;
-import datacollection33.QuestionItemType;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.model.code.CodeItem;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.BodyCell;
-import fr.insee.lunatic.model.flat.Datepicker;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -104,9 +102,11 @@ public abstract class TableCell extends EnoObject {
                 "T(fr.insee.eno.core.model.question.UniqueChoiceQuestion.DisplayFormat).DROPDOWN : null")
         UniqueChoiceQuestion.DisplayFormat displayFormat;
 
-        @DDI("#index.get(#this.getResponseDomain().getCodeListReference().getIDArray(0).getStringValue()).getCodeList()")
+        @DDI("getResponseDomain().getCodeListReference().getIDArray(0).getStringValue()")
+        String codeListReference;
+
         @Lunatic("getOptions()")
-        List<CodeItem> codeList = new ArrayList<>();
+        List<CodeItem> codeItems = new ArrayList<>();
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/TableQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/TableQuestion.java
@@ -48,14 +48,22 @@ public class TableQuestion extends MultipleResponseQuestion {
     @Lunatic("setComponentType(T(fr.insee.lunatic.model.flat.ComponentTypeEnum).valueOf(#param))")
     String lunaticComponentType = "TABLE";
 
-    /** Code list that contains header info. */
-    @DDI("#index.get(#this.getGridDimensionList().?[#this.getRank().intValue() == 2].get(0)" +
-            ".getCodeDomain().getCodeListReference().getIDArray(0).getStringValue())")
+    /** Reference of the code list that contains header info. */
+    @DDI("getGridDimensionList().?[#this.getRank().intValue() == 2].get(0)" +
+            ".getCodeDomain().getCodeListReference().getIDArray(0).getStringValue()")
+    String headerCodeListReference;
+
+    /** Code list that contains header info.
+     * In DDI, inserted here through a processing. */
     CodeList header;
 
-    /** Code list that contains left column info. */
-    @DDI("#index.get(#this.getGridDimensionList().?[#this.getRank().intValue() == 1].get(0)" +
-            ".getCodeDomain().getCodeListReference().getIDArray(0).getStringValue())")
+    /** Code list that contains header info. */
+    @DDI("getGridDimensionList().?[#this.getRank().intValue() == 1].get(0)" +
+            ".getCodeDomain().getCodeListReference().getIDArray(0).getStringValue()")
+    String leftColumnCodeListReference;
+
+    /** Code list that contains left column info.
+     * In DDI, inserted here through a processing. */
     CodeList leftColumn;
 
     /** Considering that out parameters are sorted in the same order as GridResponseDomainInMixed objects in DDI. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
@@ -58,13 +58,16 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
             "T(fr.insee.eno.core.model.question.UniqueChoiceQuestion).convertDisplayFormatToLunatic(#param))")
     DisplayFormat displayFormat;
 
+    /** Reference to the code list that contain the modalities of the question. */
+    @DDI("getResponseDomain().getCodeListReference().getIDArray(0).getStringValue()")
+    String codeListReference;
+
     /**
      * List of modalities of the unique choice question.
+     * In DDI, these are inserted here through a processing.
      */
-    @DDI("#index.get(#this.getResponseDomain().getCodeListReference().getIDArray(0).getStringValue()).getCodeList()")
     @Lunatic("getOptions()")
-    List<CodeItem> codeList = new ArrayList<>();
-    //TODO: map this only once maybe (currently a list of object is created for each unique choice question)
+    List<CodeItem> codeItems = new ArrayList<>();
 
     /**
      * From DDI question item (that correspond to a unique choice question),

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/EnoProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/EnoProcessing.java
@@ -60,6 +60,7 @@ public class EnoProcessing {
         new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
         new DDIInsertDeclarations().apply(enoQuestionnaire);
         new DDIInsertControls().apply(enoQuestionnaire);
+        new DDIInsertCodeLists().apply(enoQuestionnaire);
         new DDIResolveVariableReferencesInLabels(enoCatalog).apply(enoQuestionnaire);
         new DDIResolveSequencesStructure().apply(enoQuestionnaire);
         new DDIResolveFiltersScope().apply(enoQuestionnaire);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/impl/DDIInsertCodeLists.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/impl/DDIInsertCodeLists.java
@@ -1,0 +1,61 @@
+package fr.insee.eno.core.processing.impl;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.code.CodeList;
+import fr.insee.eno.core.model.question.TableCell;
+import fr.insee.eno.core.model.question.TableQuestion;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import fr.insee.eno.core.processing.InProcessingInterface;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** In DDI, code lists are mapped at the questionnaire level. In other places, only the reference of the code list
+ * is mapped. This processing insert code lists in these places. */
+public class DDIInsertCodeLists implements InProcessingInterface {
+
+    private final Map<String, CodeList> codeListMap = new HashMap<>();
+
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        // Put code lists in a local map
+        enoQuestionnaire.getCodeLists().forEach(codeList -> codeListMap.put(codeList.getId(), codeList));
+        // Insert code lists in unique choice questions
+        enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(UniqueChoiceQuestion.class::isInstance)
+                .map(UniqueChoiceQuestion.class::cast)
+                .forEach(this::insertCodeItems);
+        // Gather table question objects
+        List<TableQuestion> tableQuestions = enoQuestionnaire.getMultipleResponseQuestions().stream()
+                .filter(TableQuestion.class::isInstance)
+                .map(TableQuestion.class::cast)
+                .toList();
+        // Insert code lists in header and left column properties of table questions
+        tableQuestions.forEach(this::insertHeader);
+        tableQuestions.forEach(this::insertLeftColumn);
+        // Insert code lists in table cells that are a unique choice question
+        tableQuestions.forEach(tableQuestion ->
+                tableQuestion.getTableCells().stream()
+                        .filter(TableCell.UniqueChoiceCell.class::isInstance)
+                        .map(TableCell.UniqueChoiceCell.class::cast)
+                        .forEach(this::insertCodeItems));
+    }
+
+    private void insertCodeItems(UniqueChoiceQuestion uniqueChoiceQuestion) {
+        uniqueChoiceQuestion.setCodeItems(codeListMap.get(uniqueChoiceQuestion.getCodeListReference()).getCodeItems());
+    }
+
+    private void insertCodeItems(TableCell.UniqueChoiceCell uniqueChoiceCell) {
+        uniqueChoiceCell.setCodeItems(codeListMap.get(uniqueChoiceCell.getCodeListReference()).getCodeItems());
+    }
+
+    private void insertHeader(TableQuestion tableQuestion) {
+        tableQuestion.setHeader(codeListMap.get(tableQuestion.getHeaderCodeListReference()));
+    }
+
+    private void insertLeftColumn(TableQuestion tableQuestion) {
+        tableQuestion.setLeftColumn(codeListMap.get(tableQuestion.getLeftColumnCodeListReference()));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/impl/DDIResolveVariableReferencesInLabelsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/impl/DDIResolveVariableReferencesInLabelsTest.java
@@ -1,14 +1,25 @@
 package fr.insee.eno.core.processing.impl;
 
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.code.CodeList;
 import fr.insee.eno.core.model.label.Label;
+import fr.insee.eno.core.model.question.MultipleChoiceQuestion;
+import fr.insee.eno.core.model.question.SingleResponseQuestion;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.variable.CollectedVariable;
 import fr.insee.eno.core.model.variable.Variable;
+import fr.insee.eno.core.parsers.DDIParser;
 import fr.insee.eno.core.reference.EnoCatalog;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DDIResolveVariableReferencesInLabelsTest {
 
@@ -39,6 +50,130 @@ class DDIResolveVariableReferencesInLabelsTest {
         assertEquals("\"Label with reference \" || FOO", sequence.getLabel().getValue());
     }
 
-    // TODO: other tests on this
+    @Nested
+    class IntegrationTestLabels {
+
+        private static EnoQuestionnaire enoQuestionnaire;
+
+        @BeforeAll
+        static void mapQuestionnaire() throws DDIParsingException {
+            // Given
+            enoQuestionnaire = new EnoQuestionnaire();
+            DDIMapper ddiMapper = new DDIMapper();
+            ddiMapper.mapDDI(
+                    DDIParser.parse(DDIResolveVariableReferencesInLabelsTest.class.getClassLoader()
+                            .getResourceAsStream("integration/ddi/ddi-labels.xml")),
+                    enoQuestionnaire);
+            EnoCatalog enoCatalog = new EnoCatalog(enoQuestionnaire);
+            new DDIInsertDeclarations().apply(enoQuestionnaire);
+            new DDIInsertControls().apply(enoQuestionnaire);
+            new DDIInsertCodeLists().apply(enoQuestionnaire);
+            // When
+            new DDIResolveVariableReferencesInLabels(enoCatalog).apply(enoQuestionnaire);
+            // Then
+            // -> tests
+        }
+
+        @Test
+        void sequenceLabel() {
+            assertEquals("\"Static sequence name\"",
+                    enoQuestionnaire.getSequences().get(0).getLabel().getValue());
+            assertEquals("\"Dynamic sequence name: \" || Q1",
+                    enoQuestionnaire.getSequences().get(1).getLabel().getValue().trim());
+        }
+
+        @Test
+        void subsequenceLabel() {
+            assertEquals("\"Static subsequence name\"",
+                    enoQuestionnaire.getSubsequences().get(0).getLabel().getValue());
+            assertEquals("\"Dynamic subsequence name: \" || Q1",
+                    enoQuestionnaire.getSubsequences().get(1).getLabel().getValue().trim());
+        }
+
+        @Test
+        void declarationOnSequence() {
+            assertEquals("\"Static declaration on sequence\"",
+                    enoQuestionnaire.getSequences().get(0).getInstructions().get(0).getLabel().getValue());
+            assertEquals("\"Dynamic declaration on sequence: \" || Q1",
+                    enoQuestionnaire.getSequences().get(1).getInstructions().get(0).getLabel().getValue().trim());
+        }
+
+        @Test
+        void declarationOnSubsequence() {
+            assertEquals("\"Static declaration on subsequence\"",
+                    enoQuestionnaire.getSubsequences().get(0).getInstructions().get(0).getLabel().getValue());
+            assertEquals("\"Dynamic declaration on subsequence: \" || Q1",
+                    enoQuestionnaire.getSubsequences().get(1).getInstructions().get(0).getLabel().getValue().trim());
+        }
+
+        /** Question label + declarations, instructions and controls within it
+         * (so that we don't repeat the search of the questions).  */
+        @Test
+        void labelsWithinQuestion() {
+            //
+            Optional<SingleResponseQuestion> question1 = enoQuestionnaire.getSingleResponseQuestions().stream()
+                    .filter(question -> "Q1".equals(question.getName())).findAny();
+            assertTrue(question1.isPresent());
+            assertEquals("\"Static question name\"",
+                    question1.get().getLabel().getValue());
+            assertEquals("\"Static declaration before the question.\"",
+                    question1.get().getDeclarations().get(0).getLabel().getValue());
+            assertEquals("\"Static declaration after the question.\"",
+                    question1.get().getInstructions().get(0).getLabel().getValue());
+            assertEquals("\"Static control message\"",
+                    question1.get().getControls().get(0).getMessage().getValue());
+            //
+            Optional<SingleResponseQuestion> question2 = enoQuestionnaire.getSingleResponseQuestions().stream()
+                    .filter(question -> "Q2".equals(question.getName())).findAny();
+            assertTrue(question2.isPresent());
+            assertEquals("\"Dynamic question name: \" || Q1",
+                    question2.get().getLabel().getValue().trim());
+            assertEquals("\"Dynamic declaration before the question: \" || Q1",
+                    question2.get().getDeclarations().get(0).getLabel().getValue().trim());
+            assertEquals("\"Dynamic declaration after the question: \" || Q1",
+                    question2.get().getInstructions().get(0).getLabel().getValue().trim());
+            assertEquals("\"Dynamic control message: \" || Q1",
+                    question2.get().getControls().get(0).getMessage().getValue().trim());
+        }
+
+        @Test
+        void codeList_codeItemsLabel() {
+            //
+            Optional<CodeList> staticCodeList = enoQuestionnaire.getCodeLists().stream()
+                    .filter(codeList -> "STATIC_CODE_LIST".equals(codeList.getName())).findAny();
+            assertTrue(staticCodeList.isPresent());
+            assertEquals("\"Static code 1\"",
+                    staticCodeList.get().getCodeItems().get(0).getLabel().getValue());
+            assertEquals("\"Static code 2\"",
+                    staticCodeList.get().getCodeItems().get(1).getLabel().getValue());
+            //
+            Optional<CodeList> dynamicCodeList = enoQuestionnaire.getCodeLists().stream()
+                    .filter(codeList -> "DYNAMIC_CODE_LIST".equals(codeList.getName())).findAny();
+            assertTrue(dynamicCodeList.isPresent());
+            assertEquals("\"Dynamic code 1: \" || Q1",
+                    dynamicCodeList.get().getCodeItems().get(0).getLabel().getValue().trim());
+            assertEquals("\"Dynamic code 2: \" || Q1",
+                    dynamicCodeList.get().getCodeItems().get(1).getLabel().getValue().trim());
+        }
+
+        /** Note this test will be redundant with the previous one if we refactor
+         * multiple choice questions mapping using code lists. */
+        @Test
+        void multipleChoiceQuestion_codeResponsesLabel() {
+            //
+            MultipleChoiceQuestion.Simple mcq1 = (MultipleChoiceQuestion.Simple)
+                    enoQuestionnaire.getMultipleResponseQuestions().get(0);
+            assertEquals("\"Static code 1\"", mcq1.getCodeResponses().get(0).getLabel().getValue());
+            assertEquals("\"Static code 2\"", mcq1.getCodeResponses().get(1).getLabel().getValue());
+            //
+            MultipleChoiceQuestion.Simple mcq2 = (MultipleChoiceQuestion.Simple)
+                    enoQuestionnaire.getMultipleResponseQuestions().get(1);
+            assertEquals("\"Dynamic code 1: \" || Q1",
+                    mcq2.getCodeResponses().get(0).getLabel().getValue().trim());
+            assertEquals("\"Dynamic code 2: \" || Q1",
+                    mcq2.getCodeResponses().get(1).getLabel().getValue().trim());
+        }
+
+    }
 
 }

--- a/eno-core/src/test/resources/integration/ddi/ddi-labels.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-labels.xml
@@ -1,0 +1,1668 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+              xmlns:a="ddi:archive:3_3"
+              xmlns:d="ddi:datacollection:3_3"
+              xmlns:g="ddi:group:3_3"
+              xmlns:l="ddi:logicalproduct:3_3"
+              xmlns:r="ddi:reusable:3_3"
+              xmlns:s="ddi:studyunit:3_3"
+              xmlns:xhtml="http://www.w3.org/1999/xhtml"
+              xmlns:xs="http://www.w3.org/2001/XMLSchema"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+              isMaintainable="true"><!--Eno version : 2.4.1-pairwise. Generation date : 26/07/2023 - 8:45:01-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-lkgwbz1e</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Labels</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-lkgwbz1e</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw4v7r</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static declaration on sequence"</d:Text>
+               </d:LiteralText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw5f3l</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static declaration on subsequence"</d:Text>
+               </d:LiteralText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwbcj4</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static declaration after the question."</d:Text>
+               </d:LiteralText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw83gj-CI-0-II-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">warning</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static control message"</d:Text>
+               </d:LiteralText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwbmbn</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic declaration on sequence: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwhgt4</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic declaration on subsequence: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwozcf</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic declaration after the question: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwt260-CI-0-II-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">warning</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic control message: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-lkgwbz1e</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Labels</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwb7kj</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw93vs</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwb7kj</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Static sequence name"</r:Content>
+            </r:Label>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw4v7r</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw4ll2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw4ll2</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SS1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Static subsequence name"</r:Content>
+            </r:Label>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw5f3l</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">submodule</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwi1d3-SI</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>StatementItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj-CI-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>ComputationItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid1wnz-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw93vs</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S2</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Dynamic sequence name: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwbmbn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw9h1r</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw9h1r</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SS2</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Dynamic subsequence name: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwhgt4</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">submodule</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwe557-SI</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>StatementItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260-CI-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>ComputationItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid7ahs-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw83gj-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkid1wnz-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">UCQ1</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid1wnz</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkij6vip-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">MCQ1</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwt260-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkid7ahs-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">UCQ2</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid7ahs</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijhbsn-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">MCQ2</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:ComputationItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw83gj-CI-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Control with static message</r:String>
+            </d:ConstructName>
+            <r:Description>
+               <r:Content xml:lang="fr-FR">Control with static message</r:Content>
+            </r:Description>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj-CI-0-II-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfComputationItem controlledVocabularyID="INSEE-TOCI-CL-1">informational</d:TypeOfComputationItem>
+            <r:CommandCode>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:CommandContent>true</r:CommandContent>
+               </r:Command>
+            </r:CommandCode>
+         </d:ComputationItem>
+         <d:ComputationItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwt260-CI-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Control with dynamic message</r:String>
+            </d:ConstructName>
+            <r:Description>
+               <r:Content xml:lang="fr-FR">Control with dynamic message</r:Content>
+            </r:Description>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260-CI-0-II-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfComputationItem controlledVocabularyID="INSEE-TOCI-CL-1">informational</d:TypeOfComputationItem>
+            <r:CommandCode>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:CommandContent>true</r:CommandContent>
+               </r:Command>
+            </r:CommandCode>
+         </d:ComputationItem>
+         <d:StatementItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwi1d3-SI</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:ConstructName>
+            <d:DisplayText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static declaration before the question."</d:Text>
+               </d:LiteralText>
+            </d:DisplayText>
+         </d:StatementItem>
+         <d:StatementItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwe557-SI</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:ConstructName>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:ConstructName>
+            <d:DisplayText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic declaration before the question: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+            </d:DisplayText>
+         </d:StatementItem>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw83gj</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q1</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgw83gj-RDOP-lkgwwkd1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Static question name"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="10">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgw83gj-RDOP-lkgwwkd1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="10"/>
+               </r:OutParameter>
+            </d:TextDomain>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwbcj4</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkid1wnz</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">UCQ1</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid1wnz-QOP-lkid6mrg</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ1</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid1wnz-RDOP-lkid6mrg</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid1wnz-QOP-lkid6mrg</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Unique choice question 1"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">radio-button</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkicwv7a</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid1wnz-RDOP-lkid6mrg</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkicwv7a</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwt260</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260-QOP-lkgwhof6</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q2</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgwt260-RDOP-lkgwhof6</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgwt260-QOP-lkgwhof6</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Dynamic question name: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:NominalDomain>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkgwt260-RDOP-lkgwhof6</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeSubsetInformation>
+                        <r:IncludedCode>
+                           <r:CodeReference>
+                              <r:Agency>fr.insee</r:Agency>
+                              <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                              <r:Version>1</r:Version>
+                              <r:TypeOfObject>Code</r:TypeOfObject>
+                           </r:CodeReference>
+                        </r:IncludedCode>
+                     </r:CodeSubsetInformation>
+                  </r:CodeRepresentation>
+                  <r:DefaultValue/>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:NominalDomain>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwozcf</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkid7ahs</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">UCQ2</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid7ahs-QOP-lkicwavs</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ2</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid7ahs-RDOP-lkicwavs</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid7ahs-QOP-lkicwavs</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Unique choice question 2"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">radio-button</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkicukhi</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkid7ahs-RDOP-lkicwavs</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkicukhi</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+         </d:QuestionItem>
+         <d:QuestionGrid>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkij6vip</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionGridName>
+               <r:String xml:lang="fr-FR">MCQ1</r:String>
+            </d:QuestionGridName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip-QOP-lkij837f</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ11</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip-QOP-lkij9tch</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ12</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkij6vip-RDOP-lkij837f</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkij6vip-QOP-lkij837f</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkij6vip-RDOP-lkij9tch</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkij6vip-QOP-lkij9tch</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Multiple choice question 1"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:GridDimension displayCode="false" displayLabel="false" rank="1">
+               <d:CodeDomain>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkicwv7a</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </d:CodeDomain>
+            </d:GridDimension>
+            <d:StructuredMixedGridResponseDomain>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkij6vip-RDOP-lkij837f</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkij6vip-RDOP-lkij9tch</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+            </d:StructuredMixedGridResponseDomain>
+         </d:QuestionGrid>
+         <d:QuestionGrid>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijhbsn</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionGridName>
+               <r:String xml:lang="fr-FR">MCQ2</r:String>
+            </d:QuestionGridName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn-QOP-lkij77ci</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ21</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn-QOP-lkijke8q</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ22</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkijhbsn-RDOP-lkij77ci</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkijhbsn-QOP-lkij77ci</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkijhbsn-RDOP-lkijke8q</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lkijhbsn-QOP-lkijke8q</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Multiple choice question 2"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:GridDimension displayCode="false" displayLabel="false" rank="1">
+               <d:CodeDomain>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkicukhi</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </d:CodeDomain>
+            </d:GridDimension>
+            <d:StructuredMixedGridResponseDomain>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkijhbsn-RDOP-lkij77ci</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lkijhbsn-RDOP-lkijke8q</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+            </d:StructuredMixedGridResponseDomain>
+         </d:QuestionGrid>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-lkicwv7a</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">STATIC_CODE_LIST</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lkicwv7a-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Static code 1"</r:Content>
+            </r:Label>
+         </l:Category>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lkicwv7a-2</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Static code 2"</r:Content>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-lkicukhi</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">DYNAMIC_CODE_LIST</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lkicukhi-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Dynamic code 1: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+         </l:Category>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lkicukhi-2</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Dynamic code 2: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENOLABELS-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENOLABELS</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkicwv7a</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">STATIC_CODE_LIST</r:Content>
+            </r:Label>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicwv7a-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lkicwv7a-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>STATIC1</r:Value>
+            </l:Code>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicwv7a-2</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lkicwv7a-2</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>STATIC2</r:Value>
+            </l:Code>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkicukhi</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">DYNAMIC_CODE_LIST</r:Content>
+            </r:Label>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicukhi-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lkicukhi-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>DYNAMIC1</r:Value>
+            </l:Code>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicukhi-2</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lkicukhi-2</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>DYNAMIC2</r:Value>
+            </l:Code>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgw4tqi</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q1 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj-QOP-lkgwwkd1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw83gj</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="10"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkicxd4v</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ1</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ1 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid1wnz-QOP-lkid6mrg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid1wnz</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkicwv7a</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijgspa</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ11</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">STATIC1 - "Static code 1"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip-QOP-lkij837f</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijk4dg</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ12</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">STATIC2 - "Static code 2"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip-QOP-lkij9tch</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkij6vip</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkgwist8</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q2 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260-QOP-lkgwhof6</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwt260</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkicrust</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ2</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ2 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid7ahs-QOP-lkicwavs</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkid7ahs</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lkicukhi</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijbtxh</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ21</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">DYNAMIC1 - "Dynamic code 1: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn-QOP-lkij77ci</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lkijcm4c</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ22</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">DYNAMIC2 - "Dynamic code 2: " || ¤lkgw83gj-QOP-lkgwwkd1¤ </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn-QOP-lkijke8q</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijhbsn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-lkgwbz1e-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-lkgwbz1e</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENOLABELS</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgw4tqi</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicxd4v</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijgspa</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijk4dg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkgwist8</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkicrust</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijbtxh</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lkijcm4c</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+                            l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-lkgwbz1e</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-lkgwbz1e</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-lkgwbz1e</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-lkgwbz1e</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-lkgwbz1e</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-lkgwbz1e</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                           xmlns:cm="ddi:comparative:3_3"
+                           xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                           xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-lkgwbz1e</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENOLABELS</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Labels questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-lkgwbz1e</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>

--- a/eno-core/src/test/resources/integration/lunatic/lunatic-labels.json
+++ b/eno-core/src/test/resources/integration/lunatic/lunatic-labels.json
@@ -1,0 +1,643 @@
+{
+  "id": "lkgwbz1e",
+  "modele": "ENOLABELS",
+  "enoCoreVersion": "2.4.1-pairwise",
+  "lunaticModelVersion": "2.3.2-rc7",
+  "generatingDate": "26-07-2023 08:45:27",
+  "missing": false,
+  "pagination": "question",
+  "maxPage": "10",
+  "label": {
+    "value": "Eno - Labels",
+    "type": "VTL|MD"
+  },
+  "components": [
+    {
+      "id": "lkgwb7kj",
+      "componentType": "Sequence",
+      "page": "1",
+      "label": {
+        "value": "\"I - \" || \"Static sequence name\"",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgwb7kj-lkgw4v7r",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Static declaration on sequence\"",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgwb7kj",
+          "page": "1",
+          "label": {
+            "value": "\"I - \" || \"Static sequence name\"",
+            "type": "VTL|MD"
+          }
+        }
+      }
+    },
+    {
+      "id": "lkgw4ll2",
+      "componentType": "Subsequence",
+      "page": "2",
+      "goToPage": "2",
+      "label": {
+        "value": "\"Static subsequence name\"",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgw4ll2-lkgw5f3l",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Static declaration on subsequence\"",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgwb7kj",
+          "page": "1",
+          "label": {
+            "value": "\"I - \" || \"Static sequence name\"",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw4ll2",
+          "page": "2",
+          "label": {
+            "value": "\"Static subsequence name\"",
+            "type": "VTL|MD"
+          }
+        }
+      }
+    },
+    {
+      "id": "lkgw83gj",
+      "componentType": "Input",
+      "mandatory": false,
+      "page": "3",
+      "maxLength": 10,
+      "label": {
+        "value": "\"➡ \" || \"Static question name\"",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgwi1d3-SI",
+          "declarationType": "STATEMENT",
+          "position": "BEFORE_QUESTION_TEXT",
+          "label": {
+            "value": "\"Static declaration before the question.\"",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "id": "lkgw83gj-lkgwbcj4",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Static declaration after the question.\"",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "controls": [
+        {
+          "id": "lkgw83gj-CI-0",
+          "typeOfControl": "CONSISTENCY",
+          "criticality": "WARN",
+          "control": {
+            "value": "not(true)",
+            "type": "VTL"
+          },
+          "errorMessage": {
+            "value": "\"Static control message\"",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgwb7kj",
+          "page": "1",
+          "label": {
+            "value": "\"I - \" || \"Static sequence name\"",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw4ll2",
+          "page": "2",
+          "label": {
+            "value": "\"Static subsequence name\"",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1"
+      ],
+      "response": {
+        "name": "Q1"
+      }
+    },
+    {
+      "id": "lkid1wnz",
+      "componentType": "Radio",
+      "mandatory": false,
+      "page": "4",
+      "label": {
+        "value": "\"➡ \" || \"Unique choice question 1\"",
+        "type": "VTL|MD"
+      },
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgwb7kj",
+          "page": "1",
+          "label": {
+            "value": "\"I - \" || \"Static sequence name\"",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw4ll2",
+          "page": "2",
+          "label": {
+            "value": "\"Static subsequence name\"",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "UCQ1"
+      ],
+      "options": [
+        {
+          "value": "STATIC1",
+          "label": {
+            "value": "\"Static code 1\"",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "value": "STATIC2",
+          "label": {
+            "value": "\"Static code 2\"",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "response": {
+        "name": "UCQ1"
+      }
+    },
+    {
+      "id": "lkij6vip",
+      "componentType": "CheckboxGroup",
+      "page": "5",
+      "label": {
+        "value": "\"➡ \" || \"Multiple choice question 1\"",
+        "type": "VTL|MD"
+      },
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgwb7kj",
+          "page": "1",
+          "label": {
+            "value": "\"I - \" || \"Static sequence name\"",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw4ll2",
+          "page": "2",
+          "label": {
+            "value": "\"Static subsequence name\"",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "MCQ11",
+        "MCQ12"
+      ],
+      "responses": [
+        {
+          "id": "lkij6vip-QOP-lkij837f",
+          "label": {
+            "value": "\"Static code 1\"",
+            "type": "VTL|MD"
+          },
+          "response": {
+            "name": "MCQ11"
+          }
+        },
+        {
+          "id": "lkij6vip-QOP-lkij9tch",
+          "label": {
+            "value": "\"Static code 2\"",
+            "type": "VTL|MD"
+          },
+          "response": {
+            "name": "MCQ12"
+          }
+        }
+      ]
+    },
+    {
+      "id": "lkgw93vs",
+      "componentType": "Sequence",
+      "page": "6",
+      "label": {
+        "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgw93vs-lkgwbmbn",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Dynamic declaration on sequence: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgw93vs",
+          "page": "6",
+          "label": {
+            "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1"
+      ]
+    },
+    {
+      "id": "lkgw9h1r",
+      "componentType": "Subsequence",
+      "page": "7",
+      "goToPage": "7",
+      "label": {
+        "value": "\"Dynamic subsequence name: \" || Q1",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgw9h1r-lkgwhgt4",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Dynamic declaration on subsequence: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgw93vs",
+          "page": "6",
+          "label": {
+            "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw9h1r",
+          "page": "7",
+          "label": {
+            "value": "\"Dynamic subsequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1"
+      ]
+    },
+    {
+      "id": "lkgwt260",
+      "componentType": "CheckboxBoolean",
+      "mandatory": false,
+      "page": "8",
+      "label": {
+        "value": "\"➡ \" || \"Dynamic question name: \" || Q1",
+        "type": "VTL|MD"
+      },
+      "declarations": [
+        {
+          "id": "lkgwe557-SI",
+          "declarationType": "STATEMENT",
+          "position": "BEFORE_QUESTION_TEXT",
+          "label": {
+            "value": "\"Dynamic declaration before the question: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "id": "lkgwt260-lkgwozcf",
+          "declarationType": "HELP",
+          "position": "AFTER_QUESTION_TEXT",
+          "label": {
+            "value": "\"Dynamic declaration after the question: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "controls": [
+        {
+          "id": "lkgwt260-CI-0",
+          "typeOfControl": "CONSISTENCY",
+          "criticality": "WARN",
+          "control": {
+            "value": "not(true)",
+            "type": "VTL"
+          },
+          "errorMessage": {
+            "value": "\"Dynamic control message: \" || Q1 ",
+            "type": "VTL|MD"
+          },
+          "bindingDependencies": [
+            "Q1"
+          ]
+        }
+      ],
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgw93vs",
+          "page": "6",
+          "label": {
+            "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw9h1r",
+          "page": "7",
+          "label": {
+            "value": "\"Dynamic subsequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1",
+        "Q2"
+      ],
+      "response": {
+        "name": "Q2"
+      }
+    },
+    {
+      "id": "lkid7ahs",
+      "componentType": "Radio",
+      "mandatory": false,
+      "page": "9",
+      "label": {
+        "value": "\"➡ \" || \"Unique choice question 2\"",
+        "type": "VTL|MD"
+      },
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgw93vs",
+          "page": "6",
+          "label": {
+            "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw9h1r",
+          "page": "7",
+          "label": {
+            "value": "\"Dynamic subsequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1",
+        "UCQ2"
+      ],
+      "options": [
+        {
+          "value": "DYNAMIC1",
+          "label": {
+            "value": "\"Dynamic code 1: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        {
+          "value": "DYNAMIC2",
+          "label": {
+            "value": "\"Dynamic code 2: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      ],
+      "response": {
+        "name": "UCQ2"
+      }
+    },
+    {
+      "id": "lkijhbsn",
+      "componentType": "CheckboxGroup",
+      "page": "10",
+      "label": {
+        "value": "\"➡ \" || \"Multiple choice question 2\"",
+        "type": "VTL|MD"
+      },
+      "conditionFilter": {
+        "value": "true",
+        "type": "VTL"
+      },
+      "hierarchy": {
+        "sequence": {
+          "id": "lkgw93vs",
+          "page": "6",
+          "label": {
+            "value": "\"II - \" || \"Dynamic sequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        },
+        "subSequence": {
+          "id": "lkgw9h1r",
+          "page": "7",
+          "label": {
+            "value": "\"Dynamic subsequence name: \" || Q1",
+            "type": "VTL|MD"
+          }
+        }
+      },
+      "bindingDependencies": [
+        "Q1",
+        "MCQ21",
+        "MCQ22"
+      ],
+      "responses": [
+        {
+          "id": "lkijhbsn-QOP-lkij77ci",
+          "label": {
+            "value": "\"Dynamic code 1: \" || Q1",
+            "type": "VTL|MD"
+          },
+          "response": {
+            "name": "MCQ21"
+          }
+        },
+        {
+          "id": "lkijhbsn-QOP-lkijke8q",
+          "label": {
+            "value": "\"Dynamic code 2: \" || Q1",
+            "type": "VTL|MD"
+          },
+          "response": {
+            "name": "MCQ22"
+          }
+        }
+      ]
+    }
+  ],
+  "variables": [
+    {
+      "variableType": "COLLECTED",
+      "name": "Q1",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "UCQ1",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "MCQ11",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "MCQ12",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "Q2",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "UCQ2",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "MCQ21",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    },
+    {
+      "variableType": "COLLECTED",
+      "name": "MCQ22",
+      "values": {
+        "PREVIOUS": null,
+        "COLLECTED": null,
+        "FORCED": null,
+        "EDITED": null,
+        "INPUTED": null
+      }
+    }
+  ],
+  "cleaning": {},
+  "resizing": {}
+}

--- a/eno-core/src/test/resources/integration/pogues/pogues-labels.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-labels.json
@@ -1,0 +1,664 @@
+{
+  "owner": "FAKEPERMISSION",
+  "FlowControl": [],
+  "ComponentGroup": [
+    {
+      "MemberReference": [
+        "lkgwb7kj",
+        "lkgw4ll2",
+        "lkgw83gj",
+        "lkid1wnz",
+        "lkij6vip",
+        "lkgw93vs",
+        "lkgw9h1r",
+        "lkgwt260",
+        "lkid7ahs",
+        "lkijhbsn",
+        "idendquest"
+      ],
+      "Label": [
+        "Components for page 1"
+      ],
+      "id": "lkgwqqx9",
+      "Name": "PAGE_1"
+    }
+  ],
+  "agency": "fr.insee",
+  "genericName": "QUESTIONNAIRE",
+  "Label": [
+    "Eno - Labels"
+  ],
+  "childQuestionnaireRef": [],
+  "Name": "ENOLABELS",
+  "Variables": {
+    "Variable": [
+      {
+        "Label": "Q1 label",
+        "id": "lkgw4tqi",
+        "type": "CollectedVariableType",
+        "Name": "Q1",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "10"
+        }
+      },
+      {
+        "Label": "UCQ1 label",
+        "id": "lkicxd4v",
+        "type": "CollectedVariableType",
+        "CodeListReference": "lkicwv7a",
+        "Name": "UCQ1",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": 1
+        }
+      },
+      {
+        "Label": "STATIC1 - \"Static code 1\"",
+        "id": "lkijgspa",
+        "type": "CollectedVariableType",
+        "Name": "MCQ11",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "STATIC2 - \"Static code 2\"",
+        "id": "lkijk4dg",
+        "type": "CollectedVariableType",
+        "Name": "MCQ12",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "Q2 label",
+        "id": "lkgwist8",
+        "type": "CollectedVariableType",
+        "Name": "Q2",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "UCQ2 label",
+        "id": "lkicrust",
+        "type": "CollectedVariableType",
+        "CodeListReference": "lkicukhi",
+        "Name": "UCQ2",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": 1
+        }
+      },
+      {
+        "Label": "DYNAMIC1 - \"Dynamic code 1: \" || $Q1$",
+        "id": "lkijbtxh",
+        "type": "CollectedVariableType",
+        "Name": "MCQ21",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "DYNAMIC2 - \"Dynamic code 2: \" || $Q1$",
+        "id": "lkijcm4c",
+        "type": "CollectedVariableType",
+        "Name": "MCQ22",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      }
+    ]
+  },
+  "lastUpdatedDate": "Wed Jul 26 2023 10:44:57 GMT+0200 (heure d’été d’Europe centrale)",
+  "DataCollection": [
+    {
+      "id": "eec-dc1-2017",
+      "uri": "http://ddi:fr.insee:DataCollection.eec-dc1-2017"
+    }
+  ],
+  "final": false,
+  "flowLogic": "FILTER",
+  "id": "lkgwbz1e",
+  "TargetMode": [
+    "CAPI",
+    "CATI",
+    "CAWI",
+    "PAPI"
+  ],
+  "CodeLists": {
+    "CodeList": [
+      {
+        "Label": "STATIC_CODE_LIST",
+        "id": "lkicwv7a",
+        "Code": [
+          {
+            "Parent": "",
+            "Label": "\"Static code 1\"",
+            "Value": "STATIC1"
+          },
+          {
+            "Parent": "",
+            "Label": "\"Static code 2\"",
+            "Value": "STATIC2"
+          }
+        ],
+        "Name": ""
+      },
+      {
+        "Label": "DYNAMIC_CODE_LIST",
+        "id": "lkicukhi",
+        "Code": [
+          {
+            "Parent": "",
+            "Label": "\"Dynamic code 1: \" || $Q1$",
+            "Value": "DYNAMIC1"
+          },
+          {
+            "Parent": "",
+            "Label": "\"Dynamic code 2: \" || $Q1$",
+            "Value": "DYNAMIC2"
+          }
+        ],
+        "Name": ""
+      }
+    ]
+  },
+  "formulasLanguage": "VTL",
+  "Child": [
+    {
+      "Control": [],
+      "depth": 1,
+      "FlowControl": [],
+      "genericName": "MODULE",
+      "Label": [
+        "\"Static sequence name\""
+      ],
+      "id": "lkgwb7kj",
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [
+        {
+          "declarationType": "HELP",
+          "Text": "\"Static declaration on sequence\"",
+          "id": "lkgw4v7r",
+          "position": "AFTER_QUESTION_TEXT",
+          "DeclarationMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ]
+        }
+      ],
+      "type": "SequenceType",
+      "Child": [
+        {
+          "Control": [],
+          "depth": 2,
+          "FlowControl": [],
+          "genericName": "SUBMODULE",
+          "Label": [
+            "\"Static subsequence name\""
+          ],
+          "id": "lkgw4ll2",
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [
+            {
+              "declarationType": "HELP",
+              "Text": "\"Static declaration on subsequence\"",
+              "id": "lkgw5f3l",
+              "position": "AFTER_QUESTION_TEXT",
+              "DeclarationMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ]
+            }
+          ],
+          "type": "SequenceType",
+          "Child": [
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkgw4tqi",
+                  "id": "lkgwwkd1",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "10"
+                  }
+                }
+              ],
+              "Control": [
+                {
+                  "post_collect": false,
+                  "Description": "Control with static message",
+                  "Expression": "true",
+                  "during_collect": false,
+                  "criticity": "INFO",
+                  "FailMessage": "\"Static control message\"",
+                  "id": "lkicm0j2"
+                }
+              ],
+              "depth": 3,
+              "FlowControl": [],
+              "Label": [
+                "\"Static question name\""
+              ],
+              "id": "lkgw83gj",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [
+                {
+                  "declarationType": "HELP",
+                  "Text": "\"Static declaration before the question.\"",
+                  "id": "lkgwi1d3",
+                  "position": "BEFORE_QUESTION_TEXT",
+                  "DeclarationMode": [
+                    "CAPI",
+                    "CATI",
+                    "CAWI",
+                    "PAPI"
+                  ]
+                },
+                {
+                  "declarationType": "HELP",
+                  "Text": "\"Static declaration after the question.\"",
+                  "id": "lkgwbcj4",
+                  "position": "AFTER_QUESTION_TEXT",
+                  "DeclarationMode": [
+                    "CAPI",
+                    "CATI",
+                    "CAWI",
+                    "PAPI"
+                  ]
+                }
+              ],
+              "type": "QuestionType",
+              "questionType": "SIMPLE",
+              "Name": "Q1"
+            },
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkicxd4v",
+                  "id": "lkid6mrg",
+                  "mandatory": false,
+                  "CodeListReference": "lkicwv7a",
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "visualizationHint": "RADIO",
+                    "type": "TextDatatypeType",
+                    "MaxLength": 1
+                  }
+                }
+              ],
+              "Control": [],
+              "depth": 3,
+              "FlowControl": [],
+              "Label": [
+                "\"Unique choice question 1\""
+              ],
+              "ClarificationQuestion": [],
+              "id": "lkid1wnz",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [],
+              "type": "QuestionType",
+              "questionType": "SINGLE_CHOICE",
+              "Name": "UCQ1"
+            },
+            {
+              "FlowControl": [],
+              "Label": [
+                "\"Multiple choice question 1\""
+              ],
+              "ResponseStructure": {
+                "Attribute": [],
+                "Mapping": [
+                  {
+                    "MappingSource": "lkij837f",
+                    "MappingTarget": "1"
+                  },
+                  {
+                    "MappingSource": "lkij9tch",
+                    "MappingTarget": "2"
+                  }
+                ],
+                "Dimension": [
+                  {
+                    "dimensionType": "PRIMARY",
+                    "dynamic": "0",
+                    "CodeListReference": "lkicwv7a"
+                  },
+                  {
+                    "dimensionType": "MEASURE",
+                    "dynamic": "0"
+                  }
+                ]
+              },
+              "type": "QuestionType",
+              "Name": "MCQ1",
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkijgspa",
+                  "id": "lkij837f",
+                  "Datatype": {
+                    "typeName": "BOOLEAN",
+                    "type": "BooleanDatatypeType"
+                  }
+                },
+                {
+                  "CollectedVariableReference": "lkijk4dg",
+                  "id": "lkij9tch",
+                  "Datatype": {
+                    "typeName": "BOOLEAN",
+                    "type": "BooleanDatatypeType"
+                  }
+                }
+              ],
+              "Control": [],
+              "depth": 3,
+              "ClarificationQuestion": [],
+              "id": "lkij6vip",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [],
+              "questionType": "MULTIPLE_CHOICE"
+            }
+          ],
+          "Name": "SS1"
+        }
+      ],
+      "Name": "S1"
+    },
+    {
+      "Control": [],
+      "depth": 1,
+      "FlowControl": [],
+      "genericName": "MODULE",
+      "Label": [
+        "\"Dynamic sequence name: \" || $Q1$"
+      ],
+      "id": "lkgw93vs",
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [
+        {
+          "declarationType": "HELP",
+          "Text": "\"Dynamic declaration on sequence: \" || $Q1$",
+          "id": "lkgwbmbn",
+          "position": "AFTER_QUESTION_TEXT",
+          "DeclarationMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ]
+        }
+      ],
+      "type": "SequenceType",
+      "Child": [
+        {
+          "Control": [],
+          "depth": 2,
+          "FlowControl": [],
+          "genericName": "SUBMODULE",
+          "Label": [
+            "\"Dynamic subsequence name: \" || $Q1$"
+          ],
+          "id": "lkgw9h1r",
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [
+            {
+              "declarationType": "HELP",
+              "Text": "\"Dynamic declaration on subsequence: \" || $Q1$",
+              "id": "lkgwhgt4",
+              "position": "AFTER_QUESTION_TEXT",
+              "DeclarationMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ]
+            }
+          ],
+          "type": "SequenceType",
+          "Child": [
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkgwist8",
+                  "id": "lkgwhof6",
+                  "mandatory": false,
+                  "Datatype": {
+                    "typeName": "BOOLEAN",
+                    "type": "BooleanDatatypeType"
+                  }
+                }
+              ],
+              "Control": [
+                {
+                  "post_collect": false,
+                  "Description": "Control with dynamic message",
+                  "Expression": "true",
+                  "during_collect": false,
+                  "criticity": "INFO",
+                  "FailMessage": "\"Dynamic control message: \" || $Q1$",
+                  "id": "lkid4jl6"
+                }
+              ],
+              "depth": 3,
+              "FlowControl": [],
+              "Label": [
+                "\"Dynamic question name: \" || $Q1$"
+              ],
+              "id": "lkgwt260",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [
+                {
+                  "declarationType": "HELP",
+                  "Text": "\"Dynamic declaration before the question: \" || $Q1$",
+                  "id": "lkgwe557",
+                  "position": "BEFORE_QUESTION_TEXT",
+                  "DeclarationMode": [
+                    "CAPI",
+                    "CATI",
+                    "CAWI",
+                    "PAPI"
+                  ]
+                },
+                {
+                  "declarationType": "HELP",
+                  "Text": "\"Dynamic declaration after the question: \" || $Q1$",
+                  "id": "lkgwozcf",
+                  "position": "AFTER_QUESTION_TEXT",
+                  "DeclarationMode": [
+                    "CAPI",
+                    "CATI",
+                    "CAWI",
+                    "PAPI"
+                  ]
+                }
+              ],
+              "type": "QuestionType",
+              "questionType": "SIMPLE",
+              "Name": "Q2"
+            },
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkicrust",
+                  "id": "lkicwavs",
+                  "mandatory": false,
+                  "CodeListReference": "lkicukhi",
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "visualizationHint": "RADIO",
+                    "type": "TextDatatypeType",
+                    "MaxLength": 1
+                  }
+                }
+              ],
+              "Control": [],
+              "depth": 3,
+              "FlowControl": [],
+              "Label": [
+                "\"Unique choice question 2\""
+              ],
+              "ClarificationQuestion": [],
+              "id": "lkid7ahs",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [],
+              "type": "QuestionType",
+              "questionType": "SINGLE_CHOICE",
+              "Name": "UCQ2"
+            },
+            {
+              "FlowControl": [],
+              "Label": [
+                "\"Multiple choice question 2\""
+              ],
+              "ResponseStructure": {
+                "Attribute": [],
+                "Mapping": [
+                  {
+                    "MappingSource": "lkij77ci",
+                    "MappingTarget": "1"
+                  },
+                  {
+                    "MappingSource": "lkijke8q",
+                    "MappingTarget": "2"
+                  }
+                ],
+                "Dimension": [
+                  {
+                    "dimensionType": "PRIMARY",
+                    "dynamic": "0",
+                    "CodeListReference": "lkicukhi"
+                  },
+                  {
+                    "dimensionType": "MEASURE",
+                    "dynamic": "0"
+                  }
+                ]
+              },
+              "type": "QuestionType",
+              "Name": "MCQ2",
+              "Response": [
+                {
+                  "CollectedVariableReference": "lkijbtxh",
+                  "id": "lkij77ci",
+                  "Datatype": {
+                    "typeName": "BOOLEAN",
+                    "type": "BooleanDatatypeType"
+                  }
+                },
+                {
+                  "CollectedVariableReference": "lkijcm4c",
+                  "id": "lkijke8q",
+                  "Datatype": {
+                    "typeName": "BOOLEAN",
+                    "type": "BooleanDatatypeType"
+                  }
+                }
+              ],
+              "Control": [],
+              "depth": 3,
+              "ClarificationQuestion": [],
+              "id": "lkijhbsn",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "Declaration": [],
+              "questionType": "MULTIPLE_CHOICE"
+            }
+          ],
+          "Name": "SS2"
+        }
+      ],
+      "Name": "S2"
+    },
+    {
+      "Control": [],
+      "depth": 1,
+      "FlowControl": [],
+      "genericName": "MODULE",
+      "Label": [
+        "QUESTIONNAIRE_END"
+      ],
+      "id": "idendquest",
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "type": "SequenceType",
+      "Child": [],
+      "Name": "QUESTIONNAIRE_END"
+    }
+  ]
+}


### PR DESCRIPTION
- refactor DDI code lists mapping at questionnaire level + added a DDI processing to insert code lists where they were directly mapped before

(The purpose of this is to map code lists only once, so that we have the same code items objects at every places.)

- feat/fix: add code lists and code responses of multiple choice questions in the DDI processing that resolve variable references in labels
- test: add integration test on this DDI processing
- refactor: some renaming in Eno model properties (simpler / more coherent):
  - `CodeList` = `codeList`
  - `List<CodeItem>` = `codeItems`
  - `List<CodeResponse>` = `codeResponses`

Note: to do later on maybe: rework the mapping of multiple choice questions to use proper code lists objects (the mapping of code responses is a bit much complex)