### PR TITLE
fix(controls): info criticality everywhere

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    if: ${{ (github.event.pull_request.draft == false) && !contains(github.event.pull_request.labels.*.name, 'deploy-snapshot') }}
+    if: ${{ (github.event.pull_request.draft == false) && !contains(github.event.pull_request.labels.*.name, 'deploy-snapshot') && !startsWith(github.event.head_commit.message, 'chore') }}
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.6-SNAPSHOT'
+    version = '3.15.6'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.5'
+    version = '3.15.6-SNAPSHOT'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/navigation/Control.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/navigation/Control.java
@@ -27,11 +27,13 @@ public class Control extends EnoIdentifiableObject implements EnoObjectWithExpre
 
     public enum TypeOfControl { CONSISTENCY, FORMAT }
 
+    // TODO: controls "criticality" temporary set to INFO
+
     public static Criticality convertDDICriticality(String ddiCriticality) {
         return switch (ddiCriticality) {
             case "informational" -> Criticality.INFO;
-            case "warning" -> Criticality.WARN;
-            case "stumblingblock" -> Criticality.ERROR;
+            case "warning" -> Criticality.INFO; // WARN
+            case "stumblingblock" -> Criticality.INFO; // ERROR
             default -> throw new MappingException(String.format("Unknown DDI criticality '%s'", ddiCriticality));
         };
     }
@@ -39,8 +41,8 @@ public class Control extends EnoIdentifiableObject implements EnoObjectWithExpre
     public static ControlCriticityEnum convertCriticalityToLunatic(Criticality criticality) {
         return switch (criticality) {
             case INFO -> ControlCriticityEnum.INFO;
-            case WARN -> ControlCriticityEnum.WARN;
-            case ERROR -> ControlCriticityEnum.ERROR;
+            case WARN -> ControlCriticityEnum.INFO; // WARN
+            case ERROR -> ControlCriticityEnum.INFO; // ERROR
         };
     }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormat.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormat.java
@@ -213,7 +213,7 @@ public class LunaticAddControlFormat implements ProcessingStep<Questionnaire> {
         ControlType control = new ControlType();
         control.setTypeOfControl(ControlTypeOfControlEnum.FORMAT);
         control.setId(id);
-        control.setCriticality(ControlCriticityEnum.ERROR);
+        control.setCriticality(ControlCriticityEnum.INFO); // TODO: maybe but back ERROR here later
 
         LabelType controlLabel = new LabelType();
         controlLabel.setType(LabelTypeEnum.VTL);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
@@ -52,7 +52,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("number-id-format-decimal", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -100,7 +100,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-inf-sup", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -119,7 +119,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-inf", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -138,7 +138,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-sup", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -167,7 +167,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-inf-sup", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -187,7 +187,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-inf", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test
@@ -207,7 +207,7 @@ class LunaticAddControlFormatTest {
         assertEquals("VTL|MD", control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-sup", control.getId());
         assertEquals(ControlTypeOfControlEnum.FORMAT, control.getTypeOfControl());
-        assertEquals(ControlCriticityEnum.ERROR, control.getCriticality());
+        assertEquals(ControlCriticityEnum.INFO, control.getCriticality());
     }
 
     @Test


### PR DESCRIPTION
Having variable criticality introduced a change in Lunatic questionnaire's behavior compared to previous major version of Eno.