### PR TITLE
ci: build release & push artifact

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,56 +73,57 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Build Eno modules
-        run: ./gradlew build
+        run: |
+          ./gradlew build
+          mv ./eno-ws/build/libs/*.jar ./eno-ws/build/libs/eno-ws.jar
 
       - name: Upload Eno-WS jar
         uses: actions/upload-artifact@v4
         with:
           name: eno-ws-jar
-          path: ./eno-ws/build/libs/*.jar
+          path: ./eno-ws/build/libs/eno-ws.jar
 
-  create-tag:
+  create-release: # replaced with create-tag while v3 is not the main branch
     needs: [ check-version, build-sources ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ needs.check-version.outputs.release-version }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
-#  create-release: # replaced with create-tag while v3 is not the main branch
-#    needs: [ check-version, build-sources ]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.ref }}
-#          fetch-depth: 0
-#
-#      - name: Get previous final release tag
-#        id: previousTag
-#        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | tail -1)" >> $GITHUB_OUTPUT
-#
-#      - name: Create release note
-#        id: changelog
-#        uses: requarks/changelog-action@v1
-#        with:
-#          fromTag: ${{ github.sha }}
-#          toTag: ${{ steps.previousTag.outputs.previousTag}}
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          writeToFile: false
-#
-#      - uses: softprops/action-gh-release@v1
-#        with:
-#          tag_name: ${{ needs.check-version.outputs.release-version }}
-#          target_commitish: ${{ github.head_ref || github.ref }}
-#          name: ${{ needs.check-version.outputs.release-version }}
-#          body: ${{steps.changelog.outputs.changes}}
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get previous final release tag
+        id: previousTag
+        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | tail -1)" >> $GITHUB_OUTPUT
+
+      - name: Create release note
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          fromTag: ${{ github.sha }}
+          toTag: ${{ steps.previousTag.outputs.previousTag}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          writeToFile: false
+
+      - name: Download build
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: eno-ws-jar
+          path: eno-ws/build/libs/
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.check-version.outputs.release-version }}
+          target_commitish: ${{ github.head_ref || github.ref }}
+          name: ${{ needs.check-version.outputs.release-version }}
+          body: ${{steps.changelog.outputs.changes}}
+          files: eno-ws/build/libs/eno-ws.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-docker:
-    needs: [ check-version, create-tag ]
+    needs: [ check-version, create-release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Purpose
In order to launch Cast analysis in internal infrastructure by downloading uploaded jar release

## ToDo
I think we can switch default branch to `v3-main` or rename `main` to `v2-legacy` and `v3-main` to `main`