### PR TITLE
build(docker): non root user in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM eclipse-temurin:17-jre-focal
 WORKDIR /opt/eno-ws/
 COPY ./eno-ws/build/libs/*.jar /opt/eno-ws/eno-ws.jar
+EXPOSE 8080
+
+RUN addgroup eno
+RUN useradd -g eno eno
+USER eno
+
 ENTRYPOINT ["java", "-jar",  "/opt/eno-ws/eno-ws.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.11.10-SNAPSHOT'
+    version = '3.11.11-SNAPSHOT'
     sourceCompatibility = '17'
 }
 


### PR DESCRIPTION
temurin jre-apline previously used don't run as root, but jre-focal does.

- #781 

➡️ Add non root user in the Dockefile