### PR TITLE
fix: remove prefix in questionnaire id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.16.0'
+    version = '3.16.1'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
@@ -11,6 +11,7 @@ public class DDIInProcessing {
         //
         ProcessingPipeline<EnoQuestionnaire> processingPipeline = new ProcessingPipeline<>();
         processingPipeline.start(enoQuestionnaire)
+                .then(new DDICleanUpQuestionnaireId())
                 .then(new DDIMoveUnitInQuestions())
                 .then(new DDIInsertResponseInTableCells())
                 .then(new DDIResolveVariableReferencesInExpressions())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDICleanUpQuestionnaireId.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDICleanUpQuestionnaireId.java
@@ -1,0 +1,28 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.exceptions.technical.MappingException;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.processing.ProcessingStep;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * For some reason, an "Insee" prefix is added in the questionnaire identifier by the current Pogues to DDI
+ * transformation. This processing removes this prefix.
+ */
+@Slf4j
+public class DDICleanUpQuestionnaireId implements ProcessingStep<EnoQuestionnaire> {
+
+    private static final String INSEE_PREFIX = "INSEE-";
+
+    /**
+     * Removes the "Insee" prefix in the given questionnaire's id.
+     * @param enoQuestionnaire A Eno questionnaire.
+     */
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        if (enoQuestionnaire.getId() == null) // Shouldn't happen but you never know...
+            throw new MappingException("Questionnaire as a null identifier.");
+        enoQuestionnaire.setId(enoQuestionnaire.getId().replace(INSEE_PREFIX, ""));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDICleanUpQuestionnaireIdTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDICleanUpQuestionnaireIdTest.java
@@ -1,0 +1,39 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DDICleanUpQuestionnaireIdTest {
+
+    @Test
+    void questionnaireWithNullId_shouldThrowException() {
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        assertThrows(Exception.class, () -> new DDICleanUpQuestionnaireId().apply(enoQuestionnaire));
+    }
+
+    @Test
+    void questionnaireWithRegularId_shouldNotBeModified() {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setId("abcde1234");
+        //
+        new DDICleanUpQuestionnaireId().apply(enoQuestionnaire);
+        //
+        assertEquals("abcde1234", enoQuestionnaire.getId());
+    }
+
+    @Test
+    void questionnaireWithInseePrefix_shouldBeModified() {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        enoQuestionnaire.setId("INSEE-abcde1234");
+        //
+        new DDICleanUpQuestionnaireId().apply(enoQuestionnaire);
+        //
+        assertEquals("abcde1234", enoQuestionnaire.getId());
+    }
+
+}


### PR DESCRIPTION
- #889 

DDI questionnaires have a `INSEE-` prefix that comes from the current Eno Xml "Pogues to DDI" transformation.

As a result, this prefixed was also in the generated Lunatic questionnaire.

Fixed this.
