### PR TITLE
fix: remove duplicates in loop dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.8.1-SNAPSHOT'
+    version = '3.8.2-SNAPSHOT'
     sourceCompatibility = '17'
 }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/model/navigation/StandaloneLoop.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/navigation/StandaloneLoop.java
@@ -13,7 +13,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Standalone loop, in opposition to "linked" loop.
@@ -53,14 +55,14 @@ public class StandaloneLoop extends Loop {
     }
 
     public List<String> getLunaticLoopDependencies() {
-        List<String> res = new ArrayList<>();
+        Set<String> res = new HashSet<>();
         if (this.getMinIteration() != null)
             res.addAll(this.getMinIteration().getBindingReferences().stream()
                     .map(BindingReference::getVariableName).toList());
         if (this.getMaxIteration() != null)
             res.addAll(this.getMaxIteration().getBindingReferences().stream()
                     .map(BindingReference::getVariableName).toList());
-        return res;
+        return new ArrayList<>(res);
     }
 
     /** Nesting class for min and max iteration properties.

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/StandaloneLoopTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/StandaloneLoopTest.java
@@ -8,9 +8,11 @@ import fr.insee.lunatic.model.flat.Loop;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StandaloneLoopTest {
 
@@ -38,6 +40,23 @@ class StandaloneLoopTest {
         lunaticMapper.mapEnoObject(enoLoop, lunaticLoop);
         //
         assertThat(lunaticLoop.getLoopDependencies()).containsExactlyInAnyOrderElementsOf(Set.of("FOO", "BAR"));
+    }
+
+    @Test
+    void lunaticLoopDependencies_shouldBeNoDuplicate() {
+        //
+        enoLoop.setLoopIterations(new StandaloneLoop.LoopIterations());
+        CalculatedExpression minIteration = new CalculatedExpression();
+        minIteration.getBindingReferences().add(new BindingReference("foo-ref1", "FOO"));
+        enoLoop.getLoopIterations().setMinIteration(minIteration);
+        CalculatedExpression maxIteration = new CalculatedExpression();
+        maxIteration.getBindingReferences().add(new BindingReference("foo-ref2", "FOO"));
+        enoLoop.getLoopIterations().setMaxIteration(maxIteration);
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapEnoObject(enoLoop, lunaticLoop);
+        //
+        assertEquals(List.of("FOO"), lunaticLoop.getLoopDependencies());
     }
 
 }


### PR DESCRIPTION
Remove duplicates in Lunatic loop dependencies of standalone loops.

NB: dependencies of linked loops are always a single collected variable.

NB2: not yet completely sure that loop dependencies of standalone loops should include either min and max or just max.