### PR TITLE
fix: lunatic pagination parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.11.3-SNAPSHOT'
+    version = '3.11.4-SNAPSHOT'
     sourceCompatibility = '17'
 }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
@@ -42,7 +42,7 @@ public class LunaticParameters {
         this.setLunaticPaginationMode(
                 EnoParameters.Context.BUSINESS.equals(context) ?
                         EnoParameters.LunaticPaginationMode.SEQUENCE :
-                        EnoParameters.LunaticPaginationMode.NONE);
+                        EnoParameters.LunaticPaginationMode.QUESTION);
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/parameter/EnoParameterTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/parameter/EnoParameterTest.java
@@ -18,7 +18,7 @@ class EnoParameterTest {
         assertFalse(lunaticParameters.isFilterDescription());
         assertTrue(lunaticParameters.isFilterResult());
         assertFalse(lunaticParameters.isMissingVariables());
-        assertEquals(EnoParameters.LunaticPaginationMode.NONE, lunaticParameters.getLunaticPaginationMode());
+        assertEquals(EnoParameters.LunaticPaginationMode.QUESTION, lunaticParameters.getLunaticPaginationMode());
     }
 
     @Test


### PR DESCRIPTION
Absence of Lunatic pagination makes questionnaires that have loops crash at runtime.