### PR TITLE
fix: open api host config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.4'
+    version = '3.15.5'
 }
 
 subprojects {

--- a/eno-ws/src/main/java/fr/insee/eno/ws/config/OpenApiConfiguration.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/config/OpenApiConfiguration.java
@@ -4,6 +4,7 @@ package fr.insee.eno.ws.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,8 @@ import org.springframework.context.annotation.PropertySource;
 @PropertySource("classpath:version.properties")
 public class OpenApiConfiguration {
 
+    @Value("${eno.ws.url}")
+    private String enoUrl;
     @Value("${eno.legacy.ws.url}")
     private String enoLegacyUrl;
     @Value("${version.eno}")
@@ -24,7 +27,10 @@ public class OpenApiConfiguration {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        Server server = new Server();
+        server.setUrl(enoUrl);
         return new OpenAPI()
+                .addServersItem(server)
                 .info(new Info()
                         .title("Eno Web Service")
                         .description(

--- a/eno-ws/src/main/resources/application.properties
+++ b/eno-ws/src/main/resources/application.properties
@@ -7,6 +7,9 @@ springdoc.swagger-ui.operationsSorter=alpha
 
 ### Customizable properties ###
 
+# URL of the deployed web-service app (used for swagger config)
+eno.ws.url=http://localhost:8080
+
 # URL of a Eno "xml" web-service where some requests are redirected
 eno.legacy.ws.url=https://eno-url.insee.fr
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         libs {
-            version('lunatic-model', '3.2.7-SNAPSHOT')
+            version('lunatic-model', '3.2.7')
             version('pogues-model', '1.0.5')
             library('lunatic-model', 'fr.insee.lunatic', 'lunatic-model').versionRef('lunatic-model')
             library('pogues-model', 'fr.insee.pogues', 'pogues-model').versionRef('pogues-model')


### PR DESCRIPTION
Add a "server" instance in the OpenAPI configuration, so that requests sent from the swagger-ui work more reliably.

\+ by the way, changed snapshot to released version of Lunatic-Model.