### PR TITLE
refactor(parameters): proper separation of Eno and Lunatic parameters

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/EnoParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/EnoParameters.java
@@ -50,50 +50,6 @@ public class EnoParameters {
 
     private EnoParameters() {}
 
-    public static EnoParameters emptyValues() {
-        return new EnoParameters();
-    }
-
-    public static EnoParameters of(Context context, Format outFormat, ModeParameter modeParameter) {
-        log.info("Parameters with context {}, out format {}, mode {}", context, outFormat, modeParameter);
-        EnoParameters enoParameters = new EnoParameters();
-        //
-        if (! Format.LUNATIC.equals(outFormat))
-            throw new UnsupportedOperationException("Only Lunatic out format is supported for now.");
-        //
-        enoParameters.setContext(context);
-        enoParameters.setModeParameter(modeParameter);
-        //
-        switch (modeParameter) {
-            case CAPI -> enoParameters.setSelectedModes(List.of(Mode.CAPI));
-            case CATI -> enoParameters.setSelectedModes(List.of(Mode.CATI));
-            case CAWI -> enoParameters.setSelectedModes(List.of(Mode.CAWI));
-            case PAPI -> throw new IllegalArgumentException("Mode 'PAPI' is not compatible with Lunatic format.");
-            case PROCESS -> enoParameters.setSelectedModes(List.of(Mode.CAPI, Mode.CATI, Mode.CAWI));
-        }
-        //
-        enoParameters.setIdentificationQuestion(Context.BUSINESS.equals(context));
-        enoParameters.setResponseTimeQuestion(Context.BUSINESS.equals(context));
-        enoParameters.setCommentSection(Context.HOUSEHOLD.equals(context) || Context.BUSINESS.equals(context));
-        enoParameters.setQuestionNumberingMode(
-                Context.HOUSEHOLD.equals(context) ? QuestionNumberingMode.ALL : QuestionNumberingMode.SEQUENCE);
-        enoParameters.sequenceNumbering = true;
-        enoParameters.arrowCharInQuestions = true;
-        //
-        boolean isInterview = ModeParameter.CAPI.equals(modeParameter) || ModeParameter.CATI.equals(modeParameter);
-        boolean isWeb = ModeParameter.CAWI.equals(modeParameter);
-        boolean isProcess = ModeParameter.PROCESS.equals(modeParameter);
-        enoParameters.setControls(isWeb || isProcess);
-        enoParameters.setToolTip(isWeb || isProcess);
-        enoParameters.setFilterDescription(isProcess);
-        enoParameters.setFilterResult(isWeb);
-        enoParameters.setMissingVariables(isInterview);
-        enoParameters.setLunaticPaginationMode(
-                isInterview || isWeb ? LunaticPaginationMode.QUESTION : LunaticPaginationMode.NONE);
-        //
-        return enoParameters;
-    }
-
     public static EnoParameters parse(InputStream parametersInputStream) throws IOException {
         log.info("Parsing Eno parameters from input stream");
         ObjectMapper objectMapper = new ObjectMapper();
@@ -104,6 +60,72 @@ public class EnoParameters {
         log.info("Serializing parameters file");
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(enoParameters);
+    }
+
+    public static EnoParameters emptyValues() {
+        return new EnoParameters();
+    }
+
+    public static EnoParameters of(Context context, ModeParameter modeParameter) {
+        log.info("Parameters with context {}, mode {}", context, modeParameter);
+        EnoParameters enoParameters = new EnoParameters();
+        //
+        enoParameters.enoValues(context, modeParameter);
+        //
+        return enoParameters;
+    }
+
+    public static EnoParameters of(Context context, ModeParameter modeParameter, Format outFormat) {
+        log.info("Parameters with context {}, out format {}, mode {}", context, outFormat, modeParameter);
+        EnoParameters enoParameters = new EnoParameters();
+        //
+        if (! Format.LUNATIC.equals(outFormat))
+            throw new UnsupportedOperationException("Only Lunatic out format is supported for now.");
+        //
+        enoParameters.enoValues(context, modeParameter);
+        //
+        enoParameters.lunaticValues(modeParameter);
+        //
+        return enoParameters;
+    }
+
+    private void enoValues(Context context, ModeParameter modeParameter) {
+        //
+        this.setContext(context);
+        this.setModeParameter(modeParameter);
+        //
+        switch (modeParameter) {
+            case CAPI -> this.setSelectedModes(List.of(Mode.CAPI));
+            case CATI -> this.setSelectedModes(List.of(Mode.CATI));
+            case CAWI -> this.setSelectedModes(List.of(Mode.CAWI));
+            case PAPI -> this.setSelectedModes(List.of(Mode.PAPI));
+            case PROCESS -> this.setSelectedModes(List.of(Mode.CAPI, Mode.CATI, Mode.CAWI, Mode.PAPI));
+        }
+        //
+        this.setIdentificationQuestion(Context.BUSINESS.equals(context));
+        this.setResponseTimeQuestion(Context.BUSINESS.equals(context));
+        this.setCommentSection(Context.HOUSEHOLD.equals(context) || Context.BUSINESS.equals(context));
+        this.setQuestionNumberingMode(
+                Context.HOUSEHOLD.equals(context) ? QuestionNumberingMode.ALL : QuestionNumberingMode.SEQUENCE);
+        this.sequenceNumbering = true;
+        this.arrowCharInQuestions = true;
+    }
+
+    private void lunaticValues(ModeParameter modeParameter) {
+        //
+        if (ModeParameter.PAPI.equals(modeParameter))
+            throw new IllegalArgumentException("Mode 'PAPI' is not compatible with Lunatic format.");
+        //
+        boolean isInterview = ModeParameter.CAPI.equals(modeParameter) || ModeParameter.CATI.equals(modeParameter);
+        boolean isWeb = ModeParameter.CAWI.equals(modeParameter);
+        boolean isProcess = ModeParameter.PROCESS.equals(modeParameter);
+        this.setControls(isWeb || isProcess);
+        this.setToolTip(isWeb || isProcess);
+        this.setFilterDescription(isProcess);
+        this.setFilterResult(isWeb);
+        this.setMissingVariables(isInterview);
+        this.setLunaticPaginationMode(
+                isInterview || isWeb ? LunaticPaginationMode.QUESTION : LunaticPaginationMode.NONE);
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/DDIToLunaticTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/DDIToLunaticTest.java
@@ -28,7 +28,7 @@ class DDIToLunaticTest {
 
     @BeforeEach
     void setupParameters() {
-        enoParameters = EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.CAWI);
+        enoParameters = EnoParameters.of(Context.DEFAULT, ModeParameter.CAWI, Format.LUNATIC);
     }
 
     @ParameterizedTest
@@ -61,7 +61,7 @@ class DDIToLunaticTest {
         static void mapLunaticQuestionnaire() throws DDIParsingException {
             lunaticQuestionnaire = DDIToLunatic.transform(
                     AcceptanceTest.class.getClassLoader().getResourceAsStream("end-to-end/ddi/ddi-l20g2ba7.xml"),
-                    EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.CAWI));
+                    EnoParameters.of(Context.DEFAULT, ModeParameter.CAWI, Format.LUNATIC));
         }
 
         @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/DateQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/DateQuestionTest.java
@@ -28,7 +28,7 @@ class DateQuestionTest {
     void init() throws DDIParsingException {
         InputStream ddiStream = this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-dates.xml");
         EnoQuestionnaire questionnaire = DDIToEno.transform(ddiStream,
-                EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.PROCESS));
+                EnoParameters.of(Context.DEFAULT, ModeParameter.PROCESS));
         index = questionnaire.getIndex();
     }
 

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/DurationQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/DurationQuestionTest.java
@@ -27,7 +27,7 @@ class DurationQuestionTest {
     void init() throws DDIParsingException {
         InputStream ddiStream = this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-durations.xml");
         EnoQuestionnaire questionnaire = DDIToEno.transform(ddiStream,
-                EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.PROCESS));
+                EnoParameters.of(Context.DEFAULT, ModeParameter.PROCESS));
         index = questionnaire.getIndex();
     }
 

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
@@ -97,7 +97,7 @@ class CalculatedVariableTest {
             Questionnaire lunaticQuestionnaire = DDIToLunatic.transform(
                     CalculatedVariableTest.class.getClassLoader().getResourceAsStream(
                             "integration/ddi/ddi-variables.xml"),
-                    EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                    EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
             //
             calculatedVariables = new HashMap<>();
             lunaticQuestionnaire.getVariables().stream()
@@ -191,7 +191,7 @@ class CalculatedVariableTest {
             Questionnaire lunaticQuestionnaire = DDIToLunatic.transform(
                     CalculatedVariableTest.class.getClassLoader().getResourceAsStream(
                             "integration/ddi/ddi-declarations.xml"),
-                    EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                    EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
             // Then
             Optional<VariableType> lunaticVariable = lunaticQuestionnaire.getVariables().stream()
                     .filter(variableType -> "CALCULATED1".equals(variableType.getName()))

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ComponentFilterTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ComponentFilterTest.java
@@ -72,7 +72,7 @@ class ComponentFilterTest {
             lunaticQuestionnaire = DDIToLunatic.transform(
                     ComponentFilterTest.class.getClassLoader().getResourceAsStream(
                             "integration/ddi/ddi-filters-simple.xml"),
-                    EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                    EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         }
 
         @Test
@@ -143,7 +143,7 @@ class ComponentFilterTest {
             lunaticQuestionnaire = DDIToLunatic.transform(
                     ComponentFilterTest.class.getClassLoader().getResourceAsStream(
                             "integration/ddi/ddi-filters-extended.xml"),
-                    EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                    EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         }
 
         @Test
@@ -186,7 +186,7 @@ class ComponentFilterTest {
             lunaticQuestionnaire = DDIToLunatic.transform(
                     ComponentFilterTest.class.getClassLoader().getResourceAsStream(
                             "integration/ddi/ddi-filters-calculated.xml"),
-                    EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                    EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         }
 
         @ParameterizedTest

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/NumberQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/NumberQuestionTest.java
@@ -21,7 +21,7 @@ class NumberQuestionTest {
         // Given + When
         Questionnaire lunaticQuestionnaire = DDIToLunatic.transform(
                 this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-variables.xml"),
-                EnoParameters.of(EnoParameters.Context.DEFAULT, Format.LUNATIC, EnoParameters.ModeParameter.CAWI));
+                EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         // Then
         // gather components to look at
         List<InputNumber> inputNumbers = lunaticQuestionnaire.getComponents().stream()

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -106,7 +106,7 @@ class LunaticLoopResolutionTest {
             // Given
             EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(
                     this.getClass().getClassLoader().getResourceAsStream("end-to-end/ddi/ddi-l20g2ba7.xml"),
-                    EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.CAWI));
+                    EnoParameters.of(Context.DEFAULT, ModeParameter.CAWI, Format.LUNATIC));
             Questionnaire lunaticQuestionnaire = new Questionnaire();
             LunaticMapper lunaticMapper = new LunaticMapper();
             lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticSortComponentsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticSortComponentsTest.java
@@ -74,7 +74,7 @@ class LunaticSortComponentsTest {
             // Given
             EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(
                     this.getClass().getClassLoader().getResourceAsStream("end-to-end/ddi/ddi-l20g2ba7.xml"),
-                    EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.PROCESS));
+                    EnoParameters.of(Context.DEFAULT, ModeParameter.PROCESS, Format.LUNATIC));
             Questionnaire lunaticQuestionnaire = new Questionnaire();
             LunaticMapper lunaticMapper = new LunaticMapper();
             lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/DDIToLunaticController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/DDIToLunaticController.java
@@ -36,7 +36,7 @@ public class DDIToLunaticController {
     public Mono<ResponseEntity<String>> ddiToLunatic(
             @RequestPart("ddiFile") Mono<FilePart> ddiFile) {
         return controllerUtils.ddiToLunaticJson(ddiFile,
-                EnoParameters.of(Context.DEFAULT, Format.LUNATIC, ModeParameter.PROCESS));
+                EnoParameters.of(Context.DEFAULT, ModeParameter.PROCESS, Format.LUNATIC));
     }
 
     @Operation(

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationController.java
@@ -144,7 +144,7 @@ public class GenerationController {
 		Mono<LunaticPostProcessing> lunaticPostProcessings = controllerUtils.generateLunaticPostProcessings(specificTreatment);
 
 		//
-		EnoParameters parameters = EnoParameters.of(context, Format.LUNATIC, modeParameter);
+		EnoParameters parameters = EnoParameters.of(context, modeParameter, Format.LUNATIC);
 		//
 		parameters.setIdentificationQuestion(identificationQuestion);
 		parameters.setResponseTimeQuestion(endQuestionResponseTime);

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/SimpleGenerationController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/SimpleGenerationController.java
@@ -1,6 +1,5 @@
 package fr.insee.eno.ws.controller;
 
-import fr.insee.eno.core.model.mode.Mode;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.eno.legacy.parameters.CaptureEnum;
@@ -96,7 +95,7 @@ public class SimpleGenerationController {
          */
         Mono<LunaticPostProcessing> lunaticPostProcessing = controllerUtils.generateLunaticPostProcessings(specificTreatment);
         //
-        EnoParameters enoParameters = EnoParameters.of(context, Format.LUNATIC, modeParameter);
+        EnoParameters enoParameters = EnoParameters.of(context, modeParameter, Format.LUNATIC);
         //
         return controllerUtils.ddiToLunaticJson(ddiFile, enoParameters, lunaticPostProcessing);
     }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/ParameterService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/ParameterService.java
@@ -21,7 +21,7 @@ public class ParameterService {
 
     public Mono<String> defaultParams(EnoParameters.Context context, Format format, ModeParameter modeParameter) {
         try {
-            return Mono.just(EnoParameters.serialize(EnoParameters.of(context, format, modeParameter)));
+            return Mono.just(EnoParameters.serialize(EnoParameters.of(context, modeParameter, format)));
         } catch (Exception e) {
             return Mono.error(e);
         }


### PR DESCRIPTION
Refactor parameters class to properly separate Eno "core/common" parameters from Lunatic-specific ones.

The class also looks cleaner now.