### PR TITLE
refactor: null cases handling for ddi code lists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.6'
+    version = '3.15.7-SNAPSHOT'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.7-SNAPSHOT'
+    version = '3.15.7'
 }
 
 subprojects {


### PR DESCRIPTION
## Issue

- #862 

## Done

- Improve exception management in case a code list referenced in a question (or table cell, or else) is null

Having missing code lists is actually a non-issue in Eno, since this information must be present for the questionnaire to be valid.

To be resolved in Pogues.

Yet, improving the exception handling when this occurs does not hurt 🙃 
