### PR TITLE
build(docker): change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre-focal
 WORKDIR /opt/eno-ws/
 COPY ./eno-ws/build/libs/*.jar /opt/eno-ws/eno-ws.jar
 ENTRYPOINT ["java", "-jar",  "/opt/eno-ws/eno-ws.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.11.7-SNAPSHOT'
+    version = '3.11.8-SNAPSHOT'
     sourceCompatibility = '17'
 }
 


### PR DESCRIPTION
Change `eclipse-temurin` base image tag from `17-jre-alpine` to `17-jre-focal` (that include `openssl`)