### PR TITLE
feat(api): multi-model option in xforms and fo standard endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.4-SNAPSHOT'
+    version = '3.15.4'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.3'
+    version = '3.15.4-SNAPSHOT'
 }
 
 subprojects {

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/exception/EnoExceptionController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/exception/EnoExceptionController.java
@@ -8,6 +8,7 @@ import fr.insee.eno.legacy.exception.EnoGenerationException;
 import fr.insee.eno.legacy.exception.EnoLegacyParametersException;
 import fr.insee.eno.treatments.exceptions.SpecificTreatmentsDeserializationException;
 import fr.insee.eno.treatments.exceptions.SpecificTreatmentsValidationException;
+import fr.insee.eno.ws.exception.MultiModelException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,6 +43,11 @@ public class EnoExceptionController {
 	@ExceptionHandler(value = MetadataFileException.class)
 	public ResponseEntity<Object> exception(MetadataFileException exception) {
 		return new ResponseEntity<>("Metadata file error: "+exception.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = MultiModelException.class)
+	public ResponseEntity<Object> exception(MultiModelException exception) {
+		return new ResponseEntity<>("Multi-model option error: "+exception.getMessage(), HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(value = EnoGenerationException.class)

--- a/eno-ws/src/main/java/fr/insee/eno/ws/exception/MultiModelException.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/exception/MultiModelException.java
@@ -1,0 +1,9 @@
+package fr.insee.eno.ws.exception;
+
+public class MultiModelException extends Exception {
+
+    public MultiModelException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
Add a multi-model option in Xforms and FO standard endpoints.

If this option is set to true, the output questionnaire(s) are in a zip file.

Configured it to be required in the "business" context.
