### PR TITLE
fix: end question labels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.11.6-SNAPSHOT'
+    version = '3.11.7-SNAPSHOT'
     sourceCompatibility = '17'
 }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddCommentSection.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddCommentSection.java
@@ -25,6 +25,12 @@ public class EnoAddCommentSection implements ProcessingStep<EnoQuestionnaire> {
     public static final boolean COMMENT_QUESTION_MANDATORY = false;
     public static final int COMMENT_QUESTION_LENGTH = 2000;
 
+    private final EnoAddPrefixInQuestionLabels prefixingStep;
+
+    public EnoAddCommentSection(EnoAddPrefixInQuestionLabels prefixingStep) {
+        this.prefixingStep = prefixingStep;
+    }
+
     public void apply(EnoQuestionnaire enoQuestionnaire) {
         //
         EnoIndex enoIndex = enoQuestionnaire.getIndex();
@@ -49,6 +55,7 @@ public class EnoAddCommentSection implements ProcessingStep<EnoQuestionnaire> {
         commentQuestion.setName(COMMENT_VARIABLE_NAME);
         commentQuestion.setLabel(new DynamicLabel());
         commentQuestion.getLabel().setValue(COMMENT_QUESTION_LABEL);
+        prefixingStep.addPrefixInQuestionLabel(commentQuestion);
         commentQuestion.setMandatory(COMMENT_QUESTION_MANDATORY);
         commentQuestion.setLengthType(TextQuestion.qualifyLength(COMMENT_QUESTION_LENGTH));
         commentQuestion.setMaxLength(BigInteger.valueOf(COMMENT_QUESTION_LENGTH));

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddPrefixInQuestionLabels.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddPrefixInQuestionLabels.java
@@ -24,6 +24,8 @@ public class EnoAddPrefixInQuestionLabels implements ProcessingStep<EnoQuestionn
     private final QuestionNumberingMode questionNumberingMode;
     private final EnoParameters.ModeParameter modeParameter;
 
+    private int questionNumber;
+
     public EnoAddPrefixInQuestionLabels(boolean arrowCharInQuestions, QuestionNumberingMode questionNumberingMode,
                                         EnoParameters.ModeParameter modeParameter) {
         this.arrowCharInQuestions = arrowCharInQuestions;
@@ -35,30 +37,31 @@ public class EnoAddPrefixInQuestionLabels implements ProcessingStep<EnoQuestionn
         //
         assert enoQuestionnaire.getIndex() != null;
         //
-        if (QuestionNumberingMode.NONE.equals(questionNumberingMode) && !arrowCharInQuestions) {
+        if (prefixingDisabled())
             return;
-        }
         //
-        int questionNumber = 1;
+        questionNumber = 1;
         for (Sequence sequence : enoQuestionnaire.getSequences()) {
             for (String componentId : getSequenceComponentIds(sequence)) {
                 EnoComponent component = (EnoComponent) enoQuestionnaire.get(componentId);
                 if (component instanceof Subsequence subsequence) {
                     for (String questionId : getSequenceComponentIds(subsequence)) {
                         Question question = (Question) enoQuestionnaire.get(questionId);
-                        addPrefixInQuestionLabel(question, questionNumber);
-                        questionNumber ++;
+                        addPrefixInQuestionLabel(question);
                     }
                 } else {
                     Question question = (Question) component;
-                    addPrefixInQuestionLabel(question, questionNumber);
-                    questionNumber ++;
+                    addPrefixInQuestionLabel(question);
                 }
             }
             if (questionNumberingMode == QuestionNumberingMode.SEQUENCE) {
                 questionNumber = 1;
             }
         }
+    }
+
+    private boolean prefixingDisabled() {
+        return QuestionNumberingMode.NONE.equals(questionNumberingMode) && !arrowCharInQuestions;
     }
 
     /**
@@ -70,9 +73,12 @@ public class EnoAddPrefixInQuestionLabels implements ProcessingStep<EnoQuestionn
         return sequence.getSequenceStructure().stream().map(StructureItemReference::getId).toList();
     }
 
-    private void addPrefixInQuestionLabel(Question question, int questionNumber) {
+    public void addPrefixInQuestionLabel(Question question) {
+        if (prefixingDisabled())
+            return;
         DynamicLabel questionLabel = question.getLabel();
         questionLabel.setValue(addPrefixInLabel(questionLabel.getValue(), questionNumber));
+        questionNumber ++;
     }
 
     private String addPrefixInLabel(String questionLabelValue, int questionNumber) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSection.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSection.java
@@ -35,6 +35,12 @@ public class EnoAddResponseTimeSection implements ProcessingStep<EnoQuestionnair
     public static final double RESPONSE_TIME_MINUTES_QUESTION_MAX_VALUE = 59;
     public static final BigInteger RESPONSE_TIME_MINUTES_QUESTION_DECIMALS = BigInteger.ZERO;
 
+    private final EnoAddPrefixInQuestionLabels prefixingStep;
+
+    public EnoAddResponseTimeSection(EnoAddPrefixInQuestionLabels prefixingStep) {
+        this.prefixingStep = prefixingStep;
+    }
+
     public void apply(EnoQuestionnaire enoQuestionnaire) {
         //
         EnoIndex enoIndex = enoQuestionnaire.getIndex();
@@ -68,6 +74,7 @@ public class EnoAddResponseTimeSection implements ProcessingStep<EnoQuestionnair
         hoursQuestion.setName(HOURS_VARIABLE_NAME);
         hoursQuestion.setLabel(new DynamicLabel());
         hoursQuestion.getLabel().setValue(RESPONSE_TIME_QUESTION_LABEL);
+        prefixingStep.addPrefixInQuestionLabel(hoursQuestion);
         hoursQuestion.setMandatory(RESPONSE_TIME_QUESTION_MANDATORY);
         hoursQuestion.setMinValue(HOURS_QUESTION_MIN_VALUE);
         hoursQuestion.setMaxValue(HOURS_QUESTION_MAX_VALUE);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -45,6 +45,7 @@ public class LunaticProcessing {
                 .then(new LunaticAddResizing(enoQuestionnaire))
                 .then(new LunaticAddHierarchy())
                 .then(new LunaticAddPageNumbers(parameters.getLunaticPaginationMode()))
+                .then(new LunaticResponseTimeQuestionPagination())
                 .then(new LunaticAddCleaningVariables())
                 .thenIf(parameters.isControls(), new LunaticAddControlFormat())
                 .then(new LunaticReverseConsistencyControlLabel())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticResponseTimeQuestionPagination.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticResponseTimeQuestionPagination.java
@@ -1,0 +1,25 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.eno.core.processing.common.steps.EnoAddResponseTimeSection;
+import fr.insee.lunatic.model.flat.ComponentType;
+import fr.insee.lunatic.model.flat.Questionnaire;
+
+import java.util.Optional;
+
+public class LunaticResponseTimeQuestionPagination implements ProcessingStep<Questionnaire> {
+
+    @Override
+    public void apply(Questionnaire lunaticQuestionnaire) {
+        Optional<ComponentType> hoursQuestionComponent = lunaticQuestionnaire.getComponents().stream()
+                .filter(component -> EnoAddResponseTimeSection.HOURS_QUESTION_ID.equals(component.getId()))
+                .findAny();
+        if (hoursQuestionComponent.isPresent()) {
+            String pageNumber = hoursQuestionComponent.get().getPage();
+            int hoursQuestionComponentIndex = lunaticQuestionnaire.getComponents().indexOf(hoursQuestionComponent.get());
+            // minutes question is just after the hours question
+            lunaticQuestionnaire.getComponents().get(hoursQuestionComponentIndex + 1).setPage(pageNumber);
+        }
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddCommentSectionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddCommentSectionTest.java
@@ -4,17 +4,56 @@ import fr.insee.eno.core.DDIToEno;
 import fr.insee.eno.core.DDIToLunatic;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.label.DynamicLabel;
+import fr.insee.eno.core.model.question.TextQuestion;
 import fr.insee.eno.core.model.sequence.Sequence;
+import fr.insee.eno.core.model.sequence.StructureItemReference;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.Questionnaire;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EnoAddCommentSectionTest {
+
+    @Test
+    void commentQuestionLabel_arrowAndNumberPrefix() {
+        // Given a questionnaire with one question
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setIndex(new EnoIndex());
+        Sequence sequence = new Sequence();
+        sequence.getSequenceStructure().add(
+                new StructureItemReference("question-id", StructureItemReference.StructureItemType.QUESTION));
+        TextQuestion question = new TextQuestion();
+        question.setId("question-id");
+        question.setLabel(new DynamicLabel());
+        question.getLabel().setValue("\"Foo label\"");
+        enoQuestionnaire.getIndex().put("question-id", question);
+        enoQuestionnaire.getSequences().add(sequence);
+        enoQuestionnaire.getSingleResponseQuestions().add(question);
+        //
+        EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
+                true, EnoParameters.QuestionNumberingMode.ALL, EnoParameters.ModeParameter.PROCESS);
+        prefixingStep.apply(enoQuestionnaire);
+
+        // When
+        new EnoAddCommentSection(prefixingStep).apply(enoQuestionnaire);
+
+        // Then
+        Optional<TextQuestion> commentQuestion = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(TextQuestion.class::isInstance)
+                .map(TextQuestion.class::cast)
+                .filter(singleResponseQuestion -> EnoAddCommentSection.COMMENT_QUESTION_ID.equals(singleResponseQuestion.getId()))
+                .findAny();
+        assertTrue(commentQuestion.isPresent());
+        String expected = "\"➡ 2. \" || " + EnoAddCommentSection.COMMENT_QUESTION_LABEL;
+        assertEquals(expected, commentQuestion.get().getLabel().getValue());
+    }
 
     @Test
     void integrationTest() throws DDIParsingException {

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSectionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSectionTest.java
@@ -4,17 +4,89 @@ import fr.insee.eno.core.DDIToEno;
 import fr.insee.eno.core.DDIToLunatic;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.NumericQuestion;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.Questionnaire;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EnoAddResponseTimeSectionTest {
+
+    @Test
+    void hoursQuestionLabel_noPrefix() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setIndex(new EnoIndex());
+        EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
+                false, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+        EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
+        // When
+        processing.apply(enoQuestionnaire);
+        // Then
+        Optional<NumericQuestion> hoursQuestion = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(NumericQuestion.class::isInstance)
+                .map(NumericQuestion.class::cast)
+                .filter(singleResponseQuestion -> EnoAddResponseTimeSection.HOURS_QUESTION_ID.equals(singleResponseQuestion.getId()))
+                .findAny();
+        Optional<NumericQuestion> minutesQuestion = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(NumericQuestion.class::isInstance)
+                .map(NumericQuestion.class::cast)
+                .filter(singleResponseQuestion -> EnoAddResponseTimeSection.MINUTES_QUESTION_ID.equals(singleResponseQuestion.getId()))
+                .findAny();
+        assertTrue(hoursQuestion.isPresent());
+        assertTrue(minutesQuestion.isPresent());
+        assertEquals(EnoAddResponseTimeSection.RESPONSE_TIME_QUESTION_LABEL, hoursQuestion.get().getLabel().getValue());
+        assertEquals("", minutesQuestion.get().getLabel().getValue());
+    }
+
+    @Test
+    void hoursQuestionLabel_arrowPrefix() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setIndex(new EnoIndex());
+        EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
+                true, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+        EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
+        // When
+        processing.apply(enoQuestionnaire);
+        // Then
+        Optional<NumericQuestion> hoursQuestion = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(NumericQuestion.class::isInstance)
+                .map(NumericQuestion.class::cast)
+                .filter(singleResponseQuestion -> EnoAddResponseTimeSection.HOURS_QUESTION_ID.equals(singleResponseQuestion.getId()))
+                .findAny();
+        assertTrue(hoursQuestion.isPresent());
+        String expected = "\"➡ \" || " + EnoAddResponseTimeSection.RESPONSE_TIME_QUESTION_LABEL;
+        assertEquals(expected, hoursQuestion.get().getLabel().getValue());
+    }
+
+    @Test
+    void hoursQuestionLabel_arrowAndNumberPrefix() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setIndex(new EnoIndex());
+        EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
+                true, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+        EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
+        // When
+        processing.apply(enoQuestionnaire);
+        // Then
+        Optional<NumericQuestion> hoursQuestion = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(NumericQuestion.class::isInstance)
+                .map(NumericQuestion.class::cast)
+                .filter(singleResponseQuestion -> EnoAddResponseTimeSection.HOURS_QUESTION_ID.equals(singleResponseQuestion.getId()))
+                .findAny();
+        assertTrue(hoursQuestion.isPresent());
+        String expected = "\"➡ 1. \" || " + EnoAddResponseTimeSection.RESPONSE_TIME_QUESTION_LABEL;
+        assertEquals(expected, hoursQuestion.get().getLabel().getValue());
+    }
 
     @Test
     void integrationTest() throws DDIParsingException {

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSectionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddResponseTimeSectionTest.java
@@ -26,6 +26,7 @@ class EnoAddResponseTimeSectionTest {
         enoQuestionnaire.setIndex(new EnoIndex());
         EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
                 false, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+        prefixingStep.apply(enoQuestionnaire);
         EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
         // When
         processing.apply(enoQuestionnaire);
@@ -53,6 +54,7 @@ class EnoAddResponseTimeSectionTest {
         enoQuestionnaire.setIndex(new EnoIndex());
         EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
                 true, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+        prefixingStep.apply(enoQuestionnaire);
         EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
         // When
         processing.apply(enoQuestionnaire);
@@ -73,7 +75,8 @@ class EnoAddResponseTimeSectionTest {
         EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
         enoQuestionnaire.setIndex(new EnoIndex());
         EnoAddPrefixInQuestionLabels prefixingStep = new EnoAddPrefixInQuestionLabels(
-                true, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.PROCESS);
+                true, EnoParameters.QuestionNumberingMode.SEQUENCE, EnoParameters.ModeParameter.PROCESS);
+        prefixingStep.apply(enoQuestionnaire);
         EnoAddResponseTimeSection processing = new EnoAddResponseTimeSection(prefixingStep);
         // When
         processing.apply(enoQuestionnaire);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticResponseTimeQuestionPaginationTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticResponseTimeQuestionPaginationTest.java
@@ -1,0 +1,51 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.processing.common.steps.EnoAddPrefixInQuestionLabels;
+import fr.insee.eno.core.processing.common.steps.EnoAddResponseTimeSection;
+import fr.insee.eno.core.processing.out.steps.lunatic.pagination.LunaticAddPageNumbers;
+import fr.insee.eno.core.reference.EnoIndex;
+import fr.insee.lunatic.model.flat.ComponentType;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LunaticResponseTimeQuestionPaginationTest {
+
+    @Test
+    void questionPaginationMode_hoursAndMinutesQuestionShouldHaveTheSameNumber() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setIndex(new EnoIndex());
+        new EnoAddResponseTimeSection(new EnoAddPrefixInQuestionLabels(
+                true, EnoParameters.QuestionNumberingMode.NONE, EnoParameters.ModeParameter.CAWI))
+                .apply(enoQuestionnaire);
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+        //
+        new LunaticAddPageNumbers(EnoParameters.LunaticPaginationMode.QUESTION).apply(lunaticQuestionnaire);
+
+        // When
+        new LunaticResponseTimeQuestionPagination().apply(lunaticQuestionnaire);
+
+        // Then
+        Optional<ComponentType> hoursQuestionComponent = lunaticQuestionnaire.getComponents().stream()
+                .filter(component -> EnoAddResponseTimeSection.HOURS_QUESTION_ID.equals(component.getId()))
+                .findAny();
+        Optional<ComponentType> minutesQuestionComponent = lunaticQuestionnaire.getComponents().stream()
+                .filter(component -> EnoAddResponseTimeSection.MINUTES_QUESTION_ID.equals(component.getId()))
+                .findAny();
+        assertTrue(hoursQuestionComponent.isPresent());
+        assertTrue(minutesQuestionComponent.isPresent());
+        assertThat(hoursQuestionComponent.get().getPage()).isEqualTo(minutesQuestionComponent.get().getPage());
+    }
+
+}


### PR DESCRIPTION
#723 

- Refactor "common" processing classes that insert end "comment" and "response time"
- Add tests on resulting label of these questions
- Add a Lunatic processing for the "response time" hours and minutes components to make these having the same page number
- Add test on the latter