### PR TITLE
feat: other specify modality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.18.6'
+    version = '3.19.0'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIConverter.java
@@ -6,6 +6,8 @@ import datacollection33.QuestionGridType;
 import datacollection33.QuestionItemType;
 import fr.insee.eno.core.exceptions.technical.ConversionException;
 import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.question.table.TableCell;
+import fr.insee.eno.core.model.response.ModalityAttachment;
 import fr.insee.eno.core.reference.DDIIndex;
 import logicalproduct33.VariableType;
 import lombok.extern.slf4j.Slf4j;
@@ -19,17 +21,28 @@ public class DDIConverter {
      * Return an Eno instance corresponding to the given DDI object.
      * @return A Eno model object.
      */
-    public static EnoObject instantiateFromDDIObject(Object ddiObject, DDIIndex ddiIndex) {
+    public static EnoObject instantiateFromDDIObject(Object ddiObject, DDIIndex ddiIndex, Class<?> enoType) {
+
         if (ddiObject instanceof LoopType loopType)
             return DDILoopConversion.instantiateFrom(loopType);
+
         if (ddiObject instanceof QuestionItemType questionItemType)
             return DDIQuestionItemConversion.instantiateFrom(questionItemType, ddiIndex);
+
         if (ddiObject instanceof QuestionGridType questionGridType)
             return DDIQuestionGridConversion.instantiateFrom(questionGridType);
-        if (ddiObject instanceof GridResponseDomainInMixedType gridResponseDomainInMixedType)
+
+        if (ddiObject instanceof GridResponseDomainInMixedType gridResponseDomainInMixedType
+                && ModalityAttachment.class.isAssignableFrom(enoType))
+            return DDIMultipleChoiceModalityConversion.instantiateFrom(gridResponseDomainInMixedType);
+
+        if (ddiObject instanceof GridResponseDomainInMixedType gridResponseDomainInMixedType
+                && TableCell.class.isAssignableFrom(enoType))
             return DDITableCellsConversion.instantiateFrom(gridResponseDomainInMixedType);
+
         if (ddiObject instanceof VariableType variableType)
             return DDIVariableConversion.instantiateFrom(variableType);
+
         throw new ConversionException("Eno conversion for DDI type " + ddiObject.getClass() + " not implemented.");
     }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIConverter.java
@@ -1,233 +1,36 @@
 package fr.insee.eno.core.converter;
 
-import datacollection33.*;
+import datacollection33.GridResponseDomainInMixedType;
+import datacollection33.LoopType;
+import datacollection33.QuestionGridType;
+import datacollection33.QuestionItemType;
 import fr.insee.eno.core.exceptions.technical.ConversionException;
 import fr.insee.eno.core.model.EnoObject;
-import fr.insee.eno.core.model.navigation.LinkedLoop;
-import fr.insee.eno.core.model.navigation.StandaloneLoop;
-import fr.insee.eno.core.model.question.*;
-import fr.insee.eno.core.model.question.table.*;
-import fr.insee.eno.core.model.variable.CalculatedVariable;
-import fr.insee.eno.core.model.variable.CollectedVariable;
-import fr.insee.eno.core.model.variable.ExternalVariable;
 import fr.insee.eno.core.reference.DDIIndex;
 import logicalproduct33.VariableType;
 import lombok.extern.slf4j.Slf4j;
-import reusable33.*;
-
-import java.util.Set;
 
 @Slf4j
 public class DDIConverter {
-
-    public static final String DDI_PAIRWISE_KEY = "UIComponent";
-    public static final String DDI_PAIRWISE_VALUE = "HouseholdPairing";
-    public static final Set<String> DDI_DATE_TYPE_CODE = Set.of("date", "gYearMonth", "gYear");
-    public static final Set<String> DDI_DURATION_TYPE_CODE = Set.of("duration");
-    public static final String DDI_SUGGESTER_OUTPUT_FORMAT = "suggester";
 
     private DDIConverter() {}
 
     /**
      * Return an Eno instance corresponding to the given DDI object.
-     *
      * @return A Eno model object.
      */
     public static EnoObject instantiateFromDDIObject(Object ddiObject, DDIIndex ddiIndex) {
         if (ddiObject instanceof LoopType loopType)
-            return instantiateFrom(loopType);
-        else if (ddiObject instanceof QuestionItemType questionItemType)
-            return instantiateFrom(questionItemType, ddiIndex);
-        else if (ddiObject instanceof QuestionGridType questionGridType)
-            return instantiateFrom(questionGridType);
-        else if (ddiObject instanceof GridResponseDomainInMixedType gridResponseDomainInMixedType)
-            return instantiateFrom(gridResponseDomainInMixedType);
-        else if (ddiObject instanceof VariableType variableType)
-            return instantiateFrom(variableType);
-        else
-            throw new ConversionException("Eno conversion for DDI type " + ddiObject.getClass() + " not implemented.");
-    }
-
-    public static EnoObject instantiateFrom(LoopType loopType) {
-        if (loopType.getInitialValue() == null && loopType.getLoopWhile() == null) {
-            return new LinkedLoop();
-        } else {
-            // A standalone loop should have both "initial value" and "loop while" defined
-            if (loopType.getInitialValue() == null)
-                log.warn("DDI Loop '{}' has a null initial value.", loopType.getIDArray(0).getStringValue());
-            if (loopType.getLoopWhile() == null)
-                log.warn("DDI Loop '{}' has a null loop while.", loopType.getIDArray(0).getStringValue());
-            return new StandaloneLoop();
-        }
-    }
-
-    public static EnoObject instantiateFrom(QuestionItemType questionItemType, DDIIndex ddiIndex) {
-        RepresentationType representationType = questionItemType.getResponseDomain();
-        DomainReferenceType referenceType = questionItemType.getResponseDomainReference();
-
-        if (representationType instanceof NominalDomainType) {
-            return new BooleanQuestion();
-        }
-
-        if (representationType instanceof TextDomainType) {
-            return new TextQuestion();
-        }
-
-        if (representationType instanceof NumericDomainType) {
-            return new NumericQuestion();
-        }
-
-        if (representationType instanceof DateTimeDomainType dateTimeDomainType) {
-            return convertDateTimeQuestion(dateTimeDomainType);
-        }
-
-        if(referenceType != null && referenceType.getTypeOfObject().equals(TypeOfObjectType.MANAGED_DATE_TIME_REPRESENTATION)) {
-            return convertDateTimeQuestion(referenceType, ddiIndex);
-        }
-
-        if (representationType instanceof CodeDomainType) {
-            // Pairwise case
-            if (! questionItemType.getUserAttributePairList().isEmpty()) {
-                StandardKeyValuePairType userAttributePair = questionItemType.getUserAttributePairArray(0);
-                String attributeKey = userAttributePair.getAttributeKey().getStringValue();
-                String attributeValue = userAttributePair.getAttributeValue().getStringValue();
-                if (! DDI_PAIRWISE_KEY.equals(attributeKey))
-                    log.warn(String.format(
-                            "Attribute pair list found in question item '%s', but key is equal to '%s' (should be '%s')",
-                            questionItemType.getIDArray(0).getStringValue(), attributeKey, DDI_PAIRWISE_KEY));
-                if (! DDI_PAIRWISE_VALUE.equals(attributeValue))
-                    log.warn(String.format(
-                            "Attribute pair list found in question item '%s', but value is equal to '%s' (should be '%s')",
-                            questionItemType.getIDArray(0).getStringValue(), attributeValue, DDI_PAIRWISE_VALUE));
-                return new PairwiseQuestion();
-            }
-            // Suggester case
-            String ddiOutputFormat = questionItemType.getResponseDomain().getGenericOutputFormat().getStringValue();
-            if (DDI_SUGGESTER_OUTPUT_FORMAT.equals(ddiOutputFormat))
-                return new SuggesterQuestion();
-            //
-            return new UniqueChoiceQuestion();
-
-        }
-
-        throw new ConversionException(
-                "Unable to identify question type in DDI question item " +
-                        questionItemType.getIDArray(0).getStringValue());
-
-    }
-
-    private static EnoObject convertDateTimeQuestion(DateTimeDomainType dateTimeDomainType) {
-        String dateTypeCode = dateTimeDomainType.getDateTypeCode().getStringValue();
-        if (DDI_DATE_TYPE_CODE.contains(dateTypeCode))
-            return new DateQuestion();
-        if (DDI_DURATION_TYPE_CODE.contains(dateTypeCode)) {
-            return new DurationQuestion();
-        }
-        // If none match, thrown an exception
-        throw new ConversionException("Unknown date type code: "+dateTypeCode);
-    }
-
-    private static EnoObject convertDateTimeQuestion(DomainReferenceType referenceType, DDIIndex ddiIndex) {
-        AbstractIdentifiableType ddiObject = ddiIndex.get(referenceType.getIDArray(0).getStringValue());
-        ManagedDateTimeRepresentationType dateTimeRepresentation = (ManagedDateTimeRepresentationType) ddiObject;
-        String dateTypeCode = dateTimeRepresentation.getDateTypeCode().getStringValue();
-
-        if (DDI_DATE_TYPE_CODE.contains(dateTypeCode))
-            return new DateQuestion();
-        if (DDI_DURATION_TYPE_CODE.contains(dateTypeCode)) {
-            return new DurationQuestion();
-        }
-        // If none match, thrown an exception
-        throw new ConversionException("Unknown date type code: "+dateTypeCode);
-    }
-
-    public static EnoObject instantiateFrom(QuestionGridType questionGridType) {
-        int dimensionSize = questionGridType.getGridDimensionList().size();
-        if (dimensionSize == 1) {
-            RepresentationType representationType = questionGridType.getStructuredMixedGridResponseDomain()
-                    .getGridResponseDomainInMixedArray(0) // supposing that it is the same for all modalities
-                    .getResponseDomain();
-            if (representationType instanceof NominalDomainType)
-                return new SimpleMultipleChoiceQuestion();
-            else if (representationType instanceof CodeDomainType)
-                return new ComplexMultipleChoiceQuestion();
-            else
-                throw new ConversionException(
-                        "Unable to identify question type in DDI question grid " +
-                                questionGridType.getIDArray(0).getStringValue());
-        }
-        else if (dimensionSize == 2) {
-            GridDimensionType gridDimensionType = questionGridType.getGridDimensionList().stream()
-                    .filter(gridDimensionType1 -> gridDimensionType1.getRank().intValue() == 1)
-                    .findAny().orElse(null);
-            if (gridDimensionType == null) {
-                throw new ConversionException(String.format(
-                        "Question grid '%s' has no grid dimension of rank 1.",
-                        questionGridType.getIDArray(0).getStringValue()));
-            } else {
-                if (gridDimensionType.getCodeDomain() != null) {
-                    return new TableQuestion();
-                } else if (gridDimensionType.getRoster() != null) {
-                    return new DynamicTableQuestion();
-                } else {
-                    throw new ConversionException(String.format(
-                            "Grid dimension of rank 1 of question grid '%s' is neither a CodeDomain nor a Roster. " +
-                                    "This case is unexpected and Eno is unable to convert this question.",
-                            questionGridType.getIDArray(0).getStringValue()));
-                }
-            }
-
-        }
-        else {
-            throw new ConversionException(String.format(
-                    "Question grid '%s' has %s grid dimension objects. " +
-                            "Eno expects question grids to have exactly 1 or 2 of these.",
-                    questionGridType.getIDArray(0).getStringValue(), dimensionSize));
-        }
-    }
-
-    public static EnoObject instantiateFrom(GridResponseDomainInMixedType gridResponseDomainInMixedType) {
-        RepresentationType representationType = gridResponseDomainInMixedType.getResponseDomain();
-        if (representationType instanceof NominalDomainType) {
-            return new BooleanCell();
-        }
-        else if (representationType instanceof TextDomainType) {
-            return new TextCell();
-        }
-        else if (representationType instanceof NumericDomainType) {
-            return new NumericCell();
-        }
-        else if (representationType instanceof DateTimeDomainType) {
-            return new DateCell();
-        }
-        else if (representationType instanceof CodeDomainType) {
-            String ddiOutputFormat = gridResponseDomainInMixedType.getResponseDomain().getGenericOutputFormat().getStringValue();
-            if (DDI_SUGGESTER_OUTPUT_FORMAT.equals(ddiOutputFormat))
-                return new SuggesterCell();
-            return new UniqueChoiceCell();
-        }
-        else {
-            throw new ConversionException(
-                    "Unable to identify cell type in DDI GridResponseDomainInMixed object " +
-                            "with response domain of type "+representationType.getClass()+".");
-        }
-    }
-
-    /** <p>In "Insee" DDI:</p>
-     * <ul>
-     *   <li>collected variables are characterized by having a "question reference"</li>
-     *   <li>calculated variables are characterized by having a "processing instruction reference"
-     *   in their "variable representation"</li>
-     *   <li>external variables have no specific characteristics so these are the remaining cases. </li>
-     * </ul>
-     * */
-    public static EnoObject instantiateFrom(VariableType variableType) {
-        if (! variableType.getQuestionReferenceList().isEmpty())
-            return new CollectedVariable();
-        if (variableType.getVariableRepresentation() != null &&
-                variableType.getVariableRepresentation().getProcessingInstructionReference() != null)
-            return new CalculatedVariable();
-        return new ExternalVariable();
+            return DDILoopConversion.instantiateFrom(loopType);
+        if (ddiObject instanceof QuestionItemType questionItemType)
+            return DDIQuestionItemConversion.instantiateFrom(questionItemType, ddiIndex);
+        if (ddiObject instanceof QuestionGridType questionGridType)
+            return DDIQuestionGridConversion.instantiateFrom(questionGridType);
+        if (ddiObject instanceof GridResponseDomainInMixedType gridResponseDomainInMixedType)
+            return DDITableCellsConversion.instantiateFrom(gridResponseDomainInMixedType);
+        if (ddiObject instanceof VariableType variableType)
+            return DDIVariableConversion.instantiateFrom(variableType);
+        throw new ConversionException("Eno conversion for DDI type " + ddiObject.getClass() + " not implemented.");
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDILoopConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDILoopConversion.java
@@ -1,0 +1,27 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.LoopType;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.navigation.LinkedLoop;
+import fr.insee.eno.core.model.navigation.StandaloneLoop;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DDILoopConversion {
+
+    private DDILoopConversion() {}
+
+    static EnoObject instantiateFrom(LoopType loopType) {
+        if (loopType.getInitialValue() == null && loopType.getLoopWhile() == null) {
+            return new LinkedLoop();
+        } else {
+            // A standalone loop should have both "initial value" and "loop while" defined
+            if (loopType.getInitialValue() == null)
+                log.warn("DDI Loop '{}' has a null initial value.", loopType.getIDArray(0).getStringValue());
+            if (loopType.getLoopWhile() == null)
+                log.warn("DDI Loop '{}' has a null loop while.", loopType.getIDArray(0).getStringValue());
+            return new StandaloneLoop();
+        }
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIMultipleChoiceModalityConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIMultipleChoiceModalityConversion.java
@@ -1,0 +1,16 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.GridResponseDomainInMixedType;
+import fr.insee.eno.core.model.response.ModalityAttachment;
+
+public class DDIMultipleChoiceModalityConversion {
+
+    private DDIMultipleChoiceModalityConversion() {}
+
+    static ModalityAttachment instantiateFrom(GridResponseDomainInMixedType gridResponseDomainInMixedType) {
+        if (gridResponseDomainInMixedType.getResponseAttachmentLocation() != null)
+            return new ModalityAttachment.DetailAttachment();
+        return new ModalityAttachment.CodeAttachment();
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionGridConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionGridConversion.java
@@ -1,0 +1,85 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.CodeDomainType;
+import datacollection33.GridDimensionType;
+import datacollection33.NominalDomainType;
+import datacollection33.QuestionGridType;
+import fr.insee.eno.core.exceptions.technical.ConversionException;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.question.ComplexMultipleChoiceQuestion;
+import fr.insee.eno.core.model.question.DynamicTableQuestion;
+import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import fr.insee.eno.core.model.question.TableQuestion;
+import reusable33.RepresentationType;
+
+public class DDIQuestionGridConversion {
+
+    private DDIQuestionGridConversion() {}
+
+    static EnoObject instantiateFrom(QuestionGridType questionGridType) {
+        int dimensionSize = questionGridType.getGridDimensionList().size();
+        if (isMultipleChoiceQuestion(questionGridType)) {
+            RepresentationType representationType = questionGridType.getStructuredMixedGridResponseDomain()
+                    .getGridResponseDomainInMixedArray(0) // supposing that it is the same for all modalities
+                    .getResponseDomain();
+            if (representationType instanceof NominalDomainType)
+                return new SimpleMultipleChoiceQuestion();
+            if (representationType instanceof CodeDomainType)
+                return new ComplexMultipleChoiceQuestion();
+            throw new ConversionException(
+                    "Unable to identify question type in DDI question grid " +
+                            questionGridType.getIDArray(0).getStringValue());
+        }
+        if (isTableQuestion(questionGridType)) {
+            GridDimensionType gridDimensionType = getRank1GridDimension(questionGridType);
+            if (isStaticTableDimension(gridDimensionType))
+                return new TableQuestion();
+            if (isDynamicTableDimension(gridDimensionType))
+                return new DynamicTableQuestion();
+            throw new ConversionException(String.format(
+                    "Grid dimension of rank 1 of question grid '%s' is neither a CodeDomain nor a Roster. " +
+                            "This case is unexpected and Eno is unable to convert this question.",
+                    questionGridType.getIDArray(0).getStringValue()));
+        }
+        //
+        throw new ConversionException(String.format(
+                "Question grid '%s' has %s grid dimension objects. " +
+                        "Eno expects question grids to have exactly 1 or 2 of these.",
+                questionGridType.getIDArray(0).getStringValue(), dimensionSize));
+    }
+
+    private static boolean isMultipleChoiceQuestion(QuestionGridType ddiQuestionGrid) {
+        return ddiQuestionGrid.getGridDimensionList().size() == 1;
+    }
+
+    private static boolean isTableQuestion(QuestionGridType ddiQuestionGrid) {
+        return ddiQuestionGrid.getGridDimensionList().size() == 2;
+    }
+
+    private static GridDimensionType getRank1GridDimension(QuestionGridType questionGridType) {
+        GridDimensionType gridDimensionType = questionGridType.getGridDimensionList().stream()
+                .filter(gridDimensionType1 -> gridDimensionType1.getRank().intValue() == 1)
+                .findAny().orElse(null);
+        if (gridDimensionType == null)
+            throw new ConversionException(String.format(
+                    "Question grid '%s' has no grid dimension of rank 1.",
+                    questionGridType.getIDArray(0).getStringValue()));
+        return gridDimensionType;
+    }
+
+    private static boolean isStaticTableDimension(GridDimensionType gridDimensionType) {
+        return gridDimensionType.getCodeDomain() != null;
+    }
+
+    private static boolean isDynamicTableDimension(GridDimensionType gridDimensionType) {
+        return gridDimensionType.getRoster() != null;
+    }
+
+    public static boolean isDynamicTableQuestion(QuestionGridType questionGridType) {
+        if (! isTableQuestion(questionGridType))
+            return false;
+        GridDimensionType gridDimensionType = getRank1GridDimension(questionGridType);
+        return isDynamicTableDimension(gridDimensionType);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
@@ -80,6 +80,10 @@ public class DDIQuestionItemConversion {
     }
 
     private static EnoObject convertDateTimeQuestion(DomainReferenceType referenceType, DDIIndex ddiIndex) {
+        if (ddiIndex == null)
+            throw new IllegalArgumentException(
+                    "Cannot convert date/time question with a reference domain without a DDI index.");
+
         AbstractIdentifiableType ddiObject = ddiIndex.get(referenceType.getIDArray(0).getStringValue());
         ManagedDateTimeRepresentationType dateTimeRepresentation = (ManagedDateTimeRepresentationType) ddiObject;
         String dateTypeCode = dateTimeRepresentation.getDateTypeCode().getStringValue();

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
@@ -22,6 +22,12 @@ public class DDIQuestionItemConversion {
 
     private DDIQuestionItemConversion() {}
 
+    /**
+     * Instantiate an Eno object that corresponds to the given DDI question item.
+     * @param questionItemType DDI question item.
+     * @param ddiIndex DDI index used for the date/duration question cases.
+     * @return Eno object corresponding to the given DDI question item.
+     */
     static EnoObject instantiateFrom(QuestionItemType questionItemType, DDIIndex ddiIndex) {
         RepresentationType representationType = questionItemType.getResponseDomain();
         DomainReferenceType referenceType = questionItemType.getResponseDomainReference();
@@ -53,6 +59,9 @@ public class DDIQuestionItemConversion {
                 return new SuggesterQuestion();
             return new UniqueChoiceQuestion();
         }
+
+        if (hasMixedResponseDomain(questionItemType))
+            return new UniqueChoiceQuestion();
 
         throw new ConversionException(
                 "Unable to identify question type in DDI question item " +
@@ -108,6 +117,18 @@ public class DDIQuestionItemConversion {
     private static boolean isSuggesterQuestion(QuestionItemType ddiQuestionItem) {
         String ddiOutputFormat = ddiQuestionItem.getResponseDomain().getGenericOutputFormat().getStringValue();
         return DDI_SUGGESTER_OUTPUT_FORMAT.equals(ddiOutputFormat);
+    }
+
+    /**
+     * In DDI, a unique choice question normally has a "CodeDomain" response domain.
+     * However, if the unique choice question has modalities with a "please, specify", the response domain becomes
+     * a mixed response domain containing the code domain, and additional text domains for modalities that have this.
+     * This method checks the existence of such a mixed response domain in the question item object.
+     * @param ddiQuestionItem A DDI question item.
+     * @return True if the response domain is a mixed response domain.
+     */
+    private static boolean hasMixedResponseDomain(QuestionItemType ddiQuestionItem) {
+        return ddiQuestionItem.getStructuredMixedResponseDomain() != null;
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIQuestionItemConversion.java
@@ -1,0 +1,113 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.*;
+import fr.insee.eno.core.exceptions.technical.ConversionException;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.question.*;
+import fr.insee.eno.core.reference.DDIIndex;
+import lombok.extern.slf4j.Slf4j;
+import reusable33.*;
+
+import java.util.Set;
+
+@Slf4j
+public class DDIQuestionItemConversion {
+
+    private static final String DDI_PAIRWISE_KEY = "UIComponent";
+    private static final String DDI_PAIRWISE_VALUE = "HouseholdPairing";
+    private static final Set<String> DDI_DATE_TYPE_CODE = Set.of("date", "gYearMonth", "gYear");
+    private static final Set<String> DDI_DURATION_TYPE_CODE = Set.of("duration");
+
+    static final String DDI_SUGGESTER_OUTPUT_FORMAT = "suggester";
+
+    private DDIQuestionItemConversion() {}
+
+    static EnoObject instantiateFrom(QuestionItemType questionItemType, DDIIndex ddiIndex) {
+        RepresentationType representationType = questionItemType.getResponseDomain();
+        DomainReferenceType referenceType = questionItemType.getResponseDomainReference();
+
+        if (representationType instanceof NominalDomainType) {
+            return new BooleanQuestion();
+        }
+
+        if (representationType instanceof TextDomainType) {
+            return new TextQuestion();
+        }
+
+        if (representationType instanceof NumericDomainType) {
+            return new NumericQuestion();
+        }
+
+        if (representationType instanceof DateTimeDomainType dateTimeDomainType) {
+            return convertDateTimeQuestion(dateTimeDomainType);
+        }
+
+        if(referenceType != null && referenceType.getTypeOfObject().equals(TypeOfObjectType.MANAGED_DATE_TIME_REPRESENTATION)) {
+            return convertDateTimeQuestion(referenceType, ddiIndex);
+        }
+
+        if (representationType instanceof CodeDomainType) {
+            if (isPairwiseQuestion(questionItemType))
+                return new PairwiseQuestion();
+            if (isSuggesterQuestion(questionItemType))
+                return new SuggesterQuestion();
+            return new UniqueChoiceQuestion();
+        }
+
+        throw new ConversionException(
+                "Unable to identify question type in DDI question item " +
+                        questionItemType.getIDArray(0).getStringValue());
+
+    }
+
+    private static EnoObject convertDateTimeQuestion(DateTimeDomainType dateTimeDomainType) {
+        String dateTypeCode = dateTimeDomainType.getDateTypeCode().getStringValue();
+        if (DDI_DATE_TYPE_CODE.contains(dateTypeCode))
+            return new DateQuestion();
+        if (DDI_DURATION_TYPE_CODE.contains(dateTypeCode))
+            return new DurationQuestion();
+        // If none match, thrown an exception
+        throw new ConversionException("Unknown date type code: "+dateTypeCode);
+    }
+
+    private static EnoObject convertDateTimeQuestion(DomainReferenceType referenceType, DDIIndex ddiIndex) {
+        AbstractIdentifiableType ddiObject = ddiIndex.get(referenceType.getIDArray(0).getStringValue());
+        ManagedDateTimeRepresentationType dateTimeRepresentation = (ManagedDateTimeRepresentationType) ddiObject;
+        String dateTypeCode = dateTimeRepresentation.getDateTypeCode().getStringValue();
+
+        if (DDI_DATE_TYPE_CODE.contains(dateTypeCode))
+            return new DateQuestion();
+        if (DDI_DURATION_TYPE_CODE.contains(dateTypeCode)) {
+            return new DurationQuestion();
+        }
+        // If none match, thrown an exception
+        throw new ConversionException("Unknown date type code: "+dateTypeCode);
+    }
+
+    private static boolean isPairwiseQuestion(QuestionItemType ddiQuestionItem) {
+        if (ddiQuestionItem.getUserAttributePairList().isEmpty())
+            return false;
+        StandardKeyValuePairType userAttributePair = ddiQuestionItem.getUserAttributePairArray(0);
+        String attributeKey = userAttributePair.getAttributeKey().getStringValue();
+        String attributeValue = userAttributePair.getAttributeValue().getStringValue();
+        if (!DDI_PAIRWISE_KEY.equals(attributeKey)) {
+            log.warn(String.format(
+                    "Attribute pair list found in question item '%s', but key is equal to '%s' (should be '%s')",
+                    ddiQuestionItem.getIDArray(0).getStringValue(), attributeKey, DDI_PAIRWISE_KEY));
+            return false;
+        }
+        if (!DDI_PAIRWISE_VALUE.equals(attributeValue)) {
+            log.warn(String.format(
+                    "Attribute pair list found in question item '%s', but value is equal to '%s' (should be '%s')",
+                    ddiQuestionItem.getIDArray(0).getStringValue(), attributeValue, DDI_PAIRWISE_VALUE));
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isSuggesterQuestion(QuestionItemType ddiQuestionItem) {
+        String ddiOutputFormat = ddiQuestionItem.getResponseDomain().getGenericOutputFormat().getStringValue();
+        return DDI_SUGGESTER_OUTPUT_FORMAT.equals(ddiOutputFormat);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDITableCellsConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDITableCellsConversion.java
@@ -1,0 +1,40 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.*;
+import fr.insee.eno.core.exceptions.technical.ConversionException;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.question.table.*;
+import reusable33.RepresentationType;
+import reusable33.TextDomainType;
+
+public class DDITableCellsConversion {
+
+    private DDITableCellsConversion() {}
+
+    static EnoObject instantiateFrom(GridResponseDomainInMixedType gridResponseDomainInMixedType) {
+        RepresentationType representationType = gridResponseDomainInMixedType.getResponseDomain();
+        if (representationType instanceof NominalDomainType) {
+            return new BooleanCell();
+        }
+        if (representationType instanceof TextDomainType) {
+            return new TextCell();
+        }
+        if (representationType instanceof NumericDomainType) {
+            return new NumericCell();
+        }
+        if (representationType instanceof DateTimeDomainType) {
+            return new DateCell();
+        }
+        if (representationType instanceof CodeDomainType) {
+            String ddiOutputFormat = gridResponseDomainInMixedType.getResponseDomain().getGenericOutputFormat().getStringValue();
+            if (DDIQuestionItemConversion.DDI_SUGGESTER_OUTPUT_FORMAT.equals(ddiOutputFormat))
+                return new SuggesterCell();
+            return new UniqueChoiceCell();
+        }
+        //
+        throw new ConversionException(
+                "Unable to identify cell type in DDI GridResponseDomainInMixed object " +
+                        "with response domain of type "+representationType.getClass()+".");
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/DDIVariableConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/DDIVariableConversion.java
@@ -1,0 +1,38 @@
+package fr.insee.eno.core.converter;
+
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.variable.CalculatedVariable;
+import fr.insee.eno.core.model.variable.CollectedVariable;
+import fr.insee.eno.core.model.variable.ExternalVariable;
+import logicalproduct33.VariableType;
+
+public class DDIVariableConversion {
+
+    private DDIVariableConversion() {}
+
+    /** <p>In "Insee" DDI:</p>
+     * <ul>
+     *   <li>collected variables are characterized by having a "question reference"</li>
+     *   <li>calculated variables are characterized by having a "processing instruction reference"
+     *   in their "variable representation"</li>
+     *   <li>external variables have no specific characteristics so these are the remaining cases. </li>
+     * </ul>
+     * */
+    static EnoObject instantiateFrom(VariableType variableType) {
+        if (isCollectedVariable(variableType))
+            return new CollectedVariable();
+        if (isCalculatedVariable(variableType))
+            return new CalculatedVariable();
+        return new ExternalVariable();
+    }
+
+    private static boolean isCollectedVariable(VariableType ddiVariable) {
+        return ! ddiVariable.getQuestionReferenceList().isEmpty();
+    }
+
+    private static boolean isCalculatedVariable(VariableType ddiVariable) {
+        return ddiVariable.getVariableRepresentation() != null &&
+                ddiVariable.getVariableRepresentation().getProcessingInstructionReference() != null;
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/LunaticConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/LunaticConverter.java
@@ -15,6 +15,7 @@ import fr.insee.eno.core.model.navigation.StandaloneLoop;
 import fr.insee.eno.core.model.question.*;
 import fr.insee.eno.core.model.question.table.TableCell;
 import fr.insee.eno.core.model.response.CodeResponse;
+import fr.insee.eno.core.model.response.DetailResponse;
 import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.sequence.Subsequence;
@@ -68,6 +69,8 @@ public class LunaticConverter {
             return new BodyCell();
         if (enoObject instanceof Response)
             return new ResponseType();
+        if (enoObject instanceof DetailResponse)
+            return new fr.insee.lunatic.model.flat.DetailResponse();
         if (enoObject instanceof CodeItem)
             return new Options();
         if (enoObject instanceof CodeResponse)

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/DDIMapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/DDIMapper.java
@@ -216,12 +216,9 @@ public class DDIMapper extends Mapper {
         // Collection of complex types
         else if (EnoObject.class.isAssignableFrom(modelTargetType)) {
             // Iterate on the DDI collection
-            for (int i=0; i<collectionSize; i++) {
+            for (Object ddiObject2 : ddiCollection) {
                 log.debug("Iterating on "+collectionSize+" DDI objects "
                         + propertyDescription(propertyName, modelContextType.getSimpleName()));
-                Object ddiObject2 = ddiCollection.get(i);
-                // Put current DDI list index in context TODO: I don't really like this but... :(((
-                spelEngine.getContext().setVariable("listIndex", i);
                 // Instantiate a model object per DDI object and add it in the model collection
                 EnoObject enoObject2 = convert(ddiObject2, modelTargetType);
                 // Add the created instance in the model collection
@@ -239,7 +236,7 @@ public class DDIMapper extends Mapper {
     private EnoObject convert(Object ddiObject, Class<?> enoTargetType) {
         // If the Eno type is abstract call the converter
         if (Modifier.isAbstract(enoTargetType.getModifiers()))
-            return DDIConverter.instantiateFromDDIObject(ddiObject, ddiIndex); //TODO: remove usage of this (conversion using annotations)
+            return DDIConverter.instantiateFromDDIObject(ddiObject, ddiIndex, enoTargetType); //TODO: remove usage of this (conversion using annotations)
         // Else, call class constructor
         return callConstructor(enoTargetType);
     }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/navigation/LinkedLoop.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/navigation/LinkedLoop.java
@@ -5,9 +5,8 @@ import datacollection33.LoopType;
 import datacollection33.QuestionGridType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
-import fr.insee.eno.core.converter.DDIConverter;
+import fr.insee.eno.core.converter.DDIQuestionGridConversion;
 import fr.insee.eno.core.exceptions.technical.MappingException;
-import fr.insee.eno.core.model.question.DynamicTableQuestion;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.eno.core.reference.DDIIndex;
 import group33.ResourcePackageType;
@@ -80,7 +79,7 @@ public class LinkedLoop extends Loop {
         if (! (
                 loopReference instanceof LoopType ||
                 (loopReference instanceof QuestionGridType questionGridType
-                && DDIConverter.instantiateFrom(questionGridType) instanceof DynamicTableQuestion)
+                && DDIQuestionGridConversion.isDynamicTableQuestion(questionGridType))
         )) {
             throw new MappingException(String.format(
                     "Loop '%s' is based on object '%s' (type '%s'), which is neither a loop nor a dynamic table.",

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/SimpleMultipleChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/SimpleMultipleChoiceQuestion.java
@@ -4,7 +4,9 @@ import datacollection33.QuestionGridType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
+import fr.insee.eno.core.model.navigation.Binding;
 import fr.insee.eno.core.model.response.CodeResponse;
+import fr.insee.eno.core.model.response.ModalityAttachment;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.CheckboxGroup;
 import lombok.Getter;
@@ -12,7 +14,6 @@ import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
-
 
 /**
  * "Simple" multiple choice question.
@@ -26,15 +27,29 @@ import java.util.List;
 @Context(format = Format.LUNATIC, type = CheckboxGroup.class)
 public class SimpleMultipleChoiceQuestion extends MultipleResponseQuestion {
 
+    /** Reference to the code list upon which modalities are based. */
+    @DDI("getGridDimensionArray(0).getCodeDomain().getCodeListReference().getIDArray(0).getStringValue()")
+    String codeListReference;
+
     /**
      * List of modalities of the multiple choice question.
      * In DDI, this corresponds to a list ouf out parameters.
      * In Lunatic, the CheckboxGroup component has a particular way to hold this information.
+     * Note: in DDI, modalities that have an additional "please, specify" field correspond to separate out parameters.
+     * In Lunatic, the additional field is inside the response object of the modality.
+     * A DDI processing does the insertion of detail responses at the right place.
      */
     @DDI("getOutParameterList()")
     @Lunatic("getResponses()")
     List<CodeResponse> codeResponses = new ArrayList<>();
-    // TODO: refactor the mapping of these using code lists somehow maybe
+
+    /** DDI bindings used to keep the link between detail responses and the code response modality they belong to. */
+    @DDI("getBindingList()")
+    List<Binding> ddiBindings = new ArrayList<>();
+
+    /** DDI information to link modalities and detail responses. */
+    @DDI("getStructuredMixedGridResponseDomain().getGridResponseDomainInMixedList()")
+    List<ModalityAttachment> modalityAttachments = new ArrayList<>();
 
     /** Lunatic component type property.
      * This should be inserted by Lunatic-Model serializer later on. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
@@ -85,7 +85,9 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
     @DDI("getOutParameterList()")
     List<Response> ddiResponses = new ArrayList<>();
 
-    /** Detail responses for modalities that have a "please specify" field. */
+    /** Detail responses for modalities that have a "please specify" field.
+     * In DDI, these are mapped at question level.
+     * In Lunatic, they are inserted in option in through a processing. */
     @DDI("T(fr.insee.eno.core.model.question.UniqueChoiceQuestion).mapDetailResponses(#this)")
     List<DetailResponse> detailResponses = new ArrayList<>();
 

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
@@ -10,6 +10,7 @@ import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.code.CodeItem;
 import fr.insee.eno.core.model.navigation.Binding;
 import fr.insee.eno.core.model.response.DetailResponse;
+import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.CheckboxOne;
 import fr.insee.lunatic.model.flat.ComponentTypeEnum;
@@ -78,6 +79,11 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
     /** List of DDI bindings that contain the links between detail response name and label. */
     @DDI("getBindingList()")
     List<Binding> ddiBindings = new ArrayList<>();
+
+    /** List of responses defined in the DDI question item.
+     * Used in the processing that inserts detail response names. */
+    @DDI("getOutParameterList()")
+    List<Response> ddiResponses = new ArrayList<>();
 
     /** Detail responses for modalities that have a "please specify" field. */
     @DDI("T(fr.insee.eno.core.model.question.UniqueChoiceQuestion).mapDetailResponses(#this)")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
@@ -1,6 +1,8 @@
 package fr.insee.eno.core.model.question;
 
+import datacollection33.CodeDomainType;
 import datacollection33.QuestionItemType;
+import datacollection33.ResponseDomainInMixedType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
@@ -43,8 +45,6 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
     public static final String DDI_UCQ_CHECKBOX_OUTPUT_FORMAT = "checkbox";
     /** DDI value for dropdown display format. */
     public static final String DDI_UCQ_DROPDOWN_OUTPUT_FORMAT = "drop-down-list";
-    /** DDI value for suggester display format. */
-    public static final String DDI_UCQ_SUGGESTER_OUTPUT_FORMAT = "suggester";
 
     /**
      * Enum for unique choice question display format.
@@ -63,7 +63,7 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
     DisplayFormat displayFormat;
 
     /** Reference to the code list that contain the modalities of the question. */
-    @DDI("getResponseDomain().getCodeListReference().getIDArray(0).getStringValue()")
+    @DDI("T(fr.insee.eno.core.model.question.UniqueChoiceQuestion).mapDDICodeListReference(#this)")
     String codeListReference;
 
     /**
@@ -80,7 +80,7 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
      * @return A value of DisplayFormat.
      */
     public static DisplayFormat convertDDIOutputFormat(QuestionItemType questionItemType) {
-        String ddiOutputFormat = questionItemType.getResponseDomain().getGenericOutputFormat().getStringValue();
+        String ddiOutputFormat = getDDICodeDomain(questionItemType).getGenericOutputFormat().getStringValue();
         Optional<DisplayFormat> convertedDisplayFormat = ddiValueToDisplayFormat(ddiOutputFormat);
         if (convertedDisplayFormat.isEmpty())
             throw new MappingException(String.format(
@@ -114,6 +114,41 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
             case DROPDOWN -> ComponentTypeEnum.DROPDOWN;
             case CHECKBOX -> ComponentTypeEnum.CHECKBOX_ONE;
         };
+    }
+
+    public static String mapDDICodeListReference(QuestionItemType questionItemType) {
+        return getDDICodeDomain(questionItemType).getCodeListReference().getIDArray(0).getStringValue();
+    }
+
+    /**
+     * Gets the code response domain of the DDI question item. In Insee modeling, a DDI unique choice question
+     * is expected to have exactly 1 code response domain.
+     * @param ddiUniqueChoiceQuestion A DDI question item that corresponds to a unique choice question.
+     * @return DDI code response domain object of the question.
+     */
+    private static CodeDomainType getDDICodeDomain(QuestionItemType ddiUniqueChoiceQuestion) {
+        // Default case:
+        if (ddiUniqueChoiceQuestion.getResponseDomain() != null) {
+            return (CodeDomainType) ddiUniqueChoiceQuestion.getResponseDomain();
+        }
+        // Case when some modalities have a detail ("please, specify") response:
+        if (ddiUniqueChoiceQuestion.getStructuredMixedResponseDomain() != null) {
+            List<CodeDomainType> searchedCodeDomain = ddiUniqueChoiceQuestion.getStructuredMixedResponseDomain()
+                    .getResponseDomainInMixedList().stream()
+                    .map(ResponseDomainInMixedType::getResponseDomain)
+                    .filter(CodeDomainType.class::isInstance)
+                    .map(CodeDomainType.class::cast)
+                    .toList();
+            if (searchedCodeDomain.size() != 1)
+                throw new MappingException(String.format(
+                        "DDI unique choice question '%s' has no or more than 1 code response domain.",
+                        ddiUniqueChoiceQuestion.getIDArray(0).getStringValue()));
+            return searchedCodeDomain.getFirst();
+        }
+        //
+        throw new MappingException(String.format(
+                "Cannot find code response domain in DDI unique choice question '%s'.",
+                ddiUniqueChoiceQuestion.getIDArray(0).getStringValue()));
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/UniqueChoiceQuestion.java
@@ -8,6 +8,8 @@ import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.code.CodeItem;
+import fr.insee.eno.core.model.navigation.Binding;
+import fr.insee.eno.core.model.response.DetailResponse;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.CheckboxOne;
 import fr.insee.lunatic.model.flat.ComponentTypeEnum;
@@ -73,6 +75,14 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
     @Lunatic("getOptions()")
     List<CodeItem> codeItems = new ArrayList<>();
 
+    /** List of DDI bindings that contain the links between detail response name and label. */
+    @DDI("getBindingList()")
+    List<Binding> ddiBindings = new ArrayList<>();
+
+    /** Detail responses for modalities that have a "please specify" field. */
+    @DDI("T(fr.insee.eno.core.model.question.UniqueChoiceQuestion).mapDetailResponses(#this)")
+    List<DetailResponse> detailResponses = new ArrayList<>();
+
     /**
      * From DDI question item (that correspond to a unique choice question),
      * return the eno model display format for the unique choice question.
@@ -118,6 +128,15 @@ public class UniqueChoiceQuestion extends SingleResponseQuestion {
 
     public static String mapDDICodeListReference(QuestionItemType questionItemType) {
         return getDDICodeDomain(questionItemType).getCodeListReference().getIDArray(0).getStringValue();
+    }
+
+    public static List<ResponseDomainInMixedType> mapDetailResponses(QuestionItemType questionItemType) {
+        if (questionItemType.getStructuredMixedResponseDomain() == null)
+            return new ArrayList<>();
+        return questionItemType.getStructuredMixedResponseDomain().getResponseDomainInMixedList().stream()
+                .filter(responseDomainInMixedType ->
+                        !(responseDomainInMixedType.getResponseDomain() instanceof CodeDomainType))
+                .toList();
     }
 
     /**

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/CodeResponse.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/CodeResponse.java
@@ -11,21 +11,29 @@ import lombok.Getter;
 import lombok.Setter;
 import reusable33.ParameterType;
 
+/**
+ * Object that represents a modality of a "simple" multiple choice question
+ * (i.e. a multiple choice question whose modality responses are boolean).
+ */
 @Getter
 @Setter
 @Context(format = Format.DDI, type = ParameterType.class)
 @Context(format = Format.LUNATIC, type = ResponsesCheckboxGroup.class)
 public class CodeResponse extends EnoIdentifiableObject {
 
-    @DDI("#index.get(#index.get(#index.getParent(#this.getIDArray(0).getStringValue())" +
-            ".getGridDimensionArray(0).getCodeDomain().getCodeListReference().getIDArray(0).getStringValue())" +
-            ".getCodeArray(#listIndex).getCategoryReference().getIDArray(0).getStringValue())" +
-            ".getLabelArray(0)") //TODO: >_< see todo in DDIMapper....
+    /** Label of this modality.
+     * In DDI, it is inserted there through a processing. */
     @Lunatic("setLabel(#param)")
     private Label label;
 
+    /** Response of the modality. */
     @DDI("#this")
     @Lunatic("setResponse(#param)")
     Response response;
+
+    /** Additional "please specify" field of the modality.
+     * In DDI, it is inserted here through a processing. */
+    @Lunatic("setDetail(#param)")
+    DetailResponse detailResponse;
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
@@ -1,0 +1,38 @@
+package fr.insee.eno.core.model.response;
+
+import datacollection33.ResponseDomainInMixedType;
+import fr.insee.eno.core.annotations.Contexts.Context;
+import fr.insee.eno.core.annotations.DDI;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.label.Label;
+import fr.insee.eno.core.parameter.Format;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Unique/multiple choice question modalities can have an additional field for a detailed response.
+ * ("Other, please specify").
+ */
+@Getter
+@Setter
+@Context(format = Format.DDI, type = ResponseDomainInMixedType.class)
+public class DetailResponse extends EnoObject {
+
+    /** Code list value associated to the detail response. */
+    @DDI("getAttachmentLocation().getDomainSpecificValueArray(0).getValueArray(0).getStringValue()")
+    String value;
+
+    /** Label displayed, e.g. "Please, specify". */
+    @DDI("getResponseDomain().getLabelArray(0)")
+    Label label;
+
+    /** Collected response for the detail field.
+     * In DDI, it is not mapped directly (so to not write a too complicated spel expression) and resolved through
+     * a processing. */
+    Response response;
+
+    /** DDI reference of the response name. Can be used to retrieve the response name through DDI bindings. */
+    @DDI("getResponseDomain().getOutParameter().getIDArray(0).getStringValue()")
+    String responseReference;
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
@@ -12,13 +12,15 @@ import lombok.Setter;
 /**
  * Unique/multiple choice question modalities can have an additional field for a detailed response.
  * ("Other, please specify").
+ * DDI mapping annotations concern the unique choice case.
  */
 @Getter
 @Setter
 @Context(format = Format.DDI, type = ResponseDomainInMixedType.class)
 public class DetailResponse extends EnoObject {
 
-    /** Code list value associated to the detail response. */
+    /** Code list value associated to the detail response.
+     * Used to make the link between the detail and the option in Lunatic unique choice question components. */
     @DDI("getAttachmentLocation().getDomainSpecificValueArray(0).getValueArray(0).getStringValue()")
     String value;
 

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/DetailResponse.java
@@ -3,6 +3,7 @@ package fr.insee.eno.core.model.response;
 import datacollection33.ResponseDomainInMixedType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
+import fr.insee.eno.core.annotations.Lunatic;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.model.label.Label;
 import fr.insee.eno.core.parameter.Format;
@@ -17,6 +18,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Context(format = Format.DDI, type = ResponseDomainInMixedType.class)
+@Context(format = Format.LUNATIC, type = fr.insee.lunatic.model.flat.DetailResponse.class)
 public class DetailResponse extends EnoObject {
 
     /** Code list value associated to the detail response.
@@ -26,11 +28,13 @@ public class DetailResponse extends EnoObject {
 
     /** Label displayed, e.g. "Please, specify". */
     @DDI("getResponseDomain().getLabelArray(0)")
+    @Lunatic("setLabel(#param)")
     Label label;
 
     /** Collected response for the detail field.
      * In DDI, it is not mapped directly (so to not write a too complicated spel expression) and resolved through
      * a processing. */
+    @Lunatic("setResponse(#param)")
     Response response;
 
     /** DDI reference of the response name. Can be used to retrieve the response name through DDI bindings. */

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/ModalityAttachment.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/ModalityAttachment.java
@@ -1,0 +1,57 @@
+package fr.insee.eno.core.model.response;
+
+import datacollection33.GridResponseDomainInMixedType;
+import fr.insee.eno.core.annotations.Contexts.Context;
+import fr.insee.eno.core.annotations.DDI;
+import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.label.Label;
+import fr.insee.eno.core.parameter.Format;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigInteger;
+
+/**
+ * Class designed for the DDI mapping of the multiple choice question modalities, to make the link between
+ * a detail ("please specify") response and the corresponding code response modality.
+ */
+@Getter
+@Setter
+@Context(format = Format.DDI, type = GridResponseDomainInMixedType.class)
+public abstract class ModalityAttachment extends EnoObject {
+
+    /** Identifier that corresponds to the source reference in the question grid bindings. */
+    @DDI("getResponseDomain().getOutParameter().getIDArray(0).getStringValue()")
+    String responseDomainId;
+
+    /**
+     * DDI attachment of a modality response.
+     */
+    @Getter
+    @Setter
+    @Context(format = Format.DDI, type = GridResponseDomainInMixedType.class)
+    public static class CodeAttachment extends ModalityAttachment {
+
+        /** Attachment value of a modality response. */
+        @DDI("getAttachmentBase()")
+        BigInteger attachmentBase;
+    }
+
+    /**
+     * DDI attachment of a detail response.
+     */
+    @Getter
+    @Setter
+    @Context(format = Format.DDI, type = GridResponseDomainInMixedType.class)
+    public static class DetailAttachment extends ModalityAttachment {
+
+        /** Attachment value of detail response. */
+        @DDI("getResponseAttachmentLocation().getDomainSpecificValueArray(0).getAttachmentDomain()")
+        BigInteger attachmentDomain;
+
+        /** Label displayed, e.g. "Please, specify" for a detail response. */
+        @DDI("!getResponseDomain().getLabelList().isEmpty() ? getResponseDomain().getLabelArray(0) : null")
+        Label label;
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/model/response/Response.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/response/Response.java
@@ -21,4 +21,8 @@ public class Response extends EnoObject {
     @Lunatic("setName(#param)")
     String variableName;
 
+    /** DDI reference of the response. */
+    @DDI("getIDArray(0).getStringValue()")
+    String ddiReference;
+
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
@@ -16,6 +16,7 @@ public class DDIInProcessing {
                 .then(new DDICleanUpQuestionnaireId())
                 .then(new DDIMoveUnitInQuestions())
                 .then(new DDIInsertResponseInTableCells())
+                .then(new DDIInsertDetailResponses())
                 .then(new DDIResolveVariableReferencesInExpressions())
                 .then(new DDIInsertDeclarations(enoIndex))
                 .then(new DDIInsertControls())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
@@ -17,6 +17,7 @@ public class DDIInProcessing {
                 .then(new DDIMoveUnitInQuestions())
                 .then(new DDIInsertResponseInTableCells())
                 .then(new DDIInsertDetailResponses())
+                .then(new DDIInsertMultipleChoiceLabels())
                 .then(new DDIResolveVariableReferencesInExpressions())
                 .then(new DDIInsertDeclarations(enoIndex))
                 .then(new DDIInsertControls())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponses.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponses.java
@@ -1,0 +1,47 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import fr.insee.eno.core.model.response.Response;
+import fr.insee.eno.core.processing.ProcessingStep;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * TODO
+ */
+public class DDIInsertDetailResponses implements ProcessingStep<EnoQuestionnaire> {
+
+    /**
+     * TODO
+     * @param enoQuestionnaire
+     */
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        //
+        enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(UniqueChoiceQuestion.class::isInstance)
+                .map(UniqueChoiceQuestion.class::cast)
+                .forEach(this::insertDetailResponses);
+    }
+
+    private void insertDetailResponses(UniqueChoiceQuestion uniqueChoiceQuestion) {
+        //
+        Map<String, String> bindingsMap = new HashMap<>();
+        uniqueChoiceQuestion.getDdiBindings().forEach(binding ->
+                bindingsMap.put(binding.getSourceParameterId(), binding.getTargetParameterId()));
+        //
+        Map<String, String> responsesMap = new HashMap<>();
+        uniqueChoiceQuestion.getDdiResponses().forEach(response ->
+                responsesMap.put(response.getDdiReference(), response.getVariableName()));
+        //
+        uniqueChoiceQuestion.getDetailResponses().forEach(detailResponse -> {
+            String variableName = responsesMap.get(bindingsMap.get(detailResponse.getResponseReference()));
+            Response response = new Response();
+            response.setVariableName(variableName);
+            detailResponse.setResponse(response);
+        });
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabels.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabels.java
@@ -1,0 +1,47 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.code.CodeItem;
+import fr.insee.eno.core.model.code.CodeList;
+import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import fr.insee.eno.core.model.response.CodeResponse;
+import fr.insee.eno.core.processing.ProcessingStep;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Processing class to insert the label of modalities in the code responses of multiple choice questions.
+ * Warning: This processing must be called after the processing that resolves detail response of modalities.
+ * The reason is that in DDI modeling, the link between MCQ modalities and the code list is based on the ordering,
+ * and that detail responses are described as additional code responses in DDI, so they need to be cleaned up.
+ * @see DDIInsertDetailResponses
+ */
+public class DDIInsertMultipleChoiceLabels implements ProcessingStep<EnoQuestionnaire> {
+
+    private final Map<String, CodeList> codeListMap = new HashMap<>();
+
+    /**
+     * Sets code response labels of multiple choice questions, using the referenced code list.
+     * @param enoQuestionnaire Eno questionnaire.
+     */
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        enoQuestionnaire.getCodeLists().forEach(codeList -> codeListMap.put(codeList.getId(), codeList));
+        //
+        enoQuestionnaire.getMultipleResponseQuestions().stream()
+                .filter(SimpleMultipleChoiceQuestion.class::isInstance)
+                .map(SimpleMultipleChoiceQuestion.class::cast)
+                .forEach(this::insertModalityLabels);
+    }
+
+    private void insertModalityLabels(SimpleMultipleChoiceQuestion simpleMultipleChoiceQuestion) {
+        CodeList codeList = codeListMap.get(simpleMultipleChoiceQuestion.getCodeListReference());
+        for (int i = 0; i < codeList.size(); i ++) {
+            CodeItem codeItem = codeList.getCodeItems().get(i);
+            CodeResponse codeResponse = simpleMultipleChoiceQuestion.getCodeResponses().get(i);
+            codeResponse.setLabel(codeItem.getLabel());
+        }
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -40,6 +40,7 @@ public class LunaticProcessing {
                 .then(new LunaticSortComponents(enoQuestionnaire))
                 .then(new LunaticLoopResolution(enoQuestionnaire))
                 .then(new LunaticTableProcessing(enoQuestionnaire))
+                .then(new LunaticInsertUniqueChoiceDetails(enoQuestionnaire))
                 .then(new LunaticSuggestersConfiguration(enoQuestionnaire))
                 .then(new LunaticVariablesValues())
                 .thenIf(parameters.isMissingVariables(), new LunaticAddMissingVariables(enoCatalog, parameters.isMissingVariables()))

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetails.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetails.java
@@ -1,0 +1,116 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.exceptions.technical.MappingException;
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.lunatic.model.flat.*;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Unique choice modality details are at the question level in Eno model.
+ * This processing step is aimed to insert the detail response of unique choice questions at the right place.
+ */
+public class LunaticInsertUniqueChoiceDetails implements ProcessingStep<Questionnaire> {
+
+    private final EnoQuestionnaire enoQuestionnaire;
+    private Questionnaire lunaticQuestionnaire;
+    private final LunaticMapper lunaticMapper = new LunaticMapper();
+
+    public LunaticInsertUniqueChoiceDetails(EnoQuestionnaire enoQuestionnaire) {
+        this.enoQuestionnaire = enoQuestionnaire;
+    }
+
+    /**
+     * Inserts detail responses in options of unique choice components (Radio and CheckboxOne).
+     * @param lunaticQuestionnaire Lunatic questionnaire.
+     */
+    @Override
+    public void apply(Questionnaire lunaticQuestionnaire) {
+        this.lunaticQuestionnaire = lunaticQuestionnaire;
+        enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(UniqueChoiceQuestion.class::isInstance)
+                .map(UniqueChoiceQuestion.class::cast)
+                .forEach(this::insertDetailInOptions);
+    }
+
+    /**
+     * From Eno unique choice question object given, retrieves the corresponding Lunatic component,
+     * and insert detail responses in its options.
+     * @param enoUniqueChoiceQuestion Eno unique choice question.
+     */
+    private void insertDetailInOptions(UniqueChoiceQuestion enoUniqueChoiceQuestion) {
+        // Find corresponding Lunatic component
+        String questionId = enoUniqueChoiceQuestion.getId();
+        Optional<ComponentType> lunaticComponent = findComponentById(lunaticQuestionnaire, questionId);
+        if (lunaticComponent.isEmpty())
+            throw new MappingException("Cannot find Lunatic component for " + enoUniqueChoiceQuestion + ".");
+        enoUniqueChoiceQuestion.getDetailResponses().forEach(enoDetailResponse -> {
+            // Map Eno detail response object to a Lunatic detail response object
+            DetailResponse lunaticDetailResponse = new DetailResponse();
+            lunaticMapper.mapEnoObject(enoDetailResponse, lunaticDetailResponse);
+            // Insert it in the right option (only Radio and CheckboxOne are concerned)
+            boolean mappingError = false;
+            if (lunaticComponent.get() instanceof Radio radio)
+                mappingError = insertDetailInOption(lunaticDetailResponse, enoDetailResponse.getValue(), radio.getOptions());
+            if (lunaticComponent.get() instanceof CheckboxOne checkboxOne)
+                mappingError = insertDetailInOption(lunaticDetailResponse, enoDetailResponse.getValue(), checkboxOne.getOptions());
+            if (mappingError)
+                throw new MappingException(String.format(
+                        "Cannot link detail field with an option of value '%s' in Lunatic unique choice component '%s'.",
+                        enoDetailResponse.getValue(), questionId));
+        });
+    }
+
+    /**
+     * Inserts the detail response object in the right option, using the value to determine which.
+     * This method doesn't have sufficient information to throw an exception with a precise message. So it returns a
+     * boolean to indicate if insertion failed.
+     * @param detailResponse Lunatic detail response object.
+     * @param value Value of the corresponding option.
+     * @param optionsList List of Lunatic unique choice options.
+     * @return True if insertion failed.
+     */
+    private static boolean insertDetailInOption(DetailResponse detailResponse, String value, List<Options> optionsList) {
+        // Note: 'Options' class name should be singular in Lunatic-Model...
+        Optional<Options> correspondingOption = optionsList.stream()
+                .filter(options -> value.equals(options.getValue()))
+                .findAny();
+        if (correspondingOption.isEmpty())
+            return true;
+        correspondingOption.get().setDetail(detailResponse);
+        return false;
+    }
+
+    // May be refactored in Lunatic utils at some point,
+    // yet it is a bit too specific as it's currently written so better let it private here.
+    private static Optional<ComponentType> findComponentById(Questionnaire lunaticQuestionnaire, String id) {
+        // Search in questionnaire components
+        List<ComponentType> components = lunaticQuestionnaire.getComponents();
+        Optional<ComponentType> searchedComponent = findComponentInList(id, components);
+        if (searchedComponent.isPresent())
+            return searchedComponent;
+        // If not found, may be in a loop
+        List<Loop> loops = lunaticQuestionnaire.getComponents().stream()
+                .filter(Loop.class::isInstance)
+                .map(Loop.class::cast)
+                .toList();
+        for (Loop loop : loops) {
+            List<ComponentType> loopComponents = loop.getComponents();
+            searchedComponent = findComponentInList(id, loopComponents);
+            if (searchedComponent.isPresent())
+                return searchedComponent;
+        }
+        // If still not found, return empty
+        return Optional.empty();
+    }
+
+    private static Optional<ComponentType> findComponentInList(String id, List<ComponentType> loopComponents) {
+        return loopComponents.stream()
+                .filter(component -> id.equals(component.getId())).findAny();
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/reference/EnoCatalog.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/reference/EnoCatalog.java
@@ -15,6 +15,7 @@ import fr.insee.eno.core.model.sequence.AbstractSequence;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.sequence.Subsequence;
 import fr.insee.eno.core.model.variable.Variable;
+import lombok.Getter;
 
 import java.util.*;
 
@@ -32,6 +33,7 @@ public class EnoCatalog {
     /** Map of collected variables stored by their reference (warning: keys = not ids). */
     Map<String, Variable> variableMap = new HashMap<>();
     /** List with all labels that are in the questionnaire. */
+    @Getter
     private final Collection<EnoLabel> labels = new ArrayDeque<>();
     // NB: https://stackoverflow.com/questions/6129805/what-is-the-fastest-java-collection-with-the-basic-functionality-of-a-queue
 
@@ -80,9 +82,6 @@ public class EnoCatalog {
     public Collection<EnoComponent> getComponents() {
         return componentMap.values();
     }
-    public Collection<EnoLabel> getLabels() {
-        return labels;
-    }
 
     private void gatherLabels(EnoQuestionnaire enoQuestionnaire) {
         // Sequences and subsequences
@@ -100,11 +99,6 @@ public class EnoCatalog {
                 labels.addAll(enoQuestion.getControls().stream().map(Control::getMessage).toList()));
         // Code lists
         enoQuestionnaire.getCodeLists().stream().map(CodeList::getCodeItems).forEach(this::gatherLabelsFromCodeItems);
-        // Code lists in multiple response questions (might be refactored afterward)
-        enoQuestionnaire.getMultipleResponseQuestions().stream()
-                .filter(SimpleMultipleChoiceQuestion.class::isInstance)
-                .map(SimpleMultipleChoiceQuestion.class::cast)
-                .forEach(this::gatherLabelsFromCodeResponses);
     }
 
     private void gatherLabelsFromCodeItems(List<CodeItem> codeItems) {
@@ -113,10 +107,6 @@ public class EnoCatalog {
             // Recursive call in case of nested code items
             gatherLabelsFromCodeItems(codeItem.getCodeItems());
         }
-    }
-
-    private void gatherLabelsFromCodeResponses(SimpleMultipleChoiceQuestion multipleChoiceQuestion) {
-        labels.addAll(multipleChoiceQuestion.getCodeResponses().stream().map(CodeResponse::getLabel).toList());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/converter/DDIConverterTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/converter/DDIConverterTest.java
@@ -3,6 +3,7 @@ package fr.insee.eno.core.converter;
 import datacollection33.QuestionItemDocument;
 import datacollection33.QuestionItemType;
 import fr.insee.eno.core.model.EnoObject;
+import fr.insee.eno.core.model.question.SingleResponseQuestion;
 import fr.insee.eno.core.model.question.TextQuestion;
 import org.apache.xmlbeans.XmlException;
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,7 @@ class DDIConverterTest {
         QuestionItemType ddiQuestionItem = QuestionItemDocument.Factory.parse(
                 new ByteArrayInputStream(stringInput.getBytes())).getQuestionItem();
         //
-        EnoObject result = DDIConverter.instantiateFromDDIObject(ddiQuestionItem, null);
+        EnoObject result = DDIConverter.instantiateFromDDIObject(ddiQuestionItem, null, SingleResponseQuestion.class);
         //
         assertTrue(result instanceof TextQuestion);
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/converter/DDIQuestionGridConversionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/converter/DDIQuestionGridConversionTest.java
@@ -1,0 +1,37 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.QuestionGridDocument;
+import datacollection33.QuestionGridType;
+import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class DDIQuestionGridConversionTest {
+
+    @Test
+    void convertMultipleChoiceQuestion() throws XmlException, IOException {
+        //
+        QuestionGridType questionGridType = QuestionGridDocument.Factory.parse(
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "unit/ddi/ddi-multiple-choice-question.xml")).getQuestionGrid();
+        //
+        assertInstanceOf(SimpleMultipleChoiceQuestion.class,
+                DDIQuestionGridConversion.instantiateFrom(questionGridType));
+    }
+
+    @Test
+    void convertMultipleChoiceQuestionWithDetailResponses() throws XmlException, IOException {
+        //
+        QuestionGridType questionGridType = QuestionGridDocument.Factory.parse(
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "unit/ddi/ddi-multiple-choice-other-specify.xml")).getQuestionGrid();
+        //
+        assertInstanceOf(SimpleMultipleChoiceQuestion.class,
+                DDIQuestionGridConversion.instantiateFrom(questionGridType));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/converter/DDIQuestionItemConversionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/converter/DDIQuestionItemConversionTest.java
@@ -1,0 +1,26 @@
+package fr.insee.eno.core.converter;
+
+import datacollection33.QuestionItemDocument;
+import datacollection33.QuestionItemType;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class DDIQuestionItemConversionTest {
+
+    @Test
+    void convertUniqueChoiceQuestionWithDetailResponses() throws XmlException, IOException {
+        //
+        QuestionItemType questionItemType = QuestionItemDocument.Factory.parse(
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "unit/ddi/ddi-unique-choice-other-specify.xml")).getQuestionItem();
+        //
+        assertInstanceOf(UniqueChoiceQuestion.class,
+                DDIQuestionItemConversion.instantiateFrom(questionItemType, null));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
@@ -1,0 +1,30 @@
+package fr.insee.eno.core.mapping.in.ddi;
+
+import datacollection33.QuestionItemDocument;
+import datacollection33.QuestionItemType;
+import fr.insee.eno.core.mappers.DDIMapper;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import org.apache.xmlbeans.XmlException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UniqueChoiceQuestionTest {
+
+    @Test
+    void mapUniqueChoiceQuestionWithDetailResponses() throws XmlException, IOException {
+        //
+        QuestionItemType ddiUniqueChoiceQuestion = QuestionItemDocument.Factory.parse(
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "unit/ddi/ddi-unique-choice-other-specify.xml")).getQuestionItem();
+        UniqueChoiceQuestion enoUniqueChoiceQuestion = new UniqueChoiceQuestion();
+        //
+        DDIMapper ddiMapper = new DDIMapper();
+        ddiMapper.mapDDIObject(ddiUniqueChoiceQuestion, enoUniqueChoiceQuestion);
+        //
+        assertEquals("lutkfklf", enoUniqueChoiceQuestion.getCodeListReference());
+        assertEquals(UniqueChoiceQuestion.DisplayFormat.RADIO, enoUniqueChoiceQuestion.getDisplayFormat());
+    }
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
@@ -4,7 +4,6 @@ import datacollection33.QuestionItemDocument;
 import datacollection33.QuestionItemType;
 import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
-import fr.insee.eno.core.model.response.DetailResponse;
 import org.apache.xmlbeans.XmlException;
 import org.junit.jupiter.api.Test;
 
@@ -34,5 +33,11 @@ class UniqueChoiceQuestionTest {
         assertEquals(3, enoUniqueChoiceQuestion.getDdiResponses().size());
         //
         assertEquals(2, enoUniqueChoiceQuestion.getDetailResponses().size());
+        assertEquals("codeC", enoUniqueChoiceQuestion.getDetailResponses().get(0).getValue());
+        assertEquals("codeD", enoUniqueChoiceQuestion.getDetailResponses().get(1).getValue());
+        assertEquals("\"Please, specify about option C:\"",
+                enoUniqueChoiceQuestion.getDetailResponses().get(0).getLabel().getValue());
+        assertEquals("\"Please, specify about option D:\"",
+                enoUniqueChoiceQuestion.getDetailResponses().get(1).getLabel().getValue());
     }
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
@@ -4,6 +4,7 @@ import datacollection33.QuestionItemDocument;
 import datacollection33.QuestionItemType;
 import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import fr.insee.eno.core.model.response.DetailResponse;
 import org.apache.xmlbeans.XmlException;
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +21,17 @@ class UniqueChoiceQuestionTest {
                 this.getClass().getClassLoader().getResourceAsStream(
                         "unit/ddi/ddi-unique-choice-other-specify.xml")).getQuestionItem();
         UniqueChoiceQuestion enoUniqueChoiceQuestion = new UniqueChoiceQuestion();
+
         //
         DDIMapper ddiMapper = new DDIMapper();
         ddiMapper.mapDDIObject(ddiUniqueChoiceQuestion, enoUniqueChoiceQuestion);
+
         //
         assertEquals("lutkfklf", enoUniqueChoiceQuestion.getCodeListReference());
         assertEquals(UniqueChoiceQuestion.DisplayFormat.RADIO, enoUniqueChoiceQuestion.getDisplayFormat());
+        //
+        assertEquals(3, enoUniqueChoiceQuestion.getDdiBindings().size());
+        //
+        assertEquals(2, enoUniqueChoiceQuestion.getDetailResponses().size());
     }
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/UniqueChoiceQuestionTest.java
@@ -31,6 +31,7 @@ class UniqueChoiceQuestionTest {
         assertEquals(UniqueChoiceQuestion.DisplayFormat.RADIO, enoUniqueChoiceQuestion.getDisplayFormat());
         //
         assertEquals(3, enoUniqueChoiceQuestion.getDdiBindings().size());
+        assertEquals(3, enoUniqueChoiceQuestion.getDdiResponses().size());
         //
         assertEquals(2, enoUniqueChoiceQuestion.getDetailResponses().size());
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DetailResponseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DetailResponseTest.java
@@ -1,0 +1,40 @@
+package fr.insee.eno.core.mapping.out.lunatic;
+
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.label.Label;
+import fr.insee.eno.core.model.response.Response;
+import fr.insee.lunatic.model.flat.LabelTypeEnum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DetailResponseTest {
+
+    private fr.insee.eno.core.model.response.DetailResponse enoDetailResponse;
+    private fr.insee.lunatic.model.flat.DetailResponse lunaticDetailResponse;
+
+    private final LunaticMapper lunaticMapper = new LunaticMapper();
+
+    @BeforeEach
+    void createDetailResponseObjects() {
+        enoDetailResponse = new fr.insee.eno.core.model.response.DetailResponse();
+        lunaticDetailResponse = new fr.insee.lunatic.model.flat.DetailResponse();
+    }
+
+    @Test
+    void mapDetailResponse() {
+        //
+        enoDetailResponse.setResponse(new Response());
+        enoDetailResponse.getResponse().setVariableName("FOO_DETAIL");
+        enoDetailResponse.setLabel(new Label());
+        enoDetailResponse.getLabel().setValue("\"Please specify\"");
+        //
+        lunaticMapper.mapEnoObject(enoDetailResponse, lunaticDetailResponse);
+        //
+        assertEquals("FOO_DETAIL", lunaticDetailResponse.getResponse().getName());
+        assertEquals("\"Please specify\"", lunaticDetailResponse.getLabel().getValue());
+        assertEquals(LabelTypeEnum.VTL_MD, lunaticDetailResponse.getLabel().getTypeEnum());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/SimpleUniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/SimpleUniqueChoiceQuestionTest.java
@@ -1,0 +1,51 @@
+package fr.insee.eno.core.mapping.out.lunatic;
+
+import fr.insee.eno.core.DDIToEno;
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.lunatic.model.flat.CheckboxGroup;
+import fr.insee.lunatic.model.flat.LabelTypeEnum;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class SimpleUniqueChoiceQuestionTest {
+
+    @Test
+    void detailResponses_integrationTest() throws DDIParsingException {
+        //
+        EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(
+                this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-other-specify.xml"),
+                EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI));
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+
+        //
+        List<CheckboxGroup> checkboxGroupList = lunaticQuestionnaire.getComponents().stream()
+                .filter(CheckboxGroup.class::isInstance).map(CheckboxGroup.class::cast).toList();
+        assertEquals(1, checkboxGroupList.size());
+        CheckboxGroup checkboxGroup = checkboxGroupList.getFirst();
+        //
+        assertEquals(4, checkboxGroup.getResponses().size());
+        assertNull(checkboxGroup.getResponses().get(0).getDetail());
+        assertNull(checkboxGroup.getResponses().get(1).getDetail());
+        assertEquals("\"Please, specify about option C:\"",
+                checkboxGroup.getResponses().get(2).getDetail().getLabel().getValue());
+        assertEquals("\"Please, specify about option D:\"",
+                checkboxGroup.getResponses().get(3).getDetail().getLabel().getValue());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(2).getDetail().getLabel().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(3).getDetail().getLabel().getTypeEnum());
+        assertEquals("MCQ_codeC", checkboxGroup.getResponses().get(2).getDetail().getResponse().getName());
+        assertEquals("MCQ_codeD", checkboxGroup.getResponses().get(3).getDetail().getResponse().getName());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponsesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponsesTest.java
@@ -1,0 +1,57 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.DDIMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
+import fr.insee.eno.core.serialize.DDIDeserializer;
+import instance33.DDIInstanceDocument;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DDIInsertDetailResponsesTest {
+
+    @Test
+    void integrationTest() throws DDIParsingException {
+        //
+        DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
+                this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-other-specify.xml"));
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        DDIMapper ddiMapper = new DDIMapper();
+        ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
+
+        //
+        DDIInsertDetailResponses processingStep = new DDIInsertDetailResponses();
+        processingStep.apply(enoQuestionnaire);
+
+        //
+        List<UniqueChoiceQuestion> uniqueChoiceQuestions = enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(UniqueChoiceQuestion.class::isInstance).map(UniqueChoiceQuestion.class::cast).toList();
+        UniqueChoiceQuestion radioUCQ = uniqueChoiceQuestions.stream()
+                .filter(uniqueChoiceQuestion ->
+                        UniqueChoiceQuestion.DisplayFormat.RADIO.equals(uniqueChoiceQuestion.getDisplayFormat()))
+                .findAny().orElse(null);
+        UniqueChoiceQuestion checkboxUCQ = uniqueChoiceQuestions.stream()
+                .filter(uniqueChoiceQuestion ->
+                        UniqueChoiceQuestion.DisplayFormat.CHECKBOX.equals(uniqueChoiceQuestion.getDisplayFormat()))
+                .findAny().orElse(null);
+        //
+        assertNotNull(radioUCQ);
+        assertNotNull(checkboxUCQ);
+        assertThat(getDetailResponseNames(radioUCQ)).containsExactlyInAnyOrderElementsOf(
+                List.of("UCQ_codeC_RADIO", "UCQ_codeD_RADIO"));
+        assertThat(getDetailResponseNames(checkboxUCQ)).containsExactlyInAnyOrderElementsOf(
+                List.of("UCQ_codeC_CHECKBOX", "UCQ_codeD_CHECKBOX"));
+    }
+
+    /** Utility test method to gather detail response names of a unique choice question. */
+    private static List<String> getDetailResponseNames(UniqueChoiceQuestion uniqueChoiceQuestion) {
+        return uniqueChoiceQuestion.getDetailResponses().stream()
+                .map(detailResponse -> detailResponse.getResponse().getVariableName()).toList();
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponsesTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertDetailResponsesTest.java
@@ -3,31 +3,39 @@ package fr.insee.eno.core.processing.in.steps.ddi;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
 import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import instance33.DDIInstanceDocument;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DDIInsertDetailResponsesTest {
 
-    @Test
-    void integrationTest() throws DDIParsingException {
+    private static EnoQuestionnaire enoQuestionnaire;
+
+    @BeforeAll
+    static void mapAndProcessDDI() throws DDIParsingException {
         //
+        enoQuestionnaire = new EnoQuestionnaire();
         DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
-                this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-other-specify.xml"));
-        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+                DDIInsertDetailResponsesTest.class.getClassLoader().getResourceAsStream(
+                        "integration/ddi/ddi-other-specify.xml"));
         DDIMapper ddiMapper = new DDIMapper();
         ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
 
         //
-        DDIInsertDetailResponses processingStep = new DDIInsertDetailResponses();
-        processingStep.apply(enoQuestionnaire);
+        DDIInsertDetailResponses ddiInsertDetailResponses = new DDIInsertDetailResponses();
+        ddiInsertDetailResponses.apply(enoQuestionnaire);
+    }
 
+    @Test
+    void uniqueChoiceDetailsTest() {
         //
         List<UniqueChoiceQuestion> uniqueChoiceQuestions = enoQuestionnaire.getSingleResponseQuestions().stream()
                 .filter(UniqueChoiceQuestion.class::isInstance).map(UniqueChoiceQuestion.class::cast).toList();
@@ -52,6 +60,30 @@ class DDIInsertDetailResponsesTest {
     private static List<String> getDetailResponseNames(UniqueChoiceQuestion uniqueChoiceQuestion) {
         return uniqueChoiceQuestion.getDetailResponses().stream()
                 .map(detailResponse -> detailResponse.getResponse().getVariableName()).toList();
+    }
+
+    @Test
+    void multipleChoiceDetailsTest() {
+        //
+        List<SimpleMultipleChoiceQuestion> simpleMCQList = enoQuestionnaire.getMultipleResponseQuestions().stream()
+                .filter(SimpleMultipleChoiceQuestion.class::isInstance)
+                .map(SimpleMultipleChoiceQuestion.class::cast)
+                .toList();
+        assertEquals(1, simpleMCQList.size());
+        SimpleMultipleChoiceQuestion simpleMCQ = simpleMCQList.getFirst();
+        // After processing: should be only 4 code responses (that correspond to the 4 codes/modalities)
+        assertEquals(4, simpleMCQ.getCodeResponses().size());
+        //
+        assertNull(simpleMCQ.getCodeResponses().get(0).getDetailResponse());
+        assertNull(simpleMCQ.getCodeResponses().get(1).getDetailResponse());
+        assertEquals("MCQ_codeC",
+                simpleMCQ.getCodeResponses().get(2).getDetailResponse().getResponse().getVariableName());
+        assertEquals("MCQ_codeD",
+                simpleMCQ.getCodeResponses().get(3).getDetailResponse().getResponse().getVariableName());
+        assertEquals("\"Please, specify about option C:\"",
+                simpleMCQ.getCodeResponses().get(2).getDetailResponse().getLabel().getValue());
+        assertEquals("\"Please, specify about option D:\"",
+                simpleMCQ.getCodeResponses().get(3).getDetailResponse().getLabel().getValue());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabelsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabelsTest.java
@@ -1,0 +1,45 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.DDIMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import fr.insee.eno.core.serialize.DDIDeserializer;
+import instance33.DDIInstanceDocument;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DDIInsertMultipleChoiceLabelsTest {
+
+    @Test
+    void integrationTest() throws DDIParsingException {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
+                DDIInsertDetailResponsesTest.class.getClassLoader().getResourceAsStream(
+                        "integration/ddi/ddi-other-specify.xml"));
+        DDIMapper ddiMapper = new DDIMapper();
+        ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
+        new DDIInsertDetailResponses().apply(enoQuestionnaire);
+
+        //
+        new DDIInsertMultipleChoiceLabels().apply(enoQuestionnaire);
+
+        //
+        List<SimpleMultipleChoiceQuestion> simpleMCQList = enoQuestionnaire.getMultipleResponseQuestions().stream()
+                .filter(SimpleMultipleChoiceQuestion.class::isInstance)
+                .map(SimpleMultipleChoiceQuestion.class::cast)
+                .toList();
+        assertEquals(1, simpleMCQList.size());
+        SimpleMultipleChoiceQuestion simpleMCQ = simpleMCQList.getFirst();
+        //
+        assertEquals("\"Option A\"", simpleMCQ.getCodeResponses().get(0).getLabel().getValue());
+        assertEquals("\"Option B\"", simpleMCQ.getCodeResponses().get(1).getLabel().getValue());
+        assertEquals("\"Option C (with detail)\"", simpleMCQ.getCodeResponses().get(2).getLabel().getValue());
+        assertEquals("\"Option D (with detail)\"", simpleMCQ.getCodeResponses().get(3).getLabel().getValue());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInLabelsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInLabelsTest.java
@@ -67,6 +67,7 @@ class DDIResolveVariableReferencesInLabelsTest {
             new DDIInsertDeclarations(enoQuestionnaire.getIndex()).apply(enoQuestionnaire);
             new DDIInsertControls().apply(enoQuestionnaire);
             new DDIInsertCodeLists().apply(enoQuestionnaire);
+            new DDIInsertMultipleChoiceLabels().apply(enoQuestionnaire);
             EnoCatalog enoCatalog = new EnoCatalog(enoQuestionnaire);
             // When
             new DDIResolveVariableReferencesInLabels(enoCatalog).apply(enoQuestionnaire);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetailsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetailsTest.java
@@ -1,0 +1,54 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.DDIToEno;
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.lunatic.model.flat.CheckboxOne;
+import fr.insee.lunatic.model.flat.LabelTypeEnum;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.Radio;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LunaticInsertUniqueChoiceDetailsTest {
+
+    @Test
+    void integrationTest() throws DDIParsingException {
+        //
+        EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(
+                this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-other-specify.xml"),
+                EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI));
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+
+        //
+        new LunaticInsertUniqueChoiceDetails(enoQuestionnaire).apply(lunaticQuestionnaire);
+
+        //
+        Radio radio = lunaticQuestionnaire.getComponents().stream()
+                .filter(Radio.class::isInstance).map(Radio.class::cast).findAny().orElse(null);
+        CheckboxOne checkboxOne = lunaticQuestionnaire.getComponents().stream()
+                .filter(CheckboxOne.class::isInstance).map(CheckboxOne.class::cast).findAny().orElse(null);
+        assertNotNull(radio);
+        assertNotNull(checkboxOne);
+        //
+        assertNull(radio.getOptions().get(0).getDetail());
+        assertNull(radio.getOptions().get(1).getDetail());
+        assertEquals("UCQ_codeC_RADIO", radio.getOptions().get(2).getDetail().getResponse().getName());
+        assertEquals("\"Please, specify about option C:\"",
+                radio.getOptions().get(2).getDetail().getLabel().getValue());
+        assertEquals(LabelTypeEnum.VTL_MD, radio.getOptions().get(3).getDetail().getLabel().getTypeEnum());
+        //
+        assertNull(checkboxOne.getOptions().get(0).getDetail());
+        assertNull(checkboxOne.getOptions().get(1).getDetail());
+        assertEquals("UCQ_codeC_CHECKBOX", checkboxOne.getOptions().get(2).getDetail().getResponse().getName());
+        assertEquals("\"Please, specify about option C:\"",
+                checkboxOne.getOptions().get(2).getDetail().getLabel().getValue());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxOne.getOptions().get(3).getDetail().getLabel().getTypeEnum());
+    }
+
+}

--- a/eno-core/src/test/resources/integration/ddi/ddi-other-specify.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-other-specify.xml
@@ -1,0 +1,1451 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+             xmlns:a="ddi:archive:3_3"
+             xmlns:d="ddi:datacollection:3_3"
+             xmlns:g="ddi:group:3_3"
+             xmlns:l="ddi:logicalproduct:3_3"
+             xmlns:r="ddi:reusable:3_3"
+             xmlns:s="ddi:studyunit:3_3"
+             xmlns:xhtml="http://www.w3.org/1999/xhtml"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+             isMaintainable="true"><!--Eno version : 2.8.0. Generation date : 10/04/2024 - 9:02:48-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-lutk9kue</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Other please specify</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-lutk9kue</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-lutk9kue</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Other please specify</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkf97g</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkf97g</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">SEQUENCE</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkqj7u-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkmu5x-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">UCQ_CHECKBOX</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkxex2-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">MCQ</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkqj7u</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_codeC_RADIO</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_codeD_RADIO</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Unique choice question (radio buttons)"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:StructuredMixedResponseDomain>
+               <d:ResponseDomainInMixed attachmentBase="1">
+                  <d:CodeDomain>
+                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">radio-button</r:GenericOutputFormat>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeListReference>
+                              <r:Agency>fr.insee</r:Agency>
+                              <r:ID>lutkfklf</r:ID>
+                              <r:Version>1</r:Version>
+                              <r:TypeOfObject>CodeList</r:TypeOfObject>
+                           </r:CodeListReference>
+                        </r:CodeRepresentation>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:CodeDomain>
+               </d:ResponseDomainInMixed>
+               <d:ResponseDomainInMixed>
+                  <d:TextDomain maxLength="20">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option C:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="20"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:AttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="1">
+                        <r:Value>codeC</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf-3</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:AttachmentLocation>
+               </d:ResponseDomainInMixed>
+               <d:ResponseDomainInMixed>
+                  <d:TextDomain maxLength="30">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option D:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="30"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:AttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="1">
+                        <r:Value>codeD</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf-4</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:AttachmentLocation>
+               </d:ResponseDomainInMixed>
+            </d:StructuredMixedResponseDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkmu5x</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">UCQ_CHECKBOX</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_CHECKBOX</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_codeC_CHECKBOX</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">UCQ_codeD_CHECKBOX</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkmu5x-RDOP-lutl3eds</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlbp0u-RDOP-lutlhhgn</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlld7b-RDOP-lutldnjm</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Unique choice question (checkbox buttons)"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:StructuredMixedResponseDomain>
+               <d:ResponseDomainInMixed attachmentBase="1">
+                  <d:CodeDomain>
+                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">checkbox</r:GenericOutputFormat>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkmu5x-RDOP-lutl3eds</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeListReference>
+                              <r:Agency>fr.insee</r:Agency>
+                              <r:ID>lutkfklf</r:ID>
+                              <r:Version>1</r:Version>
+                              <r:TypeOfObject>CodeList</r:TypeOfObject>
+                           </r:CodeListReference>
+                        </r:CodeRepresentation>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:CodeDomain>
+               </d:ResponseDomainInMixed>
+               <d:ResponseDomainInMixed>
+                  <d:TextDomain maxLength="20">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option C:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutlbp0u-RDOP-lutlhhgn</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="20"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:AttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="1">
+                        <r:Value>codeC</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf-3</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:AttachmentLocation>
+               </d:ResponseDomainInMixed>
+               <d:ResponseDomainInMixed>
+                  <d:TextDomain maxLength="30">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option D:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutlld7b-RDOP-lutldnjm</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="30"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:AttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="1">
+                        <r:Value>codeD</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkfklf-4</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:AttachmentLocation>
+               </d:ResponseDomainInMixed>
+            </d:StructuredMixedResponseDomain>
+         </d:QuestionItem>
+         <d:QuestionGrid>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkxex2</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionGridName>
+               <r:String xml:lang="fr-FR">MCQ</r:String>
+            </d:QuestionGridName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ1</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ2</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ3</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ4</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ_codeC</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">MCQ_codeD</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Multiple choice question"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:GridDimension displayCode="false" displayLabel="false" rank="1">
+               <d:CodeDomain>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lutkfklf</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </d:CodeDomain>
+            </d:GridDimension>
+            <d:StructuredMixedGridResponseDomain>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed>
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed attachmentBase="3">
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="3" rangeMaximum="3"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed attachmentBase="4">
+                  <d:NominalDomain>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:CodeRepresentation>
+                           <r:CodeSubsetInformation>
+                              <r:IncludedCode>
+                                 <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                 </r:CodeReference>
+                              </r:IncludedCode>
+                           </r:CodeSubsetInformation>
+                        </r:CodeRepresentation>
+                        <r:DefaultValue/>
+                     </r:OutParameter>
+                     <r:ResponseCardinality maximumResponses="1"/>
+                  </d:NominalDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="4" rangeMaximum="4"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed>
+                  <d:TextDomain maxLength="20">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option C:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="20"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:ResponseAttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="3">
+                        <r:Value>1</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:ResponseAttachmentLocation>
+               </d:GridResponseDomainInMixed>
+               <d:GridResponseDomainInMixed>
+                  <d:TextDomain maxLength="30">
+                     <r:Label>
+                        <r:Content xml:lang="fr-FR">"Please, specify about option D:"</r:Content>
+                     </r:Label>
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="30"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:ResponseAttachmentLocation>
+                     <d:DomainSpecificValue attachmentDomain="4">
+                        <r:Value>1</r:Value>
+                     </d:DomainSpecificValue>
+                     <r:CodeReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>Code</r:TypeOfObject>
+                     </r:CodeReference>
+                  </d:ResponseAttachmentLocation>
+               </d:GridResponseDomainInMixed>
+            </d:StructuredMixedGridResponseDomain>
+         </d:QuestionGrid>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-lutkfklf</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">CODE_LIST_WITH_DETAIL</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lutkfklf-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Option A"</r:Content>
+            </r:Label>
+         </l:Category>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lutkfklf-2</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Option B"</r:Content>
+            </r:Label>
+         </l:Category>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lutkfklf-3</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Option C (with detail)"</r:Content>
+            </r:Label>
+         </l:Category>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-lutkfklf-4</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Option D (with detail)"</r:Content>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENO_OTHER-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENO_OTHER</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkfklf</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">CODE_LIST_WITH_DETAIL</r:Content>
+            </r:Label>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkfklf-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lutkfklf-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>codeA</r:Value>
+            </l:Code>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkfklf-2</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lutkfklf-2</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>codeB</r:Value>
+            </l:Code>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkfklf-3</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lutkfklf-3</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>codeC</r:Value>
+            </l:Code>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkfklf-4</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-lutkfklf-4</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>codeD</r:Value>
+            </l:Code>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkscmh</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_RADIO label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lutkfklf</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutl57n5</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_codeC_RADIO</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_codeC radio detail</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="20"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkv69x</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_codeD_RADIO</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_codeD radio detail</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkqj7u</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="30"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutkwsd5</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_CHECKBOX</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_CHECKBOX label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>lutkfklf</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutksrhg</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_codeC_CHECKBOX</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_codeC checkbox detail</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="20"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutl4rut</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">UCQ_codeD_CHECKBOX</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">UCQ_codeD checkbox detail</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkmu5x</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="30"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutlk4q5</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ1</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">codeA - "Option A"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutli99v</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ2</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">codeB - "Option B"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutlbath</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ3</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">codeC - "Option C (with detail)"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutl7oi1</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ4</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">codeD - "Option D (with detail)"</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeSubsetInformation>
+                     <r:IncludedCode>
+                        <r:CodeReference>
+                           <r:Agency>fr.insee</r:Agency>
+                           <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                           <r:Version>1</r:Version>
+                           <r:TypeOfObject>Code</r:TypeOfObject>
+                        </r:CodeReference>
+                     </r:IncludedCode>
+                  </r:CodeSubsetInformation>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutl5z5d</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ_codeC</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">MCQ_codeC detail </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="20"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lutlhxbn</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">MCQ_codeD</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">MCQ_codeD detail </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkxex2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="30"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-lutk9kue-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-lutk9kue</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENO_OTHER</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkscmh</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl57n5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkv69x</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutkwsd5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutksrhg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl4rut</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlk4q5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutli99v</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlbath</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl7oi1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutl5z5d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>lutlhxbn</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+                            l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-lutk9kue</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-lutk9kue</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-lutk9kue</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-lutk9kue</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-lutk9kue</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-lutk9kue</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                          xmlns:cm="ddi:comparative:3_3"
+                          xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                          xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-lutk9kue</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENO_OTHER</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Other please specify questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-lutk9kue</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>

--- a/eno-core/src/test/resources/integration/pogues/pogues-other-specify.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-other-specify.json
@@ -1,0 +1,616 @@
+{
+  "owner": "ENO-INTEGRATION-TESTS",
+  "FlowControl": [],
+  "ComponentGroup": [
+    {
+      "MemberReference": [
+        "idendquest",
+        "lutkf97g",
+        "lutkqj7u",
+        "lutkmu5x",
+        "lutkxex2"
+      ],
+      "Label": [
+        "Components for page 1"
+      ],
+      "id": "lutle9w5",
+      "Name": "PAGE_1"
+    }
+  ],
+  "agency": "fr.insee",
+  "genericName": "QUESTIONNAIRE",
+  "Label": [
+    "Eno - Other please specify"
+  ],
+  "childQuestionnaireRef": [],
+  "Name": "ENO_OTHER",
+  "Variables": {
+    "Variable": [
+      {
+        "Label": "UCQ_RADIO label",
+        "id": "lutkscmh",
+        "type": "CollectedVariableType",
+        "CodeListReference": "lutkfklf",
+        "Name": "UCQ_RADIO",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": 1
+        }
+      },
+      {
+        "Label": "UCQ_codeC radio detail",
+        "id": "lutl57n5",
+        "type": "CollectedVariableType",
+        "CodeListReference": "lutkfklf",
+        "Name": "UCQ_codeC_RADIO",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "20"
+        }
+      },
+      {
+        "Label": "UCQ_codeD radio detail",
+        "id": "lutkv69x",
+        "type": "CollectedVariableType",
+        "Name": "UCQ_codeD_RADIO",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "30"
+        }
+      },
+      {
+        "Label": "UCQ_CHECKBOX label",
+        "id": "lutkwsd5",
+        "type": "CollectedVariableType",
+        "CodeListReference": "lutkfklf",
+        "Name": "UCQ_CHECKBOX",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": 1
+        }
+      },
+      {
+        "Label": "UCQ_codeC checkbox detail",
+        "id": "lutksrhg",
+        "type": "CollectedVariableType",
+        "Name": "UCQ_codeC_CHECKBOX",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "20"
+        }
+      },
+      {
+        "Label": "UCQ_codeD checkbox detail",
+        "id": "lutl4rut",
+        "type": "CollectedVariableType",
+        "Name": "UCQ_codeD_CHECKBOX",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "30"
+        }
+      },
+      {
+        "Label": "codeA - \"Option A\"",
+        "id": "lutlk4q5",
+        "type": "CollectedVariableType",
+        "Name": "MCQ1",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "codeB - \"Option B\"",
+        "id": "lutli99v",
+        "type": "CollectedVariableType",
+        "Name": "MCQ2",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "codeC - \"Option C (with detail)\"",
+        "id": "lutlbath",
+        "type": "CollectedVariableType",
+        "Name": "MCQ3",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "codeD - \"Option D (with detail)\"",
+        "id": "lutl7oi1",
+        "type": "CollectedVariableType",
+        "Name": "MCQ4",
+        "Datatype": {
+          "typeName": "BOOLEAN",
+          "type": "BooleanDatatypeType"
+        }
+      },
+      {
+        "Label": "MCQ_codeC detail",
+        "id": "lutl5z5d",
+        "type": "CollectedVariableType",
+        "Name": "MCQ_codeC",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "20"
+        }
+      },
+      {
+        "Label": "MCQ_codeD detail",
+        "id": "lutlhxbn",
+        "type": "CollectedVariableType",
+        "Name": "MCQ_codeD",
+        "Datatype": {
+          "Pattern": "",
+          "typeName": "TEXT",
+          "type": "TextDatatypeType",
+          "MaxLength": "30"
+        }
+      }
+    ]
+  },
+  "lastUpdatedDate": "Wed Apr 10 2024 11:02:36 GMT+0200 (heure d’été d’Europe centrale)",
+  "DataCollection": [
+    {
+      "id": "esa-dc-2018",
+      "uri": "http://ddi:fr.insee:DataCollection.esa-dc-2018",
+      "Name": "Enquête sectorielle annuelle 2018"
+    }
+  ],
+  "final": false,
+  "flowLogic": "FILTER",
+  "id": "lutk9kue",
+  "TargetMode": [
+    "CAPI",
+    "CATI",
+    "CAWI",
+    "PAPI"
+  ],
+  "CodeLists": {
+    "CodeList": [
+      {
+        "Label": "CODE_LIST_WITH_DETAIL",
+        "id": "lutkfklf",
+        "Code": [
+          {
+            "Parent": "",
+            "Label": "\"Option A\"",
+            "Value": "codeA"
+          },
+          {
+            "Parent": "",
+            "Label": "\"Option B\"",
+            "Value": "codeB"
+          },
+          {
+            "Parent": "",
+            "Label": "\"Option C (with detail)\"",
+            "Value": "codeC"
+          },
+          {
+            "Parent": "",
+            "Label": "\"Option D (with detail)\"",
+            "Value": "codeD"
+          }
+        ],
+        "Name": ""
+      }
+    ]
+  },
+  "formulasLanguage": "VTL",
+  "Child": [
+    {
+      "Control": [],
+      "depth": 1,
+      "FlowControl": [],
+      "genericName": "MODULE",
+      "Label": [
+        "\"Sequence\""
+      ],
+      "id": "lutkf97g",
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "type": "SequenceType",
+      "Child": [
+        {
+          "Response": [
+            {
+              "CollectedVariableReference": "lutkscmh",
+              "id": "lutl1gyc",
+              "mandatory": false,
+              "CodeListReference": "lutkfklf",
+              "Datatype": {
+                "Pattern": "",
+                "typeName": "TEXT",
+                "visualizationHint": "RADIO",
+                "type": "TextDatatypeType",
+                "MaxLength": 1
+              }
+            }
+          ],
+          "Control": [],
+          "depth": 2,
+          "FlowControl": [
+            {
+              "Description": "$UCQ_RADIO$ = 'codeC' : UCQ_codeC_RADIO",
+              "Expression": "$UCQ_RADIO$ = 'codeC'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutlkx3g",
+              "IfTrue": "lutljq3k"
+            },
+            {
+              "Description": "$UCQ_RADIO$ = 'codeD' : UCQ_codeD_RADIO",
+              "Expression": "$UCQ_RADIO$ = 'codeD'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutlcitc",
+              "IfTrue": "lutl6vl0"
+            }
+          ],
+          "Label": [
+            "\"Unique choice question (radio buttons)\""
+          ],
+          "ClarificationQuestion": [
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutl57n5",
+                  "id": "lutliibb",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "20"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option C:\"",
+              "id": "lutljq3k",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeC"
+            },
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutkv69x",
+                  "id": "lutl1qhv",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "30"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option D:\"",
+              "id": "lutl6vl0",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeD"
+            }
+          ],
+          "id": "lutkqj7u",
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "type": "QuestionType",
+          "questionType": "SINGLE_CHOICE",
+          "Name": "UCQ_RADIO"
+        },
+        {
+          "Response": [
+            {
+              "CollectedVariableReference": "lutkwsd5",
+              "id": "lutlkq28",
+              "mandatory": false,
+              "CodeListReference": "lutkfklf",
+              "Datatype": {
+                "Pattern": "",
+                "typeName": "TEXT",
+                "visualizationHint": "CHECKBOX",
+                "type": "TextDatatypeType",
+                "MaxLength": 1
+              }
+            }
+          ],
+          "Control": [],
+          "depth": 2,
+          "FlowControl": [
+            {
+              "Description": "$UCQ_CHECKBOX$ = 'codeC' : UCQ_codeC_CHECKBOX",
+              "Expression": "$UCQ_CHECKBOX$ = 'codeC'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutl3gi6",
+              "IfTrue": "lutl5tm8"
+            },
+            {
+              "Description": "$UCQ_CHECKBOX$ = 'codeD' : UCQ_codeD_CHECKBOX",
+              "Expression": "$UCQ_CHECKBOX$ = 'codeD'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutl8ym1",
+              "IfTrue": "lutl8zv7"
+            }
+          ],
+          "Label": [
+            "\"Unique choice question (checkbox buttons)\""
+          ],
+          "ClarificationQuestion": [
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutksrhg",
+                  "id": "lutlazew",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "20"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option C:\"",
+              "id": "lutl5tm8",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeC"
+            },
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutl4rut",
+                  "id": "lutl9djy",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "30"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option D:\"",
+              "id": "lutl8zv7",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeD"
+            }
+          ],
+          "id": "lutkmu5x",
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "type": "QuestionType",
+          "questionType": "SINGLE_CHOICE",
+          "Name": "UCQ_CHECKBOX"
+        },
+        {
+          "FlowControl": [
+            {
+              "Description": "$MCQ3$ = '1' : MCQ_codeC",
+              "Expression": "$MCQ3$ = '1'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutlmafr",
+              "IfTrue": "lutlm64y"
+            },
+            {
+              "Description": "$MCQ4$ = '1' : MCQ_codeD",
+              "Expression": "$MCQ4$ = '1'",
+              "flowControlType": "CLARIFICATION",
+              "id": "lutlj6si",
+              "IfTrue": "lutl9ech"
+            }
+          ],
+          "Label": [
+            "\"Multiple choice question\""
+          ],
+          "ResponseStructure": {
+            "Attribute": [],
+            "Mapping": [
+              {
+                "MappingSource": "lutll481",
+                "MappingTarget": "1"
+              },
+              {
+                "MappingSource": "lutlkzqn",
+                "MappingTarget": "2"
+              },
+              {
+                "MappingSource": "lutlf2kj",
+                "MappingTarget": "3"
+              },
+              {
+                "MappingSource": "lutlg1iw",
+                "MappingTarget": "4"
+              }
+            ],
+            "Dimension": [
+              {
+                "dimensionType": "PRIMARY",
+                "dynamic": "0",
+                "CodeListReference": "lutkfklf"
+              },
+              {
+                "dimensionType": "MEASURE",
+                "dynamic": "0"
+              }
+            ]
+          },
+          "type": "QuestionType",
+          "Name": "MCQ",
+          "Response": [
+            {
+              "CollectedVariableReference": "lutlk4q5",
+              "id": "lutll481",
+              "Datatype": {
+                "typeName": "BOOLEAN",
+                "type": "BooleanDatatypeType"
+              }
+            },
+            {
+              "CollectedVariableReference": "lutli99v",
+              "id": "lutlkzqn",
+              "Datatype": {
+                "typeName": "BOOLEAN",
+                "type": "BooleanDatatypeType"
+              }
+            },
+            {
+              "CollectedVariableReference": "lutlbath",
+              "id": "lutlf2kj",
+              "Datatype": {
+                "typeName": "BOOLEAN",
+                "type": "BooleanDatatypeType"
+              }
+            },
+            {
+              "CollectedVariableReference": "lutl7oi1",
+              "id": "lutlg1iw",
+              "Datatype": {
+                "typeName": "BOOLEAN",
+                "type": "BooleanDatatypeType"
+              }
+            }
+          ],
+          "Control": [],
+          "depth": 2,
+          "ClarificationQuestion": [
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutl5z5d",
+                  "id": "lutlfn9e",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "20"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option C:\"",
+              "id": "lutlm64y",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeC"
+            },
+            {
+              "Response": [
+                {
+                  "CollectedVariableReference": "lutlhxbn",
+                  "id": "lutl3cfc",
+                  "mandatory": false,
+                  "Datatype": {
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "type": "TextDatatypeType",
+                    "MaxLength": "30"
+                  }
+                }
+              ],
+              "Label": "\"Please, specify about option D:\"",
+              "id": "lutl9ech",
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE",
+              "Name": "UCQ_codeD"
+            }
+          ],
+          "id": "lutkxex2",
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "questionType": "MULTIPLE_CHOICE"
+        }
+      ],
+      "Name": "SEQUENCE"
+    },
+    {
+      "Control": [],
+      "depth": 1,
+      "FlowControl": [],
+      "genericName": "MODULE",
+      "Label": [
+        "QUESTIONNAIRE_END"
+      ],
+      "id": "idendquest",
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "type": "SequenceType",
+      "Child": [],
+      "Name": "QUESTIONNAIRE_END"
+    }
+  ]
+}

--- a/eno-core/src/test/resources/unit/ddi/ddi-multiple-choice-other-specify.xml
+++ b/eno-core/src/test/resources/unit/ddi/ddi-multiple-choice-other-specify.xml
@@ -1,0 +1,317 @@
+<d:QuestionGrid xmlns:d="ddi:datacollection:3_3" xmlns:r="ddi:reusable:3_3">
+	<r:Agency>fr.insee</r:Agency>
+	<r:ID>lutkxex2</r:ID>
+	<r:Version>1</r:Version>
+	<d:QuestionGridName>
+		<r:String xml:lang="fr-FR">MCQ</r:String>
+	</d:QuestionGridName>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutkxex2-QOP-lutlb389</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ1</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutkxex2-QOP-lutligr6</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ2</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ3</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutkxex2-QOP-lutle98i</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ4</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ_codeC</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">MCQ_codeD</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-QOP-lutlb389</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-QOP-lutligr6</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkxex2-QOP-lutle98i</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<d:QuestionText>
+		<d:LiteralText>
+			<d:Text xml:lang="fr-FR">"Multiple choice question"</d:Text>
+		</d:LiteralText>
+	</d:QuestionText>
+	<d:GridDimension displayCode="false" displayLabel="false" rank="1">
+		<d:CodeDomain>
+			<r:CodeListReference>
+				<r:Agency>fr.insee</r:Agency>
+				<r:ID>lutkfklf</r:ID>
+				<r:Version>1</r:Version>
+				<r:TypeOfObject>CodeList</r:TypeOfObject>
+			</r:CodeListReference>
+		</d:CodeDomain>
+	</d:GridDimension>
+	<d:StructuredMixedGridResponseDomain>
+		<d:GridResponseDomainInMixed>
+			<d:NominalDomain>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+					<r:Version>1</r:Version>
+					<r:CodeRepresentation>
+						<r:CodeSubsetInformation>
+							<r:IncludedCode>
+								<r:CodeReference>
+									<r:Agency>fr.insee</r:Agency>
+									<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+									<r:Version>1</r:Version>
+									<r:TypeOfObject>Code</r:TypeOfObject>
+								</r:CodeReference>
+							</r:IncludedCode>
+						</r:CodeSubsetInformation>
+					</r:CodeRepresentation>
+					<r:DefaultValue/>
+				</r:OutParameter>
+				<r:ResponseCardinality maximumResponses="1"/>
+			</d:NominalDomain>
+			<d:GridAttachment>
+				<d:CellCoordinatesAsDefined>
+					<d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+				</d:CellCoordinatesAsDefined>
+			</d:GridAttachment>
+		</d:GridResponseDomainInMixed>
+		<d:GridResponseDomainInMixed>
+			<d:NominalDomain>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+					<r:Version>1</r:Version>
+					<r:CodeRepresentation>
+						<r:CodeSubsetInformation>
+							<r:IncludedCode>
+								<r:CodeReference>
+									<r:Agency>fr.insee</r:Agency>
+									<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+									<r:Version>1</r:Version>
+									<r:TypeOfObject>Code</r:TypeOfObject>
+								</r:CodeReference>
+							</r:IncludedCode>
+						</r:CodeSubsetInformation>
+					</r:CodeRepresentation>
+					<r:DefaultValue/>
+				</r:OutParameter>
+				<r:ResponseCardinality maximumResponses="1"/>
+			</d:NominalDomain>
+			<d:GridAttachment>
+				<d:CellCoordinatesAsDefined>
+					<d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
+				</d:CellCoordinatesAsDefined>
+			</d:GridAttachment>
+		</d:GridResponseDomainInMixed>
+		<d:GridResponseDomainInMixed attachmentBase="3">
+			<d:NominalDomain>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+					<r:Version>1</r:Version>
+					<r:CodeRepresentation>
+						<r:CodeSubsetInformation>
+							<r:IncludedCode>
+								<r:CodeReference>
+									<r:Agency>fr.insee</r:Agency>
+									<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+									<r:Version>1</r:Version>
+									<r:TypeOfObject>Code</r:TypeOfObject>
+								</r:CodeReference>
+							</r:IncludedCode>
+						</r:CodeSubsetInformation>
+					</r:CodeRepresentation>
+					<r:DefaultValue/>
+				</r:OutParameter>
+				<r:ResponseCardinality maximumResponses="1"/>
+			</d:NominalDomain>
+			<d:GridAttachment>
+				<d:CellCoordinatesAsDefined>
+					<d:SelectDimension rank="1" rangeMinimum="3" rangeMaximum="3"/>
+				</d:CellCoordinatesAsDefined>
+			</d:GridAttachment>
+		</d:GridResponseDomainInMixed>
+		<d:GridResponseDomainInMixed attachmentBase="4">
+			<d:NominalDomain>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+					<r:Version>1</r:Version>
+					<r:CodeRepresentation>
+						<r:CodeSubsetInformation>
+							<r:IncludedCode>
+								<r:CodeReference>
+									<r:Agency>fr.insee</r:Agency>
+									<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+									<r:Version>1</r:Version>
+									<r:TypeOfObject>Code</r:TypeOfObject>
+								</r:CodeReference>
+							</r:IncludedCode>
+						</r:CodeSubsetInformation>
+					</r:CodeRepresentation>
+					<r:DefaultValue/>
+				</r:OutParameter>
+				<r:ResponseCardinality maximumResponses="1"/>
+			</d:NominalDomain>
+			<d:GridAttachment>
+				<d:CellCoordinatesAsDefined>
+					<d:SelectDimension rank="1" rangeMinimum="4" rangeMaximum="4"/>
+				</d:CellCoordinatesAsDefined>
+			</d:GridAttachment>
+		</d:GridResponseDomainInMixed>
+		<d:GridResponseDomainInMixed>
+			<d:TextDomain maxLength="20">
+				<r:Label>
+					<r:Content xml:lang="fr-FR">"Please, specify about option C:"</r:Content>
+				</r:Label>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+					<r:Version>1</r:Version>
+					<r:TextRepresentation maxLength="20"/>
+				</r:OutParameter>
+			</d:TextDomain>
+			<d:ResponseAttachmentLocation>
+				<d:DomainSpecificValue attachmentDomain="3">
+					<r:Value>1</r:Value>
+				</d:DomainSpecificValue>
+				<r:CodeReference>
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+					<r:Version>1</r:Version>
+					<r:TypeOfObject>Code</r:TypeOfObject>
+				</r:CodeReference>
+			</d:ResponseAttachmentLocation>
+		</d:GridResponseDomainInMixed>
+		<d:GridResponseDomainInMixed>
+			<d:TextDomain maxLength="30">
+				<r:Label>
+					<r:Content xml:lang="fr-FR">"Please, specify about option D:"</r:Content>
+				</r:Label>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+					<r:Version>1</r:Version>
+					<r:TextRepresentation maxLength="30"/>
+				</r:OutParameter>
+			</d:TextDomain>
+			<d:ResponseAttachmentLocation>
+				<d:DomainSpecificValue attachmentDomain="4">
+					<r:Value>1</r:Value>
+				</d:DomainSpecificValue>
+				<r:CodeReference>
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+					<r:Version>1</r:Version>
+					<r:TypeOfObject>Code</r:TypeOfObject>
+				</r:CodeReference>
+			</d:ResponseAttachmentLocation>
+		</d:GridResponseDomainInMixed>
+	</d:StructuredMixedGridResponseDomain>
+</d:QuestionGrid>

--- a/eno-core/src/test/resources/unit/ddi/ddi-multiple-choice-question.xml
+++ b/eno-core/src/test/resources/unit/ddi/ddi-multiple-choice-question.xml
@@ -1,0 +1,225 @@
+<d:QuestionGrid xmlns:d="ddi:datacollection:3_3" xmlns:r="ddi:reusable:3_3">
+    <r:Agency>fr.insee</r:Agency>
+    <r:ID>lo5uw0qc</r:ID>
+    <r:Version>1</r:Version>
+    <d:QuestionGridName>
+        <r:String xml:lang="fr-FR">MCQ_BOOL</r:String>
+    </d:QuestionGridName>
+    <r:OutParameter isArray="false">
+        <r:Agency>fr.insee</r:Agency>
+        <r:ID>lo5uw0qc-QOP-lo5wh6sm</r:ID>
+        <r:Version>1</r:Version>
+        <r:ParameterName>
+            <r:String xml:lang="fr-FR">MCQ_BOOL1</r:String>
+        </r:ParameterName>
+    </r:OutParameter>
+    <r:OutParameter isArray="false">
+        <r:Agency>fr.insee</r:Agency>
+        <r:ID>lo5uw0qc-QOP-lo5woun5</r:ID>
+        <r:Version>1</r:Version>
+        <r:ParameterName>
+            <r:String xml:lang="fr-FR">MCQ_BOOL2</r:String>
+        </r:ParameterName>
+    </r:OutParameter>
+    <r:OutParameter isArray="false">
+        <r:Agency>fr.insee</r:Agency>
+        <r:ID>lo5uw0qc-QOP-lo5wo17c</r:ID>
+        <r:Version>1</r:Version>
+        <r:ParameterName>
+            <r:String xml:lang="fr-FR">MCQ_BOOL3</r:String>
+        </r:ParameterName>
+    </r:OutParameter>
+    <r:OutParameter isArray="false">
+        <r:Agency>fr.insee</r:Agency>
+        <r:ID>lo5uw0qc-QOP-lo5wljqy</r:ID>
+        <r:Version>1</r:Version>
+        <r:ParameterName>
+            <r:String xml:lang="fr-FR">MCQ_BOOL4</r:String>
+        </r:ParameterName>
+    </r:OutParameter>
+    <r:Binding>
+        <r:SourceParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-RDOP-lo5wh6sm</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:SourceParameterReference>
+        <r:TargetParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-QOP-lo5wh6sm</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:TargetParameterReference>
+    </r:Binding>
+    <r:Binding>
+        <r:SourceParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-RDOP-lo5woun5</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:SourceParameterReference>
+        <r:TargetParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-QOP-lo5woun5</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:TargetParameterReference>
+    </r:Binding>
+    <r:Binding>
+        <r:SourceParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-RDOP-lo5wo17c</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:SourceParameterReference>
+        <r:TargetParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-QOP-lo5wo17c</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:TargetParameterReference>
+    </r:Binding>
+    <r:Binding>
+        <r:SourceParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-RDOP-lo5wljqy</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:SourceParameterReference>
+        <r:TargetParameterReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>lo5uw0qc-QOP-lo5wljqy</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>OutParameter</r:TypeOfObject>
+        </r:TargetParameterReference>
+    </r:Binding>
+    <d:QuestionText>
+        <d:LiteralText>
+            <d:Text xml:lang="fr-FR">"Normal multiple choice question"</d:Text>
+        </d:LiteralText>
+    </d:QuestionText>
+    <d:GridDimension displayCode="false" displayLabel="false" rank="1">
+        <d:CodeDomain>
+            <r:CodeListReference>
+                <r:Agency>fr.insee</r:Agency>
+                <r:ID>lo5upwdy</r:ID>
+                <r:Version>1</r:Version>
+                <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+        </d:CodeDomain>
+    </d:GridDimension>
+    <d:StructuredMixedGridResponseDomain>
+        <d:GridResponseDomainInMixed>
+            <d:NominalDomain>
+                <r:OutParameter isArray="false">
+                    <r:Agency>fr.insee</r:Agency>
+                    <r:ID>lo5uw0qc-RDOP-lo5wh6sm</r:ID>
+                    <r:Version>1</r:Version>
+                    <r:CodeRepresentation>
+                        <r:CodeSubsetInformation>
+                            <r:IncludedCode>
+                                <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                </r:CodeReference>
+                            </r:IncludedCode>
+                        </r:CodeSubsetInformation>
+                    </r:CodeRepresentation>
+                    <r:DefaultValue/>
+                </r:OutParameter>
+                <r:ResponseCardinality maximumResponses="1"/>
+            </d:NominalDomain>
+            <d:GridAttachment>
+                <d:CellCoordinatesAsDefined>
+                    <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+                </d:CellCoordinatesAsDefined>
+            </d:GridAttachment>
+        </d:GridResponseDomainInMixed>
+        <d:GridResponseDomainInMixed>
+            <d:NominalDomain>
+                <r:OutParameter isArray="false">
+                    <r:Agency>fr.insee</r:Agency>
+                    <r:ID>lo5uw0qc-RDOP-lo5woun5</r:ID>
+                    <r:Version>1</r:Version>
+                    <r:CodeRepresentation>
+                        <r:CodeSubsetInformation>
+                            <r:IncludedCode>
+                                <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                </r:CodeReference>
+                            </r:IncludedCode>
+                        </r:CodeSubsetInformation>
+                    </r:CodeRepresentation>
+                    <r:DefaultValue/>
+                </r:OutParameter>
+                <r:ResponseCardinality maximumResponses="1"/>
+            </d:NominalDomain>
+            <d:GridAttachment>
+                <d:CellCoordinatesAsDefined>
+                    <d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
+                </d:CellCoordinatesAsDefined>
+            </d:GridAttachment>
+        </d:GridResponseDomainInMixed>
+        <d:GridResponseDomainInMixed>
+            <d:NominalDomain>
+                <r:OutParameter isArray="false">
+                    <r:Agency>fr.insee</r:Agency>
+                    <r:ID>lo5uw0qc-RDOP-lo5wo17c</r:ID>
+                    <r:Version>1</r:Version>
+                    <r:CodeRepresentation>
+                        <r:CodeSubsetInformation>
+                            <r:IncludedCode>
+                                <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                </r:CodeReference>
+                            </r:IncludedCode>
+                        </r:CodeSubsetInformation>
+                    </r:CodeRepresentation>
+                    <r:DefaultValue/>
+                </r:OutParameter>
+                <r:ResponseCardinality maximumResponses="1"/>
+            </d:NominalDomain>
+            <d:GridAttachment>
+                <d:CellCoordinatesAsDefined>
+                    <d:SelectDimension rank="1" rangeMinimum="3" rangeMaximum="3"/>
+                </d:CellCoordinatesAsDefined>
+            </d:GridAttachment>
+        </d:GridResponseDomainInMixed>
+        <d:GridResponseDomainInMixed>
+            <d:NominalDomain>
+                <r:OutParameter isArray="false">
+                    <r:Agency>fr.insee</r:Agency>
+                    <r:ID>lo5uw0qc-RDOP-lo5wljqy</r:ID>
+                    <r:Version>1</r:Version>
+                    <r:CodeRepresentation>
+                        <r:CodeSubsetInformation>
+                            <r:IncludedCode>
+                                <r:CodeReference>
+                                    <r:Agency>fr.insee</r:Agency>
+                                    <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+                                    <r:Version>1</r:Version>
+                                    <r:TypeOfObject>Code</r:TypeOfObject>
+                                </r:CodeReference>
+                            </r:IncludedCode>
+                        </r:CodeSubsetInformation>
+                    </r:CodeRepresentation>
+                    <r:DefaultValue/>
+                </r:OutParameter>
+                <r:ResponseCardinality maximumResponses="1"/>
+            </d:NominalDomain>
+            <d:GridAttachment>
+                <d:CellCoordinatesAsDefined>
+                    <d:SelectDimension rank="1" rangeMinimum="4" rangeMaximum="4"/>
+                </d:CellCoordinatesAsDefined>
+            </d:GridAttachment>
+        </d:GridResponseDomainInMixed>
+    </d:StructuredMixedGridResponseDomain>
+</d:QuestionGrid>

--- a/eno-core/src/test/resources/unit/ddi/ddi-unique-choice-other-specify.xml
+++ b/eno-core/src/test/resources/unit/ddi/ddi-unique-choice-other-specify.xml
@@ -1,0 +1,154 @@
+<d:QuestionItem xmlns:d="ddi:datacollection:3_3" xmlns:r="ddi:reusable:3_3">
+	<r:Agency>fr.insee</r:Agency>
+	<r:ID>lutkqj7u</r:ID>
+	<r:Version>1</r:Version>
+	<d:QuestionItemName>
+		<r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+	</d:QuestionItemName>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">UCQ_codeC_RADIO</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:OutParameter isArray="false">
+		<r:Agency>fr.insee</r:Agency>
+		<r:ID>lutl72ne-QOP-lutl513r</r:ID>
+		<r:Version>1</r:Version>
+		<r:ParameterName>
+			<r:String xml:lang="fr-FR">UCQ_codeD_RADIO</r:String>
+		</r:ParameterName>
+	</r:OutParameter>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<r:Binding>
+		<r:SourceParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:SourceParameterReference>
+		<r:TargetParameterReference>
+			<r:Agency>fr.insee</r:Agency>
+			<r:ID>lutl72ne-QOP-lutl513r</r:ID>
+			<r:Version>1</r:Version>
+			<r:TypeOfObject>OutParameter</r:TypeOfObject>
+		</r:TargetParameterReference>
+	</r:Binding>
+	<d:QuestionText>
+		<d:LiteralText>
+			<d:Text xml:lang="fr-FR">"Unique choice question (radio buttons)"</d:Text>
+		</d:LiteralText>
+	</d:QuestionText>
+	<d:StructuredMixedResponseDomain>
+		<d:ResponseDomainInMixed attachmentBase="1">
+			<d:CodeDomain>
+				<r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">radio-button</r:GenericOutputFormat>
+				<r:CodeListReference>
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkfklf</r:ID>
+					<r:Version>1</r:Version>
+					<r:TypeOfObject>CodeList</r:TypeOfObject>
+				</r:CodeListReference>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+					<r:Version>1</r:Version>
+					<r:CodeRepresentation>
+						<r:CodeListReference>
+							<r:Agency>fr.insee</r:Agency>
+							<r:ID>lutkfklf</r:ID>
+							<r:Version>1</r:Version>
+							<r:TypeOfObject>CodeList</r:TypeOfObject>
+						</r:CodeListReference>
+					</r:CodeRepresentation>
+				</r:OutParameter>
+				<r:ResponseCardinality maximumResponses="1"/>
+			</d:CodeDomain>
+		</d:ResponseDomainInMixed>
+		<d:ResponseDomainInMixed>
+			<d:TextDomain maxLength="20">
+				<r:Label>
+					<r:Content xml:lang="fr-FR">"Please, specify about option C:"</r:Content>
+				</r:Label>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+					<r:Version>1</r:Version>
+					<r:TextRepresentation maxLength="20"/>
+				</r:OutParameter>
+			</d:TextDomain>
+			<d:AttachmentLocation>
+				<d:DomainSpecificValue attachmentDomain="1">
+					<r:Value>codeC</r:Value>
+				</d:DomainSpecificValue>
+				<r:CodeReference>
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkfklf-3</r:ID>
+					<r:Version>1</r:Version>
+					<r:TypeOfObject>Code</r:TypeOfObject>
+				</r:CodeReference>
+			</d:AttachmentLocation>
+		</d:ResponseDomainInMixed>
+		<d:ResponseDomainInMixed>
+			<d:TextDomain maxLength="30">
+				<r:Label>
+					<r:Content xml:lang="fr-FR">"Please, specify about option D:"</r:Content>
+				</r:Label>
+				<r:OutParameter isArray="false">
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+					<r:Version>1</r:Version>
+					<r:TextRepresentation maxLength="30"/>
+				</r:OutParameter>
+			</d:TextDomain>
+			<d:AttachmentLocation>
+				<d:DomainSpecificValue attachmentDomain="1">
+					<r:Value>codeD</r:Value>
+				</d:DomainSpecificValue>
+				<r:CodeReference>
+					<r:Agency>fr.insee</r:Agency>
+					<r:ID>lutkfklf-4</r:ID>
+					<r:Version>1</r:Version>
+					<r:TypeOfObject>Code</r:TypeOfObject>
+				</r:CodeReference>
+			</d:AttachmentLocation>
+		</d:ResponseDomainInMixed>
+	</d:StructuredMixedResponseDomain>
+</d:QuestionItem>


### PR DESCRIPTION
## "Other, please specify" feature

Unique / multiple choice questions can have modalities that trigger an additional field which allows the respondent to give details.

- #919 

## Done

DDI to Lunatic mapping, implied some refactor on multiple choice question mapping.

Also split the DDIConverter class in several parts to make it more readable.

Supported at this point in the DDI to Lunatic transformation:

- "detail" response in unique choice questions (`Radio` and `CheckboxOne` formats in Lunatic)
- "detail" response in multiple choice questions

Not supported yet:

- "detail" response for Lunatic `Dropdown`
- "detail" response for a unique choice within a table
- "detail" response for the pairwise links question
