### PR TITLE
Version updates

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,9 +13,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Build with Maven
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: '11'
       - name: Build with Maven Eno
         run: mvn clean process-classes package install -DskipTests=true -Dmaven.javadoc.skip=true -Djar.finalName="eno-core" -B -V --file pom.xml
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test on push or PR
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'v3-main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: Test on push or PR
 on:
   push:
     branches-ignore:
-      - 'v3**'
+      - 'v3-main'
+      - 'v3-develop'
+      - '**/v3-**'
     paths-ignore:
       - 'docs/**'
       - 'doc/**'
@@ -11,7 +13,9 @@ on:
     types:
       - opened
     branches-ignore:
-      - 'v3**'
+      - 'v3-main'
+      - 'v3-develop'
+      - '**/v3-**'
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<properties>
 		<guice.version>5.1.0</guice.version>
 		<commons-io.version>2.13.0</commons-io.version>
-		<saxon.version>11.3</saxon.version>
+		<saxon.version>12.3</saxon.version>
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
 		<slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
 		<slf4j.version>2.0.7</slf4j.version>
-		<eclipse.version>4.0.2</eclipse.version>
+		<eclipse.version>2.7.13</eclipse.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+				<version>3.3.1</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.2.1</version>
+				<version>1.6.0</version>
 				<executions>
 					<execution>
 						<phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>1.6.0</version>
 				<executions>
 					<execution>
 						<phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
 		<slf4j.version>2.0.7</slf4j.version>
-		<eclipse.version>3.0.3</eclipse.version>
+		<eclipse.version>4.0.2</eclipse.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,14 @@
 		<saxon.version>12.3</saxon.version>
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
-		<slf4j.version>1.7.36</slf4j.version>
+		<slf4j.version>2.0.7</slf4j.version>
 		<eclipse.version>2.6.0</eclipse.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>
 		<junit.version>5.10.0</junit.version>
 		<xmlunit.version>2.9.0</xmlunit.version>
-		<log4j-slf4j.version>2.20.0</log4j-slf4j.version>
+		<log4j-slf4j2.version>2.20.0</log4j-slf4j2.version>
 
 
 		<source.plugin.version>3.2.1</source.plugin.version>
@@ -112,7 +112,7 @@
 			<version>${fop.version}</version>
 		</dependency>
 
-		<!-- LOG4j and SL4J dependancies -->
+		<!-- Logging dependencies -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
@@ -140,8 +140,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j-slf4j.version}</version>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>${log4j-slf4j2.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,13 +72,13 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
-					<!-- Configuration Sonar -->
+		<!-- Sonar -->
 		<jacoco.version>0.8.8</jacoco.version>	
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.projectName>Eno-WS</sonar.projectName>
-        <sonar.language>java</sonar.language>
+		<sonar.language>java</sonar.language>
 		<argLine>-Xms256m -Xmx512m -XX:MaxPermSize=128m -ea -Dfile.encoding=UTF-8</argLine>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
 		<slf4j.version>2.0.7</slf4j.version>
-		<eclipse.version>2.7.13</eclipse.version>
+		<eclipse.version>3.0.3</eclipse.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>
 		<slf4j.version>2.0.7</slf4j.version>
-		<eclipse.version>2.6.0</eclipse.version>
+		<eclipse.version>2.7.13</eclipse.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<apache-commons.version>3.5</apache-commons.version>
-		<junit.version>5.8.2</junit.version>
+		<junit.version>5.10.0</junit.version>
 		<xmlunit.version>2.9.0</xmlunit.version>
 		<log4j-slf4j.version>2.20.0</log4j-slf4j.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.6.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
 	<properties>
 		<guice.version>5.1.0</guice.version>
-		<commons-io.version>2.11.0</commons-io.version>
+		<commons-io.version>2.13.0</commons-io.version>
 		<saxon.version>11.3</saxon.version>
 		<fop.version>2.7</fop.version>
 		<xalan.version>2.7.3</xalan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>2.5.0</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>xjc-schema</id>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<maven.compiler.target>11</maven.compiler.target>
 
 		<!-- Sonar -->
-		<jacoco.version>0.8.8</jacoco.version>	
+		<jacoco.version>0.8.10</jacoco.version>	
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>2.5.0</version>
 				<executions>
 					<execution>
 						<id>xjc-schema</id>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.1.2</version>
 				<configuration>
 					<encoding>UTF-8</encoding>
 					<argLine>-Dfile.encoding=UTF-8


### PR DESCRIPTION
## Version updates

### Done :white_check_mark:

- saxon from 11.3 to 12.3
- eclipse dependencies from 2.6.0 to 2.7.13
- commons-io from 2.11.0 to 2.13.0

Logging dependenceis: 

- slf4j from 1.7.36 to 2.0.7 (+ changed log4j provider to log4j-slf4j2-impl)

Test dependencies:

- junit from 5.8.2 to 5.10.0
- jacoco-maven-plugin from 0.8.8 to 0.8.10

Plugins:

- exec-maven-plugin from 1.2.1 to 1.6.0

### To do

:warning: Attempted the following upgrades, that failed:

- exec-maven-plugin from 1.6.0 to 3.1.0 => Build failure

```
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.1.0:java (default) on project eno-core: 
An exception occurred while executing the Java class. Provider org.apache.xerces.jaxp.SAXParserFactoryImpl not found -> [Help 1]
```

- jaxb2-maven-plugin from 2.5.0 to 3.1.0 => Build failure

```
Error:  Failed to execute goal org.codehaus.mojo:jaxb2-maven-plugin:3.1.0:xjc (xjc-schema) on project eno-core: 
Error:  +=================== [XJC Error]
Error:  |
Error:  | 0: file:/home/runner/work/Eno/Eno/src/main/resources/params/schemas/ENOParameters.xsd
Error:  |
Error:  +=================== [End XJC Error]
Error:  -> [Help 1]
```

:arrow_up: _NB: we might consider replacing these two plugins_

- eclipse dependencies: I tried 3.0.3 and 4.0.2 versions, same result with both:

```
Tests run: 29, Failures: 12, Errors: 1, Skipped: 0
```
