### PR TITLE
fix: pairwise ucq condition filter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.13.2-SNAPSHOT'
+    version = '3.13.3-SNAPSHOT'
     sourceCompatibility = '17'
 }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
@@ -71,7 +71,7 @@ public class LunaticFilterResult implements ProcessingStep<Questionnaire> {
                     .forEach(variableName -> filterVariable.getBindingDependencies().add(variableName));
         }
         LabelType expression = new LabelType();
-        expression.setType(conditionFilter.getType());
+        expression.setType(conditionFilter.getTypeEnum());
         expression.setValue(conditionFilter.getValue());
         filterVariable.setExpression(expression);
         return Optional.of(filterVariable);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwise.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwise.java
@@ -40,7 +40,7 @@ public class LunaticFinalizePairwise implements ProcessingStep<Questionnaire> {
         pairwiseLinks.setSymLinks(PairwiseLinks.createDefaultSymLinks(simpleResponseComponent.getResponse().getName()));
 
         ComponentType pairwiseSubComponent = pairwiseLinks.getComponents().get(0);
-        pairwiseSubComponent.getConditionFilter().setValue("xAxis <> yAxis");
+        pairwiseSubComponent.setConditionFilter(null);
 
         List<IVariableType> variables = lunaticQuestionnaire.getVariables();
         variables.addAll(createCalculatedAxisVariables(pairwiseLinks));
@@ -91,7 +91,6 @@ public class LunaticFinalizePairwise implements ProcessingStep<Questionnaire> {
             calculatedAxis.setExpression(expression);
             calculatedAxis.setBindingDependencies(List.of(pairwiseName));
             calculatedAxis.setShapeFrom(pairwiseName);
-            calculatedAxis.setInFilter("true");
             variables.add(calculatedAxis);
         }
         return variables;

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwiseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwiseTest.java
@@ -46,6 +46,7 @@ class LunaticFinalizePairwiseTest {
         radioComponent.setResponse(responseType);
         ConditionFilterType conditionFilterType = new ConditionFilterType();
         conditionFilterType.setValue("true");
+        conditionFilterType.setType(LabelTypeEnum.VTL);
         radioComponent.setConditionFilter(conditionFilterType);
         pairwiseLinks1.setComponents(List.of(radioComponent));
     }
@@ -66,7 +67,7 @@ class LunaticFinalizePairwiseTest {
     void whenFinalizingSubComponentConditionFilterIsSet() {
         lunaticQuestionnaire.getComponents().add(pairwiseLinks1);
         processing.apply(lunaticQuestionnaire);
-        assertEquals("xAxis <> yAxis", radioComponent.getConditionFilter().getValue());
+        assertNull(radioComponent.getConditionFilter());
     }
 
     @Test
@@ -76,7 +77,7 @@ class LunaticFinalizePairwiseTest {
         lunaticQuestionnaire.getComponents().add(loop);
         loop.getComponents().add(pairwiseLinks1);
         processing.apply(lunaticQuestionnaire);
-        assertEquals("xAxis <> yAxis", radioComponent.getConditionFilter().getValue());
+        assertNull(radioComponent.getConditionFilter());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- https://github.com/InseeFr/Eno/issues/795

In Lunatc, the unique choice question component within the pairwise component is not deprecated had a condition filter `"xAxis <> yAxis"`. This filter is no more required.
