### PR TITLE
fix: add label type in Lunatic linked loop 'iterations'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.9.1-SNAPSHOT'
+    version = '3.9.2-SNAPSHOT'
     sourceCompatibility = '17'
 }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
+import fr.insee.eno.core.Constant;
 import fr.insee.eno.core.exceptions.business.LunaticLoopResolutionException;
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoIdentifiableObject;
@@ -153,6 +154,7 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
             String variableName = findFirstVariableOfReference(enoLinkedLoop, enoReferenceLoop);
             lunaticLoop.setIterations(new LabelType());
             lunaticLoop.getIterations().setValue("count("+ variableName +")");
+            lunaticLoop.getIterations().setType(Constant.LUNATIC_LABEL_VTL);
             lunaticLoop.getLoopDependencies().add(variableName);
             return;
         }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
+import fr.insee.eno.core.Constant;
 import fr.insee.eno.core.DDIToEno;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.mappers.LunaticMapper;
@@ -144,6 +145,8 @@ class LunaticLoopResolutionTest {
         void linkedLoopsIterations() {
             assertEquals("count(Q1A)", lunaticLoops.get(1).getIterations().getValue());
             assertEquals("count(Q3A)", lunaticLoops.get(3).getIterations().getValue());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(1).getIterations().getType());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(3).getIterations().getType());
         }
 
         @Test
@@ -236,6 +239,8 @@ class LunaticLoopResolutionTest {
         void linkedLoopsIterations() {
             assertEquals("count(Q1A)", lunaticLoops.get(1).getIterations().getValue());
             assertEquals("count(Q2A)", lunaticLoops.get(3).getIterations().getValue());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(1).getIterations().getType());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(3).getIterations().getType());
         }
 
         @Test
@@ -317,6 +322,7 @@ class LunaticLoopResolutionTest {
             assertThat(lunaticLoops.get(0).getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q1"), lunaticLoops.get(1).getLoopDependencies());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(1).getIterations().getType());
         }
 
         @Test
@@ -389,6 +395,7 @@ class LunaticLoopResolutionTest {
             assertThat(lunaticLoops.get(0).getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q11"), lunaticLoops.get(1).getLoopDependencies());
+            assertEquals(Constant.LUNATIC_LABEL_VTL, lunaticLoops.get(1).getIterations().getType());
         }
 
         @Test


### PR DESCRIPTION
Closes #706 

In Lunatic loops, `"iterations"` is a property linked loops that defines the number of iterations of the linked loop, based on the length of the first variable of the "main" loop it is linked with.

The `"type"` property was missing in the label object (=> at runtime, Lunatic couldn't evaluate the expression).
