### PR TITLE
fix(api): oversight in xforms and fo standard controllers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.2'
+    version = '3.15.3'
 }
 
 subprojects {

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -87,13 +87,14 @@ public class GenerationStandardController {
             ServerHttpRequest request, ServerHttpResponse response) {
         if (Context.HOUSEHOLD.equals(context))
             return Mono.error(new ContextException("Xforms format is not compatible with 'HOUSEHOLD' context."));
-        return metadata.hasElement()
+        metadata.hasElement()
                 .flatMap(hasElementValue -> {
                     if (Context.BUSINESS.equals(context) && Boolean.FALSE.equals(hasElementValue))
                         return Mono.error(new MetadataFileException(
                                 "The metadata file is required in 'BUSINESS' context."));
-                    return passThrough.passePlatPost(request, response);
+                    return null;
                 });
+        return passThrough.passePlatPost(request, response);
     }
 
     @Operation(
@@ -114,13 +115,14 @@ public class GenerationStandardController {
             @RequestParam(value="Capture", required=false) CaptureEnum capture,
             @PathVariable Context context,
             ServerHttpRequest request, ServerHttpResponse response) {
-        return metadata.hasElement()
+        metadata.hasElement()
                 .flatMap(hasElementValue -> {
                     if (Context.BUSINESS.equals(context) && Boolean.FALSE.equals(hasElementValue))
                         return Mono.error(new MetadataFileException(
                                 "The metadata file is required in 'BUSINESS' context."));
-                    return passThrough.passePlatPost(request, response);
+                    return null;
                 });
+        return passThrough.passePlatPost(request, response);
     }
 
     @Operation(

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/exception/EnoExceptionController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/exception/EnoExceptionController.java
@@ -8,6 +8,7 @@ import fr.insee.eno.legacy.exception.EnoGenerationException;
 import fr.insee.eno.legacy.exception.EnoLegacyParametersException;
 import fr.insee.eno.treatments.exceptions.SpecificTreatmentsDeserializationException;
 import fr.insee.eno.treatments.exceptions.SpecificTreatmentsValidationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 
 @ControllerAdvice
+@Slf4j
 public class EnoExceptionController {
 
 	@ExceptionHandler(value = EnoLegacyParametersException.class)
@@ -59,6 +61,7 @@ public class EnoExceptionController {
 
 	@ExceptionHandler(value = Exception.class)
 	public ResponseEntity<Object> exception(Exception exception) {
+		log.error("Unhandled exception thrown in controller: ", exception);
 		return new ResponseEntity<>("Unknown error during generation: "+exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 


### PR DESCRIPTION
- #852 

> POST [/questionnaire/{context}/xforms] : Unknown error during generation: SSLTube(SocketTube(5)) stream=1 [reactor-http-epoll-6] Too few bytes returned by the publisher (0/984670)

Cause: an oversight in the code that verifies that the metadata is present in 'business' context.
