### PR TITLE
fix: lunatic variables serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.18.3'
+    version = '3.18.4'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/LunaticConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/LunaticConverter.java
@@ -18,8 +18,14 @@ import fr.insee.eno.core.model.response.CodeResponse;
 import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.sequence.Subsequence;
+import fr.insee.eno.core.model.variable.CalculatedVariable;
+import fr.insee.eno.core.model.variable.CollectedVariable;
+import fr.insee.eno.core.model.variable.ExternalVariable;
 import fr.insee.eno.core.model.variable.Variable;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.ExternalVariableType;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -38,8 +44,8 @@ public class LunaticConverter {
         if (! enoObject.getClass().getPackageName().startsWith("fr.insee.eno.core.model"))
             throw new IllegalArgumentException("Not an Eno object.");
         //
-        if (enoObject instanceof Variable)
-            return new VariableType();
+        if (enoObject instanceof Variable enoVariable)
+            return instantiateFrom(enoVariable);
         if (enoObject instanceof Sequence)
             return new fr.insee.lunatic.model.flat.Sequence();
         if (enoObject instanceof Subsequence)
@@ -126,6 +132,16 @@ public class LunaticConverter {
             case CHECKBOX -> new CheckboxOne();
             case DROPDOWN -> new Dropdown();
         };
+    }
+
+    private static Object instantiateFrom(Variable enoVariable) {
+        if (enoVariable instanceof CollectedVariable)
+            return new CollectedVariableType();
+        if (enoVariable instanceof CalculatedVariable)
+            return new CalculatedVariableType();
+        if (enoVariable instanceof ExternalVariable)
+            return new ExternalVariableType();
+        throw new ConversionException(unimplementedMessage(enoVariable));
     }
 
     private static Object instantiateFrom(MultipleResponseQuestion enoQuestion) {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/variable/CalculatedVariable.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/variable/CalculatedVariable.java
@@ -7,6 +7,7 @@ import fr.insee.eno.core.model.EnoObjectWithExpression;
 import fr.insee.eno.core.model.calculated.BindingReference;
 import fr.insee.eno.core.model.calculated.CalculatedExpression;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Context(format = Format.DDI, type = logicalproduct33.VariableType.class)
-@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.VariableType.class)
+@Context(format = Format.LUNATIC, type = CalculatedVariableType.class)
 public class CalculatedVariable extends Variable implements EnoObjectWithExpression {
 
     @Getter

--- a/eno-core/src/main/java/fr/insee/eno/core/model/variable/CollectedVariable.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/variable/CollectedVariable.java
@@ -4,13 +4,14 @@ import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Context(format = Format.DDI, type = logicalproduct33.VariableType.class)
-@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.VariableType.class)
+@Context(format = Format.LUNATIC, type = CollectedVariableType.class)
 public class CollectedVariable extends Variable {
 
     @Lunatic("setVariableType(T(fr.insee.eno.core.model.variable.Variable).lunaticCollectionType(#param))")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/variable/ExternalVariable.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/variable/ExternalVariable.java
@@ -4,13 +4,14 @@ import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.lunatic.model.flat.variable.ExternalVariableType;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Context(format = Format.DDI, type = logicalproduct33.VariableType.class)
-@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.VariableType.class)
+@Context(format = Format.LUNATIC, type = ExternalVariableType.class)
 public class ExternalVariable extends Variable {
 
     @Lunatic("setVariableType(T(fr.insee.eno.core.model.variable.Variable).lunaticCollectionType(#param))")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/variable/Variable.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/variable/Variable.java
@@ -5,14 +5,14 @@ import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.parameter.Format;
-import fr.insee.lunatic.model.flat.VariableTypeEnum;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Context(format = Format.DDI, type = logicalproduct33.VariableType.class)
-@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.VariableType.class)
+@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.variable.VariableType.class)
 public abstract class Variable extends EnoObject {
 
     public enum CollectionType {COLLECTED, CALCULATED, EXTERNAL}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddCleaningVariables.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddCleaningVariables.java
@@ -2,6 +2,8 @@ package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.eno.core.processing.ProcessingStep;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.VariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
@@ -114,7 +116,7 @@ public class LunaticAddCleaningVariables implements ProcessingStep<Questionnaire
     private static List<String> filterNonCollectedVariables(List<String> variableNames, Questionnaire lunaticQuestionnaire) {
         return lunaticQuestionnaire.getVariables().stream()
                 .filter(variable -> VariableTypeEnum.COLLECTED.equals(variable.getVariableType()))
-                .map(IVariableType::getName)
+                .map(VariableType::getName)
                 .filter(variableNames::contains)
                 .toList();
     }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariables.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariables.java
@@ -5,6 +5,8 @@ import fr.insee.eno.core.processing.ProcessingStep;
 import fr.insee.eno.core.reference.EnoCatalog;
 import fr.insee.eno.core.utils.LunaticUtils;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -84,27 +86,27 @@ public class LunaticAddMissingVariables implements ProcessingStep<Questionnaire>
                 LunaticUtils.getResponseComponents(loop.getComponents()).forEach(loopComponent -> {
                     Question question = enoCatalog.getQuestion(loopComponent.getId());
                     String missingResponseName = setMissingResponse(loopComponent, question.getName());
-                    addMissingVariable(new VariableTypeArray(), missingResponseName, lunaticQuestionnaire);
+                    addMissingVariable(missingResponseName, new CollectedVariableValues.Array(), lunaticQuestionnaire);
                 });
             }
 
             case ROSTER_FOR_LOOP -> {
                 Question question = enoCatalog.getQuestion(component.getId());
                 String missingResponseName = setMissingResponse(component, question.getName());
-                addMissingVariable(new VariableTypeArray(), missingResponseName, lunaticQuestionnaire);
+                addMissingVariable(missingResponseName,new CollectedVariableValues.Array(), lunaticQuestionnaire);
             }
 
             case PAIRWISE_LINKS -> {
                 ComponentType pairwiseInnerComponent = LunaticUtils.getPairwiseInnerComponent((PairwiseLinks) component);
                 String pairwiseResponseName = ((ComponentSimpleResponseType) pairwiseInnerComponent).getResponse().getName();
                 String missingResponseName = setMissingResponse(pairwiseInnerComponent, pairwiseResponseName);
-                addMissingVariable(new VariableTypeTwoDimensionsArray(), missingResponseName, lunaticQuestionnaire);
+                addMissingVariable(missingResponseName, new CollectedVariableValues.DoubleArray(), lunaticQuestionnaire);
             }
 
             default -> {
                 Question question = enoCatalog.getQuestion(component.getId());
                 String missingResponseName = setMissingResponse(component, question.getName());
-                addMissingVariable(new VariableType(), missingResponseName, lunaticQuestionnaire);
+                addMissingVariable(missingResponseName, new CollectedVariableValues.Scalar(), lunaticQuestionnaire);
             }
         }
     }
@@ -124,10 +126,11 @@ public class LunaticAddMissingVariables implements ProcessingStep<Questionnaire>
         return missingResponseName;
     }
 
-    private void addMissingVariable(IVariableType variable, String missingResponseName,
+    private void addMissingVariable(String missingResponseName, CollectedVariableValues values,
                                     Questionnaire lunaticQuestionnaire) {
+        CollectedVariableType variable = new CollectedVariableType();
         variable.setName(missingResponseName);
-        variable.setVariableType(VariableTypeEnum.COLLECTED);
+        variable.setValues(values);
         lunaticQuestionnaire.getVariables().add(variable);
     }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddShapeToCalculatedVariables.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddShapeToCalculatedVariables.java
@@ -4,8 +4,7 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.processing.ProcessingStep;
 import fr.insee.eno.core.processing.out.steps.lunatic.calculatedvariable.ShapefromAttributeRetrieval;
 import fr.insee.lunatic.model.flat.Questionnaire;
-import fr.insee.lunatic.model.flat.VariableType;
-import fr.insee.lunatic.model.flat.VariableTypeEnum;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
 
 import java.util.List;
 
@@ -24,13 +23,12 @@ public class LunaticAddShapeToCalculatedVariables implements ProcessingStep<Ques
 
     @Override
     public void apply(Questionnaire lunaticQuestionnaire) {
-        List<VariableType> lunaticCalculatedVariables = lunaticQuestionnaire.getVariables().stream()
-                .filter(VariableType.class::isInstance)
-                .map(VariableType.class::cast)
-                .filter(variableType -> variableType.getVariableType().equals(VariableTypeEnum.CALCULATED))
+        List<CalculatedVariableType> lunaticCalculatedVariables = lunaticQuestionnaire.getVariables().stream()
+                .filter(CalculatedVariableType.class::isInstance)
+                .map(CalculatedVariableType.class::cast)
                 .toList();
 
-        for(VariableType lunaticCalculatedVariable : lunaticCalculatedVariables) {
+        for(CalculatedVariableType lunaticCalculatedVariable : lunaticCalculatedVariables) {
             shapeFromAttributeRetrieval.getShapeFrom(lunaticCalculatedVariable.getName(), enoQuestionnaire)
                     .ifPresent(shapeFromVariable -> lunaticCalculatedVariable.setShapeFrom(shapeFromVariable.getName()));
         }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
@@ -7,6 +7,8 @@ import fr.insee.eno.core.model.question.Question;
 import fr.insee.eno.core.processing.ProcessingStep;
 import fr.insee.eno.core.processing.out.steps.lunatic.calculatedvariable.ShapefromAttributeRetrieval;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +27,7 @@ public class LunaticFilterResult implements ProcessingStep<Questionnaire> {
 
     @Override
     public void apply(Questionnaire lunaticQuestionnaire) {
-        List<VariableType> calculatedVariables = generateFilterVariables(lunaticQuestionnaire.getComponents());
+        List<CalculatedVariableType> calculatedVariables = generateFilterVariables(lunaticQuestionnaire.getComponents());
         lunaticQuestionnaire.getVariables().addAll(calculatedVariables);
     }
 
@@ -34,8 +36,8 @@ public class LunaticFilterResult implements ProcessingStep<Questionnaire> {
      * @param components list of components
      * @return filter result calculated variables
      */
-    private List<VariableType> generateFilterVariables(List<ComponentType> components) {
-        List<VariableType> filterVariables = new ArrayList<>();
+    private List<CalculatedVariableType> generateFilterVariables(List<ComponentType> components) {
+        List<CalculatedVariableType> filterVariables = new ArrayList<>();
         for(ComponentType component : components) {
             generateFilterVariable(component)
                     .ifPresent(filterVariables::add);
@@ -51,12 +53,12 @@ public class LunaticFilterResult implements ProcessingStep<Questionnaire> {
      * @param component generate a filter variable from this component
      * @return a filter variable if the component is a question with condition filter, otherwise none
      */
-    private Optional<VariableType> generateFilterVariable(ComponentType component) {
+    private Optional<CalculatedVariableType> generateFilterVariable(ComponentType component) {
         if(!isQuestionWithConditionFilter(component)) {
             return Optional.empty();
         }
 
-        VariableType filterVariable = new VariableType();
+        CalculatedVariableType filterVariable = new CalculatedVariableType();
         filterVariable.setVariableType(VariableTypeEnum.CALCULATED);
         Question question = (Question) enoQuestionnaire.getIndex().get(component.getId());
         String questionName = question.getName();

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwise.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwise.java
@@ -1,12 +1,12 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
-import fr.insee.eno.core.exceptions.business.LunaticSerializationException;
 import fr.insee.eno.core.exceptions.technical.LunaticPairwiseException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.question.PairwiseQuestion;
 import fr.insee.eno.core.processing.ProcessingStep;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,8 +48,7 @@ public class LunaticFinalizePairwise implements ProcessingStep<Questionnaire> {
         ComponentType pairwiseSubComponent = pairwiseLinks.getComponents().getFirst();
         pairwiseSubComponent.setConditionFilter(null);
 
-        List<IVariableType> variables = lunaticQuestionnaire.getVariables();
-        variables.addAll(createCalculatedAxisVariables(pairwiseLinks));
+        lunaticQuestionnaire.getVariables().addAll(createCalculatedAxisVariables(pairwiseLinks));
     }
 
     /**
@@ -78,18 +77,17 @@ public class LunaticFinalizePairwise implements ProcessingStep<Questionnaire> {
      * @param pairwiseLinks Lunatic pairwise links component.
      * @return calculated axis variables.
      */
-    private List<VariableType> createCalculatedAxisVariables(PairwiseLinks pairwiseLinks) {
+    private List<CalculatedVariableType> createCalculatedAxisVariables(PairwiseLinks pairwiseLinks) {
         PairwiseQuestion pairwiseQuestion = (PairwiseQuestion) enoIndex.get(pairwiseLinks.getId());
         String pairwiseName = pairwiseQuestion.getLoopVariableName();
 
-        List<VariableType> variables = new ArrayList<>();
+        List<CalculatedVariableType> variables = new ArrayList<>();
 
         List<String> calculatedVariableNames = List.of("xAxis", "yAxis");
 
         // create calculated variables
         for(String calculatedVariableName : calculatedVariableNames) {
-            VariableType calculatedAxis = new VariableType();
-            calculatedAxis.setVariableType(VariableTypeEnum.CALCULATED);
+            CalculatedVariableType calculatedAxis = new CalculatedVariableType();
             calculatedAxis.setName(calculatedVariableName);
             LabelType expression = new LabelType();
             expression.setType(LabelTypeEnum.VTL);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogic.java
@@ -11,6 +11,8 @@ import fr.insee.eno.core.processing.out.steps.lunatic.LunaticLoopResolution;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.eno.core.utils.LunaticUtils;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.VariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
@@ -77,7 +79,7 @@ public class LunaticLoopResizingLogic {
                 .toList();
         return lunaticQuestionnaire.getVariables().stream()
                 .filter(variable -> VariableTypeEnum.COLLECTED.equals(variable.getVariableType()))
-                .map(IVariableType::getName)
+                .map(VariableType::getName)
                 .filter(maxIterationDependencies::contains)
                 .toList();
     }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticPairwiseResizingLogic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticPairwiseResizingLogic.java
@@ -6,11 +6,16 @@ import fr.insee.eno.core.model.question.PairwiseQuestion;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.eno.core.utils.LunaticUtils;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
+@Slf4j
 public class LunaticPairwiseResizingLogic {
 
     private final Questionnaire lunaticQuestionnaire;
@@ -55,7 +60,7 @@ public class LunaticPairwiseResizingLogic {
         // Source variable of the pairwise
         String pairwiseSourceVariableName = enoPairwiseQuestion.getLoopVariableName();
         // Find corresponding variable object
-        Optional<IVariableType> correspondingVariable = lunaticQuestionnaire.getVariables().stream()
+        Optional<VariableType> correspondingVariable = lunaticQuestionnaire.getVariables().stream()
                 .filter(variable -> pairwiseSourceVariableName.equals(variable.getName()))
                 .findAny();
         if (correspondingVariable.isEmpty())
@@ -66,7 +71,9 @@ public class LunaticPairwiseResizingLogic {
         if (! VariableTypeEnum.CALCULATED.equals(correspondingVariable.get().getVariableType()))
             return Set.of(pairwiseSourceVariableName);
         // Otherwise return its binding dependencies (without the calculated variable)
-        VariableType pairwiseSourceVariable = (VariableType) correspondingVariable.get();
+        // Shouldn't happen with current modeling
+        log.warn("Source variable of a pairwise component should be a collected variable (not a calculated one).");
+        CalculatedVariableType pairwiseSourceVariable = (CalculatedVariableType) correspondingVariable.get();
         return new LinkedHashSet<>(pairwiseSourceVariable.getBindingDependencies().stream()
                 .filter(variableName -> !pairwiseSourceVariableName.equals(variableName))
                 .toList());

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -112,7 +112,7 @@ public class LunaticUtils {
      * Return the response name of the component that belong to the given pairwise links. This method checks if
      * the inner component is valid.
      * @param pairwiseLinks A pairwise links component.
-     * @return The pairwise inner component.
+     * @return The response name of the pairwise inner component.
      * @throws LunaticPairwiseException if the component in the pairwise is invalid.
      */
     public static String getPairwiseResponseVariable(PairwiseLinks pairwiseLinks) {
@@ -130,7 +130,7 @@ public class LunaticUtils {
     public static ComponentType getPairwiseInnerComponent(PairwiseLinks pairwiseLinks) {
         // Get the pairwise inner component
         checkPairwiseComponentSize(pairwiseLinks);
-        ComponentType pairwiseComponent = pairwiseLinks.getComponents().get(0);
+        ComponentType pairwiseComponent = pairwiseLinks.getComponents().getFirst();
         // Check that this component has a complying type
         if (! (ComponentTypeEnum.DROPDOWN.equals(pairwiseComponent.getComponentType()) ||
                 ComponentTypeEnum.RADIO.equals(pairwiseComponent.getComponentType()) ||

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
@@ -11,8 +11,8 @@ import fr.insee.eno.core.parameter.Format;
 import fr.insee.eno.core.processing.out.steps.lunatic.LunaticFilterResult;
 import fr.insee.lunatic.model.flat.LabelTypeEnum;
 import fr.insee.lunatic.model.flat.Questionnaire;
-import fr.insee.lunatic.model.flat.VariableType;
-import fr.insee.lunatic.model.flat.VariableTypeEnum;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -27,12 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CalculatedVariableTest {
 
     private CalculatedVariable enoVariable;
-    private VariableType lunaticVariable;
+    private CalculatedVariableType lunaticVariable;
 
     @BeforeEach
     void createObjects() {
         enoVariable = new CalculatedVariable();
-        lunaticVariable = new VariableType();
+        lunaticVariable = new CalculatedVariableType();
     }
 
     @Test
@@ -90,7 +90,7 @@ class CalculatedVariableTest {
     @Nested
     class IntegrationTest1 {
 
-        private static Map<String, VariableType> calculatedVariables;
+        private static Map<String, CalculatedVariableType> filterResultVariables;
 
         @BeforeAll
         static void mapQuestionnaire() throws DDIParsingException {
@@ -99,17 +99,17 @@ class CalculatedVariableTest {
                             "integration/ddi/ddi-variables.xml"),
                     EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
             //
-            calculatedVariables = new HashMap<>();
+            filterResultVariables = new HashMap<>();
             lunaticQuestionnaire.getVariables().stream()
-                    .map(VariableType.class::cast)
-                    .filter(variableType -> VariableTypeEnum.CALCULATED.equals(variableType.getVariableType()))
+                    .filter(CalculatedVariableType.class::isInstance)
+                    .map(CalculatedVariableType.class::cast)
                     .filter(variableType -> !variableType.getName().startsWith(LunaticFilterResult.FILTER_RESULT_PREFIX))
-                    .forEach(variableType -> calculatedVariables.put(variableType.getName(), variableType));
+                    .forEach(variableType -> filterResultVariables.put(variableType.getName(), variableType));
         }
 
         @Test
         void variablesCount() {
-            assertEquals(9, calculatedVariables.size());
+            assertEquals(9, filterResultVariables.size());
         }
 
         @Test
@@ -117,65 +117,65 @@ class CalculatedVariableTest {
             assertEquals(
                     Set.of("CALCULATED1", "CALCULATED2", "CALCULATED3", "CALCULATED4",
                             "CALCULATED5", "CALCULATED6", "CALCULATED7", "CALCULATED8", "CALCULATED9"),
-                    calculatedVariables.keySet());
+                    filterResultVariables.keySet());
         }
 
         @Test
         void calculatedExpressions() {
             assertEquals("cast(NUMBER1, number) * 10",
-                    calculatedVariables.get("CALCULATED1").getExpression().getValue());
+                    filterResultVariables.get("CALCULATED1").getExpression().getValue());
             // ...
         }
 
         @Test
         void calculatedExpressionType() {
-            calculatedVariables.values().forEach(variableType ->
+            filterResultVariables.values().forEach(variableType ->
                     assertEquals(LabelTypeEnum.VTL, variableType.getExpression().getTypeEnum()));
         }
 
         @Test
         void bindingDependencies_collectedOnly() {
-            assertThat(calculatedVariables.get("CALCULATED1").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED1").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("NUMBER1"));
-            assertThat(calculatedVariables.get("CALCULATED2").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED2").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("NUMBER1", "NUMBER2"));
         }
 
         @Test
         void bindingDependencies_withCalculated() {
-            assertThat(calculatedVariables.get("CALCULATED3").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED3").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("CALCULATED1", "NUMBER1"));
-            assertThat(calculatedVariables.get("CALCULATED4").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED4").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("CALCULATED2", "NUMBER1", "NUMBER2"));
         }
 
         @Test
         void bindingDependencies_intermediateCalculatedReference() {
-            assertThat(calculatedVariables.get("CALCULATED5").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED5").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("CALCULATED4", "NUMBER1", "NUMBER2"));
         }
 
         @Test
         void bindingDependencies_external() {
-            assertThat(calculatedVariables.get("CALCULATED6").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED6").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("EXTERNAL_TEXT"));
         }
 
         @Test
         void bindingDependencies_externalAndCollected() {
-            assertThat(calculatedVariables.get("CALCULATED7").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED7").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("EXTERNAL_NUMBER", "NUMBER1"));
         }
 
         @Test
         void bindingDependencies_externalAndCollectedAndCalculated() {
-            assertThat(calculatedVariables.get("CALCULATED8").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED8").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("EXTERNAL_NUMBER", "NUMBER1", "CALCULATED7"));
         }
 
         @Test
         void bindingDependencies_finalBoss() {
-            assertThat(calculatedVariables.get("CALCULATED9").getBindingDependencies())
+            assertThat(filterResultVariables.get("CALCULATED9").getBindingDependencies())
                     .containsExactlyInAnyOrderElementsOf(List.of("EXTERNAL_NUMBER", "NUMBER1", "NUMBER2",
                             "CALCULATED4", "CALCULATED7"));
         }
@@ -193,9 +193,9 @@ class CalculatedVariableTest {
                             "integration/ddi/ddi-declarations.xml"),
                     EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
             // Then
-            Optional<VariableType> lunaticVariable = lunaticQuestionnaire.getVariables().stream()
+            Optional<CalculatedVariableType> lunaticVariable = lunaticQuestionnaire.getVariables().stream()
                     .filter(variableType -> "CALCULATED1".equals(variableType.getName()))
-                    .map(VariableType.class::cast)
+                    .map(CalculatedVariableType.class::cast)
                     .findAny();
             assertTrue(lunaticVariable.isPresent());
             assertEquals(VariableTypeEnum.CALCULATED, lunaticVariable.get().getVariableType());
@@ -203,7 +203,7 @@ class CalculatedVariableTest {
             assertEquals("cast(Q3, integer) + 5", lunaticVariable.get().getExpression().getValue());
             assertEquals(LabelTypeEnum.VTL, lunaticVariable.get().getExpression().getTypeEnum());
             assertEquals(1, lunaticVariable.get().getBindingDependencies().size());
-            assertEquals("Q3", lunaticVariable.get().getBindingDependencies().get(0));
+            assertEquals("Q3", lunaticVariable.get().getBindingDependencies().getFirst());
         }
 
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DynamicTableIntegrationTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DynamicTableIntegrationTest.java
@@ -12,7 +12,13 @@ import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertCodeLists;
 import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertResponseInTableCells;
 import fr.insee.eno.core.processing.out.steps.lunatic.table.LunaticTableProcessing;
 import fr.insee.eno.core.serialize.DDIDeserializer;
-import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.BodyCell;
+import fr.insee.lunatic.model.flat.ComponentTypeEnum;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.RosterForLoop;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import instance33.DDIInstanceDocument;
 import org.junit.jupiter.api.Test;
 
@@ -63,10 +69,11 @@ class DynamicTableIntegrationTest {
 
         // Roster variables are present and are array variables
         List.of(rosterResponseName1, rosterResponseName2).forEach(rosterResponseName -> {
-            Optional<IVariableType> rosterVariable = lunaticQuestionnaire.getVariables().stream()
+            Optional<VariableType> searched = lunaticQuestionnaire.getVariables().stream()
                     .filter(variable -> rosterResponseName.equals(variable.getName())).findAny();
-            assertTrue(rosterVariable.isPresent());
-            assertInstanceOf(VariableTypeArray.class, rosterVariable.get());
+            assertTrue(searched.isPresent());
+            CollectedVariableType rosterVariable = assertInstanceOf(CollectedVariableType.class, searched.get());
+            assertInstanceOf(CollectedVariableValues.class, rosterVariable.getValues());
         });
 
         // roster component should have 2 controls

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/VariableTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/VariableTest.java
@@ -1,7 +1,7 @@
 package fr.insee.eno.core.mapping.out.lunatic;
 
 import fr.insee.eno.core.model.variable.Variable;
-import fr.insee.lunatic.model.flat.VariableTypeEnum;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddCleaningVariablesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddCleaningVariablesTest.java
@@ -1,6 +1,10 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.ExternalVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -376,22 +380,20 @@ class LunaticAddCleaningVariablesTest {
         return conditionFilter;
     }
 
-    private VariableType buildCollectedVariable(String variableName) {
-        VariableType variable = new VariableType();
-        variable.setVariableType(VariableTypeEnum.COLLECTED);
+    private CollectedVariableType buildCollectedVariable(String variableName) {
+        CollectedVariableType variable = new CollectedVariableType();
         variable.setName(variableName);
         return variable;
     }
 
-    private VariableType buildCalculatedVariable(String variableName) {
-        VariableType variable = new VariableType();
-        variable.setVariableType(VariableTypeEnum.CALCULATED);
+    private CalculatedVariableType buildCalculatedVariable(String variableName) {
+        CalculatedVariableType variable = new CalculatedVariableType();
         variable.setName(variableName);
         return variable;
     }
 
-    private VariableType buildExternalVariable(String variableName) {
-        VariableType variable = new VariableType();
+    private ExternalVariableType buildExternalVariable(String variableName) {
+        ExternalVariableType variable = new ExternalVariableType();
         variable.setVariableType(VariableTypeEnum.EXTERNAL);
         variable.setName(variableName);
         return variable;

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesPairwiseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddMissingVariablesPairwiseTest.java
@@ -1,6 +1,8 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -33,11 +35,13 @@ class LunaticAddMissingVariablesPairwiseTest {
         assertNotNull(dropdown.getMissingResponse());
         assertEquals("FOO_LINKS_MISSING", dropdown.getMissingResponse().getName());
         //
-        Optional<IVariableType> pairwiseMissingVariable = lunaticQuestionnaire.getVariables().stream()
+        Optional<CollectedVariableType> pairwiseMissingVariable = lunaticQuestionnaire.getVariables().stream()
+                .filter(CollectedVariableType.class::isInstance)
+                .map(CollectedVariableType.class::cast)
                 .filter(variable -> "FOO_LINKS_MISSING".equals(variable.getName()))
                 .findAny();
         assertTrue(pairwiseMissingVariable.isPresent());
-        assertInstanceOf(VariableTypeTwoDimensionsArray.class, pairwiseMissingVariable.get());
+        assertInstanceOf(CollectedVariableValues.DoubleArray.class, pairwiseMissingVariable.get().getValues());
         //
         MissingType missingType = lunaticQuestionnaire.getMissingBlock();
         assertEquals(2, missingType.countMissingEntries());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddShapeToCalculatedVariablesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddShapeToCalculatedVariablesTest.java
@@ -2,47 +2,43 @@ package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.processing.out.steps.lunatic.calculatedvariable.ShapefromAttributeRetrievalReturnVariableNameInVariable;
-import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.ExternalVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LunaticAddShapeToCalculatedVariablesTest {
     LunaticAddShapeToCalculatedVariables processing;
     Questionnaire lunaticQuestionnaire;
     EnoQuestionnaire enoQuestionnaire;
 
-    VariableType var1, var2, var3;
+    CalculatedVariableType var1;
+    CollectedVariableType var2;
+    ExternalVariableType var3;
 
     @BeforeEach
     void init() {
         enoQuestionnaire = new EnoQuestionnaire();
         lunaticQuestionnaire = new Questionnaire();
-        var1 = new VariableType();
-        var1.setVariableType(VariableTypeEnum.CALCULATED);
+        var1 = new CalculatedVariableType();
         var1.setName("var1");
-        var2 = new VariableType();
-        var2.setVariableType(VariableTypeEnum.COLLECTED);
+        var2 = new CollectedVariableType();
         var2.setName("var2");
-        var3 = new VariableType();
-        var3.setVariableType(VariableTypeEnum.EXTERNAL);
+        var3 = new ExternalVariableType();
         var3.setName("var3");
 
-        List<IVariableType> variables = lunaticQuestionnaire.getVariables();
+        List<VariableType> variables = lunaticQuestionnaire.getVariables();
         variables.addAll(Set.of(var1, var2, var3));
 
         processing = new LunaticAddShapeToCalculatedVariables(enoQuestionnaire, new ShapefromAttributeRetrievalReturnVariableNameInVariable());
-    }
-
-    @Test
-    void whenApplyingShapeOnNonCalculatedVariablesDoNothing() {
-        processing.apply(lunaticQuestionnaire);
-        assertNull(var2.getShapeFrom());
-        assertNull(var3.getShapeFrom());
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResultTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResultTest.java
@@ -9,13 +9,15 @@ import fr.insee.eno.core.model.variable.VariableGroup;
 import fr.insee.eno.core.processing.out.steps.lunatic.calculatedvariable.ShapefromAttributeRetrievalReturnVariableNameInVariable;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
+import fr.insee.lunatic.model.flat.variable.VariableTypeEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class LunaticFilterResultTest {
 
@@ -100,7 +102,7 @@ class LunaticFilterResultTest {
 
         processing.apply(lunaticQuestionnaire);
         assertEquals(1, lunaticQuestionnaire.getVariables().size());
-        VariableType variable = (VariableType) lunaticQuestionnaire.getVariables().get(0);
+        VariableType variable = lunaticQuestionnaire.getVariables().getFirst();
         testInputCalculatedVariable(variable);
     }
 
@@ -112,7 +114,7 @@ class LunaticFilterResultTest {
 
         processing.apply(lunaticQuestionnaire);
         assertEquals(1, lunaticQuestionnaire.getVariables().size());
-        VariableType variable = (VariableType) lunaticQuestionnaire.getVariables().get(0);
+        VariableType variable = lunaticQuestionnaire.getVariables().getFirst();
         testTableCalculatedVariable(variable);
     }
 
@@ -130,26 +132,28 @@ class LunaticFilterResultTest {
 
         processing.apply(lunaticQuestionnaire);
         assertEquals(2, lunaticQuestionnaire.getVariables().size());
-        testInputCalculatedVariable((VariableType) lunaticQuestionnaire.getVariables().get(0));
-        testTableCalculatedVariable((VariableType) lunaticQuestionnaire.getVariables().get(1));
+        testInputCalculatedVariable(lunaticQuestionnaire.getVariables().get(0));
+        testTableCalculatedVariable(lunaticQuestionnaire.getVariables().get(1));
     }
 
     private void testInputCalculatedVariable(VariableType variable) {
-        assertEquals(VariableTypeEnum.CALCULATED, variable.getVariableType());
         assertEquals("FILTER_RESULT_" + textQuestion.getName(), variable.getName());
-        assertEquals(1, variable.getBindingDependencies().size());
-        assertTrue(variable.getBindingDependencies().contains("CALCULATED_VARIABLE"));
-        assertEquals("input-name", variable.getShapeFrom());
-        assertEquals("count(CALCULATED_VARIABLE) < 2", variable.getExpression().getValue());
+        assertEquals(VariableTypeEnum.CALCULATED, variable.getVariableType());
+        CalculatedVariableType calculatedVariable = assertInstanceOf(CalculatedVariableType.class, variable);
+        assertEquals(1, calculatedVariable.getBindingDependencies().size());
+        assertTrue(calculatedVariable.getBindingDependencies().contains("CALCULATED_VARIABLE"));
+        assertEquals("input-name", calculatedVariable.getShapeFrom());
+        assertEquals("count(CALCULATED_VARIABLE) < 2", calculatedVariable.getExpression().getValue());
     }
 
     private void testTableCalculatedVariable(VariableType variable) {
-        assertEquals(VariableTypeEnum.CALCULATED, variable.getVariableType());
         assertEquals("FILTER_RESULT_" + tableQuestion.getName(), variable.getName());
-        assertEquals(2, variable.getBindingDependencies().size());
-        assertTrue(variable.getBindingDependencies().contains("CALCULATED_VARIABLE_2"));
-        assertTrue(variable.getBindingDependencies().contains("NUMERIC_USED_FOR_CALCULATED_VARIABLE_2"));
-        assertEquals("table-name", variable.getShapeFrom());
-        assertEquals("count(CALCULATED_VARIABLE_2) + NUMERIC_USED_FOR_CALCULATED_VARIABLE_2 < 4", variable.getExpression().getValue());
+        assertEquals(VariableTypeEnum.CALCULATED, variable.getVariableType());
+        CalculatedVariableType calculatedVariable = assertInstanceOf(CalculatedVariableType.class, variable);
+        assertEquals(2, calculatedVariable.getBindingDependencies().size());
+        assertTrue(calculatedVariable.getBindingDependencies().contains("CALCULATED_VARIABLE_2"));
+        assertTrue(calculatedVariable.getBindingDependencies().contains("NUMERIC_USED_FOR_CALCULATED_VARIABLE_2"));
+        assertEquals("table-name", calculatedVariable.getShapeFrom());
+        assertEquals("count(CALCULATED_VARIABLE_2) + NUMERIC_USED_FOR_CALCULATED_VARIABLE_2 < 4", calculatedVariable.getExpression().getValue());
     }
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwiseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFinalizePairwiseTest.java
@@ -5,6 +5,7 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.question.PairwiseQuestion;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -105,7 +106,7 @@ class LunaticFinalizePairwiseTest {
     void whenFinalizingCalculatedVariablesAreSet() {
         lunaticQuestionnaire.getComponents().add(pairwiseLinks1);
         processing.apply(lunaticQuestionnaire);
-        List<IVariableType> variables = lunaticQuestionnaire.getVariables();
+        List<VariableType> variables = lunaticQuestionnaire.getVariables();
         assertEquals(2, variables.size());
         assertEquals("xAxis", variables.get(0).getName());
         assertEquals("yAxis", variables.get(1).getName());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabelTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabelTest.java
@@ -1,6 +1,5 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
-import fr.insee.eno.core.processing.out.steps.lunatic.LunaticReverseConsistencyControlLabel;
 import fr.insee.lunatic.model.flat.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticVariablesValuesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticVariablesValuesTest.java
@@ -5,6 +5,9 @@ import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -20,11 +23,11 @@ class LunaticVariablesValuesTest {
                 this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-simple.xml"),
                 EnoParameters.of(EnoParameters.Context.HOUSEHOLD, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         //
-        Optional<IVariableType> searchedVariable = lunaticQuestionnaire.getVariables().stream()
+        Optional<VariableType> searchedVariable = lunaticQuestionnaire.getVariables().stream()
                 .filter(variable -> "Q1".equals(variable.getName())).findAny();
         assertTrue(searchedVariable.isPresent());
-        VariableType variableType = assertInstanceOf(VariableType.class, searchedVariable.get());
-        assertNotNull(variableType.getValues());
+        CollectedVariableType variableType = assertInstanceOf(CollectedVariableType.class, searchedVariable.get());
+        assertInstanceOf(CollectedVariableValues.Scalar.class, variableType.getValues());
     }
 
     @Test
@@ -40,7 +43,7 @@ class LunaticVariablesValuesTest {
         loop.getComponents().add(textarea);
         lunaticQuestionnaire.getComponents().add(loop);
         //
-        VariableType variableType = new VariableType();
+        VariableType variableType = new CollectedVariableType();
         variableType.setName("FOO_VAR");
         lunaticQuestionnaire.getVariables().add(variableType);
 
@@ -50,13 +53,10 @@ class LunaticVariablesValuesTest {
         //
         assertFalse(lunaticQuestionnaire.getVariables().isEmpty());
         assertEquals(1, lunaticQuestionnaire.getVariables().size());
-        assertInstanceOf(VariableTypeArray.class, lunaticQuestionnaire.getVariables().getFirst());
-        //
-        VariableTypeArray loopVariable = (VariableTypeArray) lunaticQuestionnaire.getVariables().getFirst();
-        assertEquals(VariableTypeEnum.COLLECTED, loopVariable.getVariableType());
+        CollectedVariableType loopVariable = assertInstanceOf(CollectedVariableType.class, lunaticQuestionnaire.getVariables().getFirst());
         assertEquals("FOO_VAR", loopVariable.getName());
-        assertNotNull(loopVariable.getValues());
-        assertNotNull(loopVariable.getValues().getCollected());
+        CollectedVariableValues.Array values = assertInstanceOf(CollectedVariableValues.Array.class, loopVariable.getValues());
+        assertNotNull(values.getCollected());
     }
 
     @Test
@@ -72,7 +72,7 @@ class LunaticVariablesValuesTest {
         rosterForLoop.getComponents().add(dropdownCell);
         lunaticQuestionnaire.getComponents().add(rosterForLoop);
         //
-        VariableType variableType = new VariableType();
+        VariableType variableType = new CollectedVariableType();
         variableType.setName("COLUMN1_VAR");
         lunaticQuestionnaire.getVariables().add(variableType);
 
@@ -82,13 +82,10 @@ class LunaticVariablesValuesTest {
         //
         assertFalse(lunaticQuestionnaire.getVariables().isEmpty());
         assertEquals(1, lunaticQuestionnaire.getVariables().size());
-        assertInstanceOf(VariableTypeArray.class, lunaticQuestionnaire.getVariables().getFirst());
-        //
-        VariableTypeArray loopVariable = (VariableTypeArray) lunaticQuestionnaire.getVariables().getFirst();
-        assertEquals(VariableTypeEnum.COLLECTED, loopVariable.getVariableType());
+        CollectedVariableType loopVariable = assertInstanceOf(CollectedVariableType.class, lunaticQuestionnaire.getVariables().getFirst());
         assertEquals("COLUMN1_VAR", loopVariable.getName());
-        assertNotNull(loopVariable.getValues());
-        assertNotNull(loopVariable.getValues().getCollected());
+        CollectedVariableValues.Array values = assertInstanceOf(CollectedVariableValues.Array.class, loopVariable.getValues());
+        assertNotNull(values.getCollected());
     }
 
     @Test
@@ -103,6 +100,10 @@ class LunaticVariablesValuesTest {
         dropdown.getResponse().setName("LINKS_VAR");
         pairwiseLinks.getComponents().add(dropdown);
         lunaticQuestionnaire.getComponents().add(pairwiseLinks);
+        //
+        VariableType variableType = new CollectedVariableType();
+        variableType.setName("LINKS_VAR");
+        lunaticQuestionnaire.getVariables().add(variableType);
 
         //
         new LunaticVariablesValues().apply(lunaticQuestionnaire);
@@ -110,14 +111,10 @@ class LunaticVariablesValuesTest {
         //
         assertFalse(lunaticQuestionnaire.getVariables().isEmpty());
         assertEquals(1, lunaticQuestionnaire.getVariables().size());
-        assertInstanceOf(VariableTypeTwoDimensionsArray.class, lunaticQuestionnaire.getVariables().getFirst());
-        //
-        VariableTypeTwoDimensionsArray pairwiseVariable = (VariableTypeTwoDimensionsArray)
-                lunaticQuestionnaire.getVariables().getFirst();
-        assertEquals(VariableTypeEnum.COLLECTED, pairwiseVariable.getVariableType());
+        CollectedVariableType pairwiseVariable = assertInstanceOf(CollectedVariableType.class, lunaticQuestionnaire.getVariables().getFirst());
         assertEquals("LINKS_VAR", pairwiseVariable.getName());
-        assertNotNull(pairwiseVariable.getValues());
-        assertNotNull(pairwiseVariable.getValues().getCollected());
+        CollectedVariableValues.DoubleArray values = assertInstanceOf(CollectedVariableValues.DoubleArray.class, pairwiseVariable.getValues());
+        assertNotNull(values.getCollected());
     }
-    
+
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
@@ -11,6 +11,10 @@ import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.model.sequence.StructureItemReference;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CalculatedVariableType;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.ExternalVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,8 +56,7 @@ class LunaticLoopResizingLogicTest {
         simpleResponseComponent.getResponse().setName("RESPONSE_VAR");
         lunaticLoop.getComponents().add(simpleResponseComponent);
         //
-        VariableType numberVariable = new VariableType();
-        numberVariable.setVariableType(VariableTypeEnum.COLLECTED);
+        VariableType numberVariable = new CollectedVariableType();
         numberVariable.setName("LOOP_SIZE_VAR");
         lunaticQuestionnaire.getVariables().add(numberVariable);
         //
@@ -221,8 +224,7 @@ class LunaticLoopResizingLogicTest {
         // Adding a second variable in max size expression
         lunaticLoop.getLines().getMax().setValue("LOOP_SIZE_VAR + LOOP_SIZE_VAR2");
         //
-        VariableType numberVariable = new VariableType();
-        numberVariable.setVariableType(VariableTypeEnum.COLLECTED);
+        VariableType numberVariable = new CollectedVariableType();
         numberVariable.setName("LOOP_SIZE_VAR2");
         lunaticQuestionnaire.getVariables().add(numberVariable);
 
@@ -263,8 +265,7 @@ class LunaticLoopResizingLogicTest {
         //
         lunaticLoop.getLines().getMax().setValue("count(EXTERNAL_VAR)");
         //
-        VariableType externalVariable = new VariableType();
-        externalVariable.setVariableType(VariableTypeEnum.EXTERNAL);
+        VariableType externalVariable = new ExternalVariableType();
         externalVariable.setName("EXTERNAL_VAR");
         lunaticQuestionnaire.getVariables().add(externalVariable);
         //
@@ -285,16 +286,13 @@ class LunaticLoopResizingLogicTest {
         lunaticLoop.getLines().getMax().setValue("CALCULATED_VAR");
         //
         lunaticQuestionnaire.getVariables().clear();
-        VariableType calculatedVariable = new VariableType();
-        calculatedVariable.setVariableType(VariableTypeEnum.CALCULATED);
+        VariableType calculatedVariable = new CalculatedVariableType();
         calculatedVariable.setName("CALCULATED_VAR");
         lunaticQuestionnaire.getVariables().add(calculatedVariable);
-        VariableType collectedVariable = new VariableType();
-        collectedVariable.setVariableType(VariableTypeEnum.COLLECTED);
+        VariableType collectedVariable = new CollectedVariableType();
         collectedVariable.setName("COLLECTED_VAR");
         lunaticQuestionnaire.getVariables().add(collectedVariable);
-        VariableType externalVariable = new VariableType();
-        externalVariable.setVariableType(VariableTypeEnum.EXTERNAL);
+        VariableType externalVariable = new ExternalVariableType();
         externalVariable.setName("EXTERNAL_VAR");
         lunaticQuestionnaire.getVariables().add(externalVariable);
 
@@ -321,8 +319,7 @@ class LunaticLoopResizingLogicTest {
         // Adding an external variable
         lunaticLoop.getLines().getMax().setValue("LOOP_SIZE_VAR + EXTERNAL_VAR");
         //
-        VariableType externalVariable = new VariableType();
-        externalVariable.setVariableType(VariableTypeEnum.EXTERNAL);
+        VariableType externalVariable = new ExternalVariableType();
         externalVariable.setName("EXTERNAL_VAR");
         lunaticQuestionnaire.getVariables().add(externalVariable);
 

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticPairwiseResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticPairwiseResizingLogicTest.java
@@ -3,6 +3,8 @@ package fr.insee.eno.core.processing.out.steps.lunatic.resizing;
 import fr.insee.eno.core.model.question.PairwiseQuestion;
 import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,8 +33,7 @@ class LunaticPairwiseResizingLogicTest {
         lunaticPairwise.getComponents().add(dropdown);
         lunaticQuestionnaire.getComponents().add(lunaticPairwise);
         //
-        VariableType loopVariable = new VariableType();
-        loopVariable.setVariableType(VariableTypeEnum.COLLECTED);
+        VariableType loopVariable = new CollectedVariableType();
         loopVariable.setName("LOOP_VAR");
         lunaticQuestionnaire.getVariables().add(loopVariable);
 

--- a/eno-core/src/test/java/fr/insee/eno/core/sandbox/LunaticTests.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/sandbox/LunaticTests.java
@@ -2,6 +2,8 @@ package fr.insee.eno.core.sandbox;
 
 import fr.insee.lunatic.conversion.JsonDeserializer;
 import fr.insee.lunatic.model.flat.*;
+import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
+import fr.insee.lunatic.model.flat.variable.VariableType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,12 +36,10 @@ class LunaticTests {
         lunaticLabel.setType(LabelTypeEnum.VTL_MD);
         lunaticQuestionnaire.setLabel(lunaticLabel);
         // Variables list
-        List<IVariableType> lunaticVariables = lunaticQuestionnaire.getVariables();
         // Add a variable
-        IVariableType lunaticVariable = new VariableType();
+        VariableType lunaticVariable = new CollectedVariableType();
         lunaticVariable.setName("FOO_VARIABLE");
-        lunaticVariable.setComponentRef("azerty");
-        lunaticVariables.add(lunaticVariable);
+        lunaticQuestionnaire.getVariables().add(lunaticVariable);
         // Sequence
         Sequence sequence = new Sequence();
         ComponentTypeEnum sequenceType = ComponentTypeEnum.valueOf("SEQUENCE");

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         libs {
-            version('lunatic-model', '3.4.2')
+            version('lunatic-model', '3.5.0')
             version('pogues-model', '1.3.3')
             library('lunatic-model', 'fr.insee.lunatic', 'lunatic-model').versionRef('lunatic-model')
             library('pogues-model', 'fr.insee.pogues', 'pogues-model').versionRef('pogues-model')


### PR DESCRIPTION
## Summary

Previous modeling of Luantic-Model variables allowed to serialize invalid variable objects (e.g. external variables with a `"values"` props).

## Done

- use new version of Lunatic-Model
- refactor with new variable objects

This fix issues like the `"values"` property appearing in calculated or external variables.
