### PR TITLE
fix: ddi expression references resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.15.8'
+    version = '3.15.9'
 }
 
 subprojects {

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
@@ -48,7 +48,7 @@ class DDIResolveVariableReferencesInExpressionsTest {
             EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
             Filter filter = new Filter();
             CalculatedExpression calculatedExpression= new CalculatedExpression();
-            calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-1O = 1");
+            calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-10 = 1");
             Set<BindingReference> bindingReferences = new LinkedHashSet<>();
             bindingReferences.add(new BindingReference("foo-ref-1", "FOO_A"));
             bindingReferences.add(new BindingReference("foo-ref-10", "FOO_K"));

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
@@ -4,7 +4,11 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.calculated.BindingReference;
 import fr.insee.eno.core.model.calculated.CalculatedExpression;
 import fr.insee.eno.core.model.navigation.Filter;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -25,6 +29,63 @@ class DDIResolveVariableReferencesInExpressionsTest {
         new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
         //
         assertEquals("FOO = 1", enoQuestionnaire.getFilters().get(0).getExpression().getValue());
+    }
+
+    /**
+     * In some cases variable references can overlap. This could lead to incorrect replacement of references by the
+     * corresponding variable name. This nested class contains a group of tests for these cases.
+     */
+    @Nested
+    class OverlappingCases {
+
+        /**
+         * This test uses an ordered implementation of Set for binding references, to simulate what could happen with
+         * real data.
+         */
+        @Test
+        void filterExpression_overlappingReferences_ascendingCase() {
+            //
+            EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+            Filter filter = new Filter();
+            CalculatedExpression calculatedExpression= new CalculatedExpression();
+            calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-1O = 1");
+            Set<BindingReference> bindingReferences = new LinkedHashSet<>();
+            bindingReferences.add(new BindingReference("foo-ref-1", "FOO_A"));
+            bindingReferences.add(new BindingReference("foo-ref-10", "FOO_K"));
+            calculatedExpression.setBindingReferences(bindingReferences);
+            filter.setExpression(calculatedExpression);
+            enoQuestionnaire.getFilters().add(filter);
+            //
+            new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
+            //
+            assertEquals("FOO_A = 1 and FOO_K = 1",
+                    enoQuestionnaire.getFilters().get(0).getExpression().getValue());
+        }
+
+        /**
+         * Same test with binding references in the reverse order. (These two tests could have been a parametrized
+         * test, but it would have been harder to read.)
+         */
+        @Test
+        void filterExpression_overlappingReferences_descendingCase() {
+            //
+            EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+            Filter filter = new Filter();
+            CalculatedExpression calculatedExpression= new CalculatedExpression();
+            calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-10 = 1");
+            Set<BindingReference> bindingReferences = new LinkedHashSet<>();
+            bindingReferences.add(new BindingReference("foo-ref-10", "FOO_K"));
+            bindingReferences.add(new BindingReference("foo-ref-1", "FOO_A"));
+            calculatedExpression.setBindingReferences(bindingReferences);
+            filter.setExpression(calculatedExpression);
+            enoQuestionnaire.getFilters().add(filter);
+            //
+            new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
+            //
+            assertEquals("FOO_A = 1 and FOO_K = 1",
+                    enoQuestionnaire.getFilters().get(0).getExpression().getValue());
+        }
+
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
@@ -1,0 +1,30 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.calculated.BindingReference;
+import fr.insee.eno.core.model.calculated.CalculatedExpression;
+import fr.insee.eno.core.model.navigation.Filter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DDIResolveVariableReferencesInExpressionsTest {
+
+    @Test
+    void filterExpression_oneReference() {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        Filter filter = new Filter();
+        CalculatedExpression calculatedExpression= new CalculatedExpression();
+        calculatedExpression.setValue("foo-reference = 1");
+        calculatedExpression.getBindingReferences()
+                .add(new BindingReference("foo-reference", "FOO"));
+        filter.setExpression(calculatedExpression);
+        enoQuestionnaire.getFilters().add(filter);
+        //
+        new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
+        //
+        assertEquals("FOO = 1", enoQuestionnaire.getFilters().get(0).getExpression().getValue());
+    }
+
+}


### PR DESCRIPTION
## Summary

_(Reminder)_

1. In Pogues, the user inputs VTL expressions with variable names sourrounded with `$`.
2. In DDI, variable names are replaced with references.
3. In the Lunatic questionnaire, these references must be replaced by the corresponding variable names.

The issue: 

Variable references in DDI are a referrence suffixed with a number 1, 2, 3...

This could lead to an incorrect replacement in expressions that use 10 or more variables: 

`ref-10` could be replaced by `<name of variable "1">0`

## Done

Sort variable references in a certain way before replacing them in DDI "variable reference in expression resolution" processing.

---

Note: this is more tricky than it should be imo...

We may rework the DDI implementation of the references subject to make our lives easier 🙃 
