### PR TITLE
fix: insert responses in complex multiple choice questions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.13.7'
+    version = '3.13.8'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertResponseInTableCells.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertResponseInTableCells.java
@@ -2,32 +2,54 @@ package fr.insee.eno.core.processing.in.steps.ddi;
 
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.ComplexMultipleChoiceQuestion;
 import fr.insee.eno.core.model.question.EnoTable;
 import fr.insee.eno.core.model.question.table.TableCell;
 import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.processing.ProcessingStep;
 
-public class DDIInsertResponseInTableCells implements ProcessingStep<EnoQuestionnaire> {
+import java.util.List;
 
+public class DDIInsertResponseInTableCells implements ProcessingStep<EnoQuestionnaire> {
 
     @Override
     public void apply(EnoQuestionnaire enoQuestionnaire) {
+        // Objects that implement the EnoTable interface
         enoQuestionnaire.getMultipleResponseQuestions().stream()
                 .filter(EnoTable.class::isInstance)
                 .map(EnoTable.class::cast)
                 .forEach(this::insertResponsesInCells);
+        // Complex multiple choice question objects (that correspond to tables in Lunatic)
+        enoQuestionnaire.getMultipleResponseQuestions().stream()
+                .filter(ComplexMultipleChoiceQuestion.class::isInstance)
+                .map(ComplexMultipleChoiceQuestion.class::cast)
+                .forEach(this::insertResponsesInCells);
     }
 
     private void insertResponsesInCells(EnoTable enoTable) {
-        int cellsCount = enoTable.getTableCells().size();
-        int variableNamesCount = enoTable.getVariableNames().size();
+        insertResponsesInCells(enoTable.getTableCells(), enoTable.getVariableNames(), enoTable.getId());
+    }
+
+    private void insertResponsesInCells(ComplexMultipleChoiceQuestion enoComplexMCQ) {
+        insertResponsesInCells(enoComplexMCQ.getTableCells(), enoComplexMCQ.getVariableNames(), enoComplexMCQ.getId());
+    }
+
+    /**
+     * Insert the response name property in table cells, using the ordered list of variable names.
+     * @param tableCells List of Eno table cells objects.
+     * @param variableNames List of variable names such as its n-th value is the response name of the n-th table cell.
+     * @param questionId The identifier of the question object holding the table cells (for logging purposes).
+     */
+    private void insertResponsesInCells(List<TableCell> tableCells, List<String> variableNames, String questionId) {
+        int cellsCount = tableCells.size();
+        int variableNamesCount = variableNames.size();
         if (cellsCount != variableNamesCount)
             throw new MappingException(String.format(
                     "Table question '%s' mapped from DDI has %s cells and %s response names (the two must be equal).",
-                    enoTable.getId(), cellsCount, variableNamesCount));
+                    questionId, cellsCount, variableNamesCount));
         for (int k = 0; k< cellsCount; k++) {
-            TableCell tableCell = enoTable.getTableCells().get(k);
-            String variableName = enoTable.getVariableNames().get(k);
+            TableCell tableCell = tableCells.get(k);
+            String variableName = variableNames.get(k);
             Response response = new Response();
             response.setVariableName(variableName);
             tableCell.setResponse(response);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertResponseInTableCellsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertResponseInTableCellsTest.java
@@ -1,6 +1,7 @@
 package fr.insee.eno.core.processing.in.steps.ddi;
 
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.ComplexMultipleChoiceQuestion;
 import fr.insee.eno.core.model.question.DynamicTableQuestion;
 import fr.insee.eno.core.model.question.TableQuestion;
 import fr.insee.eno.core.model.question.table.BooleanCell;
@@ -45,6 +46,23 @@ class DDIInsertResponseInTableCellsTest {
         dynamicTableQuestion.getTableCells().forEach(tableCell -> assertNotNull(tableCell.getResponse()));
         assertEquals("FOO", dynamicTableQuestion.getTableCells().get(0).getResponse().getVariableName());
         assertEquals("BAR", dynamicTableQuestion.getTableCells().get(1).getResponse().getVariableName());
+    }
+
+    @Test
+    void complexMultipleChoiceQuestionCase() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        ComplexMultipleChoiceQuestion complexMultipleChoiceQuestion = new ComplexMultipleChoiceQuestion();
+        complexMultipleChoiceQuestion.setTableCells(List.of(new BooleanCell(), new BooleanCell()));
+        complexMultipleChoiceQuestion.setVariableNames(List.of("FOO", "BAR"));
+        enoQuestionnaire.getMultipleResponseQuestions().add(complexMultipleChoiceQuestion);
+        // When
+        DDIInsertResponseInTableCells processing = new DDIInsertResponseInTableCells();
+        processing.apply(enoQuestionnaire);
+        // Then
+        complexMultipleChoiceQuestion.getTableCells().forEach(tableCell -> assertNotNull(tableCell.getResponse()));
+        assertEquals("FOO", complexMultipleChoiceQuestion.getTableCells().get(0).getResponse().getVariableName());
+        assertEquals("BAR", complexMultipleChoiceQuestion.getTableCells().get(1).getResponse().getVariableName());
     }
 
 }


### PR DESCRIPTION
## Summary

Responses were not mapped in Lunatic table components generated from  a "complex multiple choice question" (in Pogues, it is a multiple choice question that uses a code list for its responses).

Probably a regression introduced by a side effect of #773

## Done

Add complex multiple choice question objects in the `DDIInsertResponsesInTableCells` processing.
