### PR TITLE
fix: pairwise missing variable name

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/Question.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/Question.java
@@ -13,7 +13,9 @@ import fr.insee.eno.core.model.label.DynamicLabel;
 import fr.insee.eno.core.model.navigation.ComponentFilter;
 import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.parameter.Format;
-import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.ComponentMultipleResponseType;
+import fr.insee.lunatic.model.flat.ComponentSimpleResponseType;
+import fr.insee.lunatic.model.flat.PairwiseLinks;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,7 +29,9 @@ import java.util.List;
         type = {ComponentSimpleResponseType.class, ComponentMultipleResponseType.class, PairwiseLinks.class})
 public abstract class Question extends EnoIdentifiableObject implements EnoComponent {
 
-    /** Attribute is defined here to factor toString methods,
+    /**
+     * Business name of the question.
+     * Attribute is defined here to factor toString methods,
      * but DDI mapping is done in subclasses since DDI classes are different. */
     String name;
 

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -5,13 +5,66 @@ import fr.insee.eno.core.exceptions.technical.LunaticPairwiseException;
 import fr.insee.lunatic.model.flat.*;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Slf4j
 public class LunaticUtils {
 
     private LunaticUtils() {}
+
+    /**
+     * Return the list of components that contain a response (questions/loops) from the given component list.
+     * @param components A list of Lunatic components.
+     * @return A new list with only components that contain a response.
+     */
+    public static List<ComponentType> getResponseComponents(List<ComponentType> components) {
+        return components.stream()
+                .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.SEQUENCE))
+                .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.SUBSEQUENCE))
+                .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.FILTER_DESCRIPTION))
+                .toList();
+    }
+
+    /**
+     * Get the list of response names that belong to the component.
+     * @param component A Lunatic component which hold responses.
+     * @return List of response names that belong to the given component.
+     * @throws IllegalArgumentException if the given component is of a type that does not contain responses.
+     */
+    public static List<String> getResponseNames(ComponentType component) {
+        List<String> names;
+        switch (component.getComponentType()) {
+            case CHECKBOX_GROUP -> names = ((CheckboxGroup) component).getResponses().stream()
+                    .map(ResponsesCheckboxGroup::getResponse)
+                    .map(ResponseType::getName)
+                    .toList();
+            case ROSTER_FOR_LOOP -> names = ((RosterForLoop) component).getComponents().stream()
+                    .filter(subcomponent -> subcomponent.getResponse() != null)
+                    .map(subcomponent -> subcomponent.getResponse().getName())
+                    .toList();
+            case LOOP -> names = getResponseComponents(((Loop) component).getComponents()).stream()
+                    .map(LunaticUtils::getResponseNames)
+                    .flatMap(Collection::stream)
+                    .toList();
+            case TABLE -> names = ((Table) component).getBodyLines().stream()
+                    .map(BodyLine::getBodyCells)
+                    .flatMap(Collection::stream)
+                    .filter(subcomponent -> subcomponent.getResponse() != null)
+                    .map(subcomponent -> subcomponent.getResponse().getName())
+                    .toList();
+            default -> {
+                if (! (component instanceof ComponentSimpleResponseType simpleResponseComponent))
+                    throw new IllegalArgumentException(String.format(
+                            "Method to get response names cannot be called on a component of type %s.",
+                            component.getComponentType()));
+                names = List.of(simpleResponseComponent.getResponse().getName());
+            }
+        }
+        return names;
+    }
 
     /**
      * From a Lunatic loop object given, returns the list of collected variable names that belong to this loop.
@@ -52,14 +105,30 @@ public class LunaticUtils {
         return result;
     }
 
+    /**
+     * Return the response name of the component that belong to the given pairwise links. This method checks if
+     * the inner component is valid.
+     * @param pairwiseLinks A pairwise links component.
+     * @return The pairwise inner component.
+     * @throws LunaticPairwiseException if the component in the pairwise is invalid.
+     */
     public static String getPairwiseResponseVariable(PairwiseLinks pairwiseLinks) {
-        // Some controls...
-        int pairwiseComponentsSize = pairwiseLinks.getComponents().size();
-        if (pairwiseComponentsSize != 1)
-            throw new LunaticPairwiseException(String.format(
-                    "Lunatic pairwise must contain exactly 1 component. Pairwise object '%s' contains %s.",
-                    pairwiseLinks.getId(), pairwiseComponentsSize));
+        ComponentType pairwiseInnerComponent = getPairwiseInnerComponent(pairwiseLinks);
+        return ((ComponentSimpleResponseType) pairwiseInnerComponent).getResponse().getName();
+    }
+
+    /**
+     * Return the unique choice component that belong to the given pairwise links. This method checks if the inner
+     * component is valid.
+     * @param pairwiseLinks A pairwise links component.
+     * @return The pairwise inner component.
+     * @throws LunaticPairwiseException if the component in the pairwise is invalid.
+     */
+    public static ComponentType getPairwiseInnerComponent(PairwiseLinks pairwiseLinks) {
+        // Get the pairwise inner component
+        checkPairwiseComponentSize(pairwiseLinks);
         ComponentType pairwiseComponent = pairwiseLinks.getComponents().get(0);
+        // Check that this component has a complying type
         if (! (ComponentTypeEnum.DROPDOWN.equals(pairwiseComponent.getComponentType()) ||
                 ComponentTypeEnum.RADIO.equals(pairwiseComponent.getComponentType()) ||
                 ComponentTypeEnum.CHECKBOX_ONE.equals(pairwiseComponent.getComponentType())))
@@ -68,7 +137,20 @@ public class LunaticUtils {
                             "contains a component of type '%s'.",
                     pairwiseLinks.getId(), pairwiseComponent.getComponentType()));
         //
-        return ((ComponentSimpleResponseType) pairwiseComponent).getResponse().getName();
+        return pairwiseComponent;
+    }
+
+    /**
+     * Checks if the given pairwise links contains exactly one component.
+     * @param pairwiseLinks A pairwise component.
+     * @throws LunaticPairwiseException if there is not exactly one component in the pairwise.
+     */
+    private static void checkPairwiseComponentSize(PairwiseLinks pairwiseLinks) {
+        int pairwiseComponentsSize = pairwiseLinks.getComponents().size();
+        if (pairwiseComponentsSize != 1)
+            throw new LunaticPairwiseException(String.format(
+                    "Lunatic pairwise must contain exactly 1 component. Pairwise object '%s' contains %s.",
+                    pairwiseLinks.getId(), pairwiseComponentsSize));
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesPairwiseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesPairwiseTest.java
@@ -1,0 +1,62 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.model.lunatic.MissingBlock;
+import fr.insee.lunatic.model.flat.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests on the Lunatic "missing variables" processing focused on the pairwise links component case.
+ * */
+class LunaticAddMissingVariablesPairwiseTest {
+
+    @Test
+    void pairwiseMissingVariable_unitTest() {
+        // Given
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        PairwiseLinks pairwiseLinks = new PairwiseLinks();
+        pairwiseLinks.setComponentType(ComponentTypeEnum.PAIRWISE_LINKS);
+        Dropdown dropdown = new Dropdown();
+        dropdown.setComponentType(ComponentTypeEnum.DROPDOWN);
+        ResponseType responseType = new ResponseType();
+        responseType.setName("FOO_LINKS");
+        dropdown.setResponse(responseType);
+        pairwiseLinks.getComponents().add(dropdown);
+        lunaticQuestionnaire.getComponents().add(pairwiseLinks);
+
+        // When (no need of the Eno catalog in this case)
+        new LunaticAddMissingVariables(null, true).apply(lunaticQuestionnaire);
+
+        // Then
+        assertNotNull(dropdown.getMissingResponse());
+        assertEquals("FOO_LINKS_MISSING", dropdown.getMissingResponse().getName());
+        //
+        Optional<IVariableType> pairwiseMissingVariable = lunaticQuestionnaire.getVariables().stream()
+                .filter(variable -> "FOO_LINKS_MISSING".equals(variable.getName()))
+                .findAny();
+        assertTrue(pairwiseMissingVariable.isPresent());
+        //
+        List<MissingBlock> missingEntries = lunaticQuestionnaire.getMissingBlock().getAny().stream()
+                .map(MissingBlock.class::cast).toList();
+        assertEquals(2, missingEntries.size());
+        //
+        Optional<MissingBlock> pairwiseMissingBlock = missingEntries.stream()
+                .filter(missingBlock -> "FOO_LINKS_MISSING".equals(missingBlock.getMissingName()))
+                .findAny();
+        assertTrue(pairwiseMissingBlock.isPresent());
+        assertEquals(1, pairwiseMissingBlock.get().getNames().size());
+        assertEquals("FOO_LINKS", pairwiseMissingBlock.get().getNames().get(0));
+        //
+        Optional<MissingBlock> pairwiseReverseMissingBlock = missingEntries.stream()
+                .filter(missingBlock -> "FOO_LINKS".equals(missingBlock.getMissingName()))
+                .findAny();
+        assertTrue(pairwiseReverseMissingBlock.isPresent());
+        assertEquals(1, pairwiseReverseMissingBlock.get().getNames().size());
+        assertEquals("FOO_LINKS_MISSING", pairwiseReverseMissingBlock.get().getNames().get(0));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesTest.java
@@ -454,6 +454,7 @@ class LunaticAddMissingVariablesTest {
         loop.setId(id);
         loop.getComponents().addAll(components);
         if(isMainLoop) {
+            loop.setPaginatedLoop(false);
             LinesLoop line = new LinesLoop();
             LabelType label = new LabelType();
             label.setValue("COUNT(prenom)");
@@ -464,6 +465,7 @@ class LunaticAddMissingVariablesTest {
         LabelType label = new LabelType();
         label.setValue("COUNT(prenom)");
         loop.setIterations(label);
+        loop.setPaginatedLoop(true);
         return loop;
     }
 


### PR DESCRIPTION
- #875 

The "response" object was put instead of its "name" value.

Also updated to condition which differentiate the behavior between main loops and linked loops for the "missing" variables: the difference shouldn't be between main vs. linked loops, but between non paginated/paginated loops.

\+ refactor and add javadoc to make code clearer
