### PR TITLE
feat: lunatic dsfr question component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.20.0-SNAPSHOT'
+    version = '3.20.1-SNAPSHOT'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.19.4'
+    version = '3.20.0-SNAPSHOT'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
@@ -33,7 +33,7 @@ public class DynamicLabel extends EnoObject implements EnoLabel {
     /** Property that is specific to Lunatic.
      * For now, Lunatic type in label objects does not come from metadata, but is hardcoded here in Eno.
      * See labels documentation. */
-    @Lunatic("setType(#param)")
+    @Lunatic("setType(T(fr.insee.lunatic.model.flat.LabelTypeEnum).fromValue(#param))")
     String type = LabelTypeEnum.VTL_MD.value();
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.parameter;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +17,10 @@ public class LunaticParameters {
     private boolean filterResult;
     private boolean filterDescription;
     private LunaticPaginationMode lunaticPaginationMode;
+
+    /** Parameter to enable Lunatic v3 (known as Lunatic-DSFR) features. */
+    @JsonProperty("DSFR")
+    private boolean lunaticV3;
 
     private LunaticParameters() {}
 
@@ -39,6 +44,7 @@ public class LunaticParameters {
         this.setFilterResult(isWeb || isProcess);
         this.setMissingVariables(isInterview || isProcess);
         this.setLunaticPaginationMode(paginationValue(context, modeParameter));
+        this.setLunaticV3(false);
     }
 
     private LunaticPaginationMode paginationValue(EnoParameters.Context context, EnoParameters.ModeParameter modeParameter) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -53,7 +53,8 @@ public class LunaticProcessing {
                 .then(new LunaticReverseConsistencyControlLabel())
                 .then(new LunaticAddShapeToCalculatedVariables(enoQuestionnaire, shapefromAttributeRetrieval))
                 .then(new LunaticFinalizePairwise(enoQuestionnaire))
-                .thenIf(parameters.isFilterResult(), new LunaticFilterResult(enoQuestionnaire, shapefromAttributeRetrieval));
+                .thenIf(parameters.isFilterResult(), new LunaticFilterResult(enoQuestionnaire, shapefromAttributeRetrieval))
+                .thenIf(parameters.isLunaticV3(), new LunaticQuestionComponent());
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticFilterResult.java
@@ -73,7 +73,7 @@ public class LunaticFilterResult implements ProcessingStep<Questionnaire> {
                     .forEach(variableName -> filterVariable.getBindingDependencies().add(variableName));
         }
         LabelType expression = new LabelType();
-        expression.setType(conditionFilter.getTypeEnum());
+        expression.setType(conditionFilter.getType());
         expression.setValue(conditionFilter.getValue());
         filterVariable.setExpression(expression);
         return Optional.of(filterVariable);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponent.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponent.java
@@ -1,0 +1,46 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.lunatic.model.flat.ComponentType;
+import fr.insee.lunatic.model.flat.Loop;
+import fr.insee.lunatic.model.flat.Question;
+import fr.insee.lunatic.model.flat.Questionnaire;
+
+import java.util.List;
+
+/**
+ * Lunatic V3 introduced a question component.
+ * This processing wraps each response components (such as Input, InputNumber, Table, etc.) in a Question component.
+ */
+public class LunaticQuestionComponent implements ProcessingStep<Questionnaire> {
+
+    /**
+     * Wraps each response component (e.g. Input, InputNumber, Table, etc.) is a question component.
+     * @param lunaticQuestionnaire Lunatic questionnaire object.
+     */
+    @Override
+    public void apply(Questionnaire lunaticQuestionnaire) {
+        // Questionnaire-level components
+        wrapComponentsInQuestions(lunaticQuestionnaire.getComponents());
+        // Loop components
+        lunaticQuestionnaire.getComponents().stream()
+                .filter(Loop.class::isInstance).map(Loop.class::cast)
+                .forEach(loop -> wrapComponentsInQuestions(loop.getComponents()));
+    }
+
+    private static void wrapComponentsInQuestions(List<ComponentType> components) {
+        components.replaceAll(componentType -> {
+            //
+            if (! Question.isQuestionComponent(componentType))
+                return componentType;
+            //
+            Question question = new Question();
+            question.setId("question-"+componentType.getId());
+            question.setPage(componentType.getPage());
+            question.setConditionFilter(question.getConditionFilter());
+            question.addComponent(componentType);
+            return question;
+        });
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -27,7 +27,6 @@ public class LunaticUtils {
         return components.stream()
                 .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.SEQUENCE))
                 .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.SUBSEQUENCE))
-                .filter(component -> !component.getComponentType().equals(ComponentTypeEnum.FILTER_DESCRIPTION))
                 .toList();
     }
 

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/CalculatedVariableTest.java
@@ -72,7 +72,7 @@ class CalculatedVariableTest {
         lunaticMapper.mapEnoObject(enoVariable, lunaticVariable);
         //
         assertEquals("BAR = 1 or BAZ = 1", lunaticVariable.getExpression().getValue());
-        assertEquals(LabelTypeEnum.VTL, lunaticVariable.getExpression().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, lunaticVariable.getExpression().getType());
     }
 
     @Test
@@ -130,7 +130,7 @@ class CalculatedVariableTest {
         @Test
         void calculatedExpressionType() {
             filterResultVariables.values().forEach(variableType ->
-                    assertEquals(LabelTypeEnum.VTL, variableType.getExpression().getTypeEnum()));
+                    assertEquals(LabelTypeEnum.VTL, variableType.getExpression().getType()));
         }
 
         @Test
@@ -201,7 +201,7 @@ class CalculatedVariableTest {
             assertEquals(VariableTypeEnum.CALCULATED, lunaticVariable.get().getVariableType());
             assertEquals("CALCULATED1", lunaticVariable.get().getName());
             assertEquals("cast(Q3, integer) + 5", lunaticVariable.get().getExpression().getValue());
-            assertEquals(LabelTypeEnum.VTL, lunaticVariable.get().getExpression().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticVariable.get().getExpression().getType());
             assertEquals(1, lunaticVariable.get().getBindingDependencies().size());
             assertEquals("Q3", lunaticVariable.get().getBindingDependencies().getFirst());
         }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ComponentFilterTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ComponentFilterTest.java
@@ -41,7 +41,7 @@ class ComponentFilterTest {
         lunaticMapper.mapEnoObject(enoComponentFilter, lunaticConditionFilter);
         //
         assertEquals(ComponentFilter.DEFAULT_FILTER_VALUE, lunaticConditionFilter.getValue());
-        assertEquals(LabelTypeEnum.VTL, lunaticConditionFilter.getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, lunaticConditionFilter.getType());
         assertTrue(lunaticConditionFilter.getBindingDependencies().isEmpty());
     }
 
@@ -92,7 +92,7 @@ class ComponentFilterTest {
             lunaticQuestionnaire.getComponents().stream()
                     .map(ComponentType::getConditionFilter)
                     .forEach(conditionFilterType ->
-                            assertEquals(LabelTypeEnum.VTL, conditionFilterType.getTypeEnum()));
+                            assertEquals(LabelTypeEnum.VTL, conditionFilterType.getType()));
         }
 
         @Test
@@ -177,7 +177,7 @@ class ComponentFilterTest {
         void filterWithCalculatedVariable(int index) {
             ConditionFilterType conditionFilter = lunaticQuestionnaire.getComponents().get(index).getConditionFilter();
             assertEquals("(SUM_Q11_Q12 < 10)", conditionFilter.getValue());
-            assertEquals(LabelTypeEnum.VTL, conditionFilter.getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, conditionFilter.getType());
             assertEquals(3, conditionFilter.getBindingDependencies().size());
             assertTrue(conditionFilter.getBindingDependencies().containsAll(List.of("SUM_Q11_Q12", "Q11", "Q12")));
         }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ControlRowTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ControlRowTest.java
@@ -44,10 +44,10 @@ class ControlRowTest {
         assertEquals(ControlCriticalityEnum.WARN, rowControl.getCriticality());
         assertEquals("cast(DYNAMIC_TABLE1, integer) + cast(DYNAMIC_TABLE2, integer) > 100",
                 rowControl.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, rowControl.getControl().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, rowControl.getControl().getType());
         assertEquals("\"Sum of percentages cannot be > 100%.\"",
                 rowControl.getErrorMessage().getValue());
-        assertEquals(LabelTypeEnum.VTL_MD, rowControl.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, rowControl.getErrorMessage().getType());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DetailResponseTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/DetailResponseTest.java
@@ -34,7 +34,7 @@ class DetailResponseTest {
         //
         assertEquals("FOO_DETAIL", lunaticDetailResponse.getResponse().getName());
         assertEquals("\"Please specify\"", lunaticDetailResponse.getLabel().getValue());
-        assertEquals(LabelTypeEnum.VTL_MD, lunaticDetailResponse.getLabel().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, lunaticDetailResponse.getLabel().getType());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/LabelTests.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/LabelTests.java
@@ -22,7 +22,7 @@ class LabelTests {
         LunaticMapper lunaticMapper = new LunaticMapper();
         lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
         //
-        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getType());
     }
 
     @Test
@@ -34,7 +34,7 @@ class LabelTests {
         LunaticMapper lunaticMapper = new LunaticMapper();
         lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
         //
-        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getType());
     }
 
     @Test
@@ -46,7 +46,7 @@ class LabelTests {
         LunaticMapper lunaticMapper = new LunaticMapper();
         lunaticMapper.mapEnoObject(enoLabel, lunaticLabel);
         //
-        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, lunaticLabel.getType());
     }
 
     @Test
@@ -58,7 +58,7 @@ class LabelTests {
         LunaticMapper lunaticMapper = new LunaticMapper();
         lunaticMapper.mapEnoObject(enoCalculatedExpression, lunaticLabel);
         //
-        assertEquals(LabelTypeEnum.VTL, lunaticLabel.getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, lunaticLabel.getType());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/MultipleChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/MultipleChoiceQuestionTest.java
@@ -53,7 +53,7 @@ class MultipleChoiceQuestionTest {
         assertEquals("\"Code D\"", lunaticCheckboxGroup.getResponses().get(3).getLabel().getValue());
         //
         lunaticCheckboxGroup.getResponses().forEach(responsesCheckboxGroup ->
-                assertEquals(LabelTypeEnum.VTL_MD, responsesCheckboxGroup.getLabel().getTypeEnum()));
+                assertEquals(LabelTypeEnum.VTL_MD, responsesCheckboxGroup.getLabel().getType()));
         //
         assertEquals("MCQ_BOOL1", lunaticCheckboxGroup.getResponses().get(0).getResponse().getName());
         assertEquals("MCQ_BOOL2", lunaticCheckboxGroup.getResponses().get(1).getResponse().getName());

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/PairwiseQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/PairwiseQuestionTest.java
@@ -61,8 +61,8 @@ class PairwiseQuestionTest {
         assertEquals("lo9tyy1v", lunaticPairwise.getId());
         assertEquals("count(PAIRWISE_SOURCE)", lunaticPairwise.getXAxisIterations().getValue());
         assertEquals("count(PAIRWISE_SOURCE)", lunaticPairwise.getYAxisIterations().getValue());
-        assertEquals(LabelTypeEnum.VTL, lunaticPairwise.getXAxisIterations().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL, lunaticPairwise.getYAxisIterations().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, lunaticPairwise.getXAxisIterations().getType());
+        assertEquals(LabelTypeEnum.VTL, lunaticPairwise.getYAxisIterations().getType());
         assertEquals(1, lunaticPairwise.getComponents().size());
         //
         ComponentType pairwiseInnerComponent = lunaticPairwise.getComponents().get(0);

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/SimpleUniqueChoiceQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/SimpleUniqueChoiceQuestionTest.java
@@ -42,8 +42,8 @@ public class SimpleUniqueChoiceQuestionTest {
                 checkboxGroup.getResponses().get(2).getDetail().getLabel().getValue());
         assertEquals("\"Please, specify about option D:\"",
                 checkboxGroup.getResponses().get(3).getDetail().getLabel().getValue());
-        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(2).getDetail().getLabel().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(3).getDetail().getLabel().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(2).getDetail().getLabel().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxGroup.getResponses().get(3).getDetail().getLabel().getType());
         assertEquals("MCQ_codeC", checkboxGroup.getResponses().get(2).getDetail().getResponse().getName());
         assertEquals("MCQ_codeD", checkboxGroup.getResponses().get(3).getDetail().getResponse().getName());
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
@@ -48,8 +48,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(NUMBERVAR))  and round(NUMBERVAR,10)<>NUMBERVAR)", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("number-id-format-decimal", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -96,8 +96,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(NUMBERVAR)) and (5>NUMBERVAR or 10<NUMBERVAR))", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-inf-sup", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -115,8 +115,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(NUMBERVAR)) and 5>NUMBERVAR)", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-inf", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -134,8 +134,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(NUMBERVAR)) and 10<NUMBERVAR)", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("number-id-format-borne-sup", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -163,8 +163,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(DATEVAR)) and (cast(DATEVAR, date, \"YYYY-MM-DD\")<cast(\"2020-01-01\", date, \"YYYY-MM-DD\") or cast(DATEVAR, date, \"YYYY-MM-DD\")>cast(\"2023-01-01\", date, \"YYYY-MM-DD\")))", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-inf-sup", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -183,8 +183,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(DATEVAR)) and (cast(DATEVAR, date, \"YYYY-MM-DD\")<cast(\"2020-01-01\", date, \"YYYY-MM-DD\")))", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-inf", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());
@@ -203,8 +203,8 @@ class LunaticAddControlFormatTest {
         ControlType control = controls.get(0);
 
         assertEquals("not(not(isnull(DATEVAR)) and (cast(DATEVAR, date, \"YYYY-MM-DD\")>cast(\"2023-01-01\", date, \"YYYY-MM-DD\")))", control.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, control.getControl().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, control.getControl().getType());
+        assertEquals(LabelTypeEnum.VTL_MD, control.getErrorMessage().getType());
         assertEquals("datepicker-id-format-date-borne-sup", control.getId());
         assertEquals(ControlTypeEnum.FORMAT, control.getTypeOfControl());
         assertEquals(ControlCriticalityEnum.ERROR, control.getCriticality());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetailsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticInsertUniqueChoiceDetailsTest.java
@@ -41,14 +41,14 @@ public class LunaticInsertUniqueChoiceDetailsTest {
         assertEquals("UCQ_codeC_RADIO", radio.getOptions().get(2).getDetail().getResponse().getName());
         assertEquals("\"Please, specify about option C:\"",
                 radio.getOptions().get(2).getDetail().getLabel().getValue());
-        assertEquals(LabelTypeEnum.VTL_MD, radio.getOptions().get(3).getDetail().getLabel().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, radio.getOptions().get(3).getDetail().getLabel().getType());
         //
         assertNull(checkboxOne.getOptions().get(0).getDetail());
         assertNull(checkboxOne.getOptions().get(1).getDetail());
         assertEquals("UCQ_codeC_CHECKBOX", checkboxOne.getOptions().get(2).getDetail().getResponse().getName());
         assertEquals("\"Please, specify about option C:\"",
                 checkboxOne.getOptions().get(2).getDetail().getLabel().getValue());
-        assertEquals(LabelTypeEnum.VTL_MD, checkboxOne.getOptions().get(3).getDetail().getLabel().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL_MD, checkboxOne.getOptions().get(3).getDetail().getLabel().getType());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -143,8 +143,8 @@ class LunaticLoopResolutionTest {
         void linkedLoopsIterations() {
             assertEquals("count(Q1A)", lunaticLoops.get(1).getIterations().getValue());
             assertEquals("count(Q3A)", lunaticLoops.get(3).getIterations().getValue());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getTypeEnum());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(3).getIterations().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(3).getIterations().getType());
         }
 
         @Test
@@ -237,8 +237,8 @@ class LunaticLoopResolutionTest {
         void linkedLoopsIterations() {
             assertEquals("count(Q1A)", lunaticLoops.get(1).getIterations().getValue());
             assertEquals("count(Q2A)", lunaticLoops.get(3).getIterations().getValue());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getTypeEnum());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(3).getIterations().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(3).getIterations().getType());
         }
 
         @Test
@@ -320,7 +320,7 @@ class LunaticLoopResolutionTest {
             assertThat(lunaticLoops.get(0).getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q1"), lunaticLoops.get(1).getLoopDependencies());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());
         }
 
         @Test
@@ -393,7 +393,7 @@ class LunaticLoopResolutionTest {
             assertThat(lunaticLoops.get(0).getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q11"), lunaticLoops.get(1).getLoopDependencies());
-            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());
         }
 
         @Test
@@ -484,7 +484,7 @@ class LunaticLoopResolutionTest {
             //
             lunaticLinkedLoop.getComponents().forEach(component -> {
                 assertEquals("(not(nvl(AGE, 0) < 18))", component.getConditionFilter().getValue());
-                assertEquals(LabelTypeEnum.VTL, component.getConditionFilter().getTypeEnum());
+                assertEquals(LabelTypeEnum.VTL, component.getConditionFilter().getType());
             });
         }
 
@@ -516,7 +516,7 @@ class LunaticLoopResolutionTest {
             assertEquals(List.of("DYNAMIC_TABLE1", "DYNAMIC_TABLE2", "DYNAMIC_TABLE3"),
                     lunaticLinkedLoop.getLoopDependencies());
             assertEquals("count(DYNAMIC_TABLE1)", lunaticLinkedLoop.getIterations().getValue());
-            assertEquals(LabelTypeEnum.VTL, lunaticLinkedLoop.getIterations().getTypeEnum());
+            assertEquals(LabelTypeEnum.VTL, lunaticLinkedLoop.getIterations().getType());
         }
 
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponentTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponentTest.java
@@ -3,7 +3,7 @@ package fr.insee.eno.core.processing.out.steps.lunatic;
 import fr.insee.lunatic.model.flat.*;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class LunaticQuestionComponentTest {
 
@@ -22,6 +22,28 @@ class LunaticQuestionComponentTest {
         inputNumber.setPage("1");
         inputNumber.setMin(0d);
         inputNumber.setMax(10d);
+        inputNumber.setLabel(new LabelType());
+        inputNumber.getLabel().setValue("\"Question label.\"");
+        inputNumber.getLabel().setType(LabelTypeEnum.VTL_MD);
+        //
+        DeclarationType beforeQuestionDeclaration = new DeclarationType();
+        beforeQuestionDeclaration.setId("declaration-1-id");
+        beforeQuestionDeclaration.setDeclarationType(DeclarationTypeEnum.STATEMENT);
+        beforeQuestionDeclaration.setPosition(DeclarationPositionEnum.BEFORE_QUESTION_TEXT);
+        beforeQuestionDeclaration.setLabel(new LabelType());
+        beforeQuestionDeclaration.getLabel().setValue("\"Before question declaration.\"");
+        beforeQuestionDeclaration.getLabel().setType(LabelTypeEnum.VTL_MD);
+        inputNumber.getDeclarations().add(beforeQuestionDeclaration);
+        //
+        DeclarationType afterQuestionDeclaration = new DeclarationType();
+        afterQuestionDeclaration.setId("declaration-2-id");
+        afterQuestionDeclaration.setDeclarationType(DeclarationTypeEnum.HELP);
+        afterQuestionDeclaration.setPosition(DeclarationPositionEnum.AFTER_QUESTION_TEXT);
+        afterQuestionDeclaration.setLabel(new LabelType());
+        afterQuestionDeclaration.getLabel().setValue("\"After question declaration.\"");
+        afterQuestionDeclaration.getLabel().setType(LabelTypeEnum.VTL_MD);
+        inputNumber.getDeclarations().add(afterQuestionDeclaration);
+        //
         questionnaire.getComponents().add(inputNumber);
 
         //
@@ -30,7 +52,23 @@ class LunaticQuestionComponentTest {
         // Sequence component should not be changed
         assertEquals(sequence, questionnaire.getComponents().get(0));
         // Input number should be replaced by a Question component
+        Question question = assertInstanceOf(Question.class, questionnaire.getComponents().get(1));
         assertEquals(ComponentTypeEnum.QUESTION, questionnaire.getComponents().get(1).getComponentType());
+        assertEquals(1, question.getComponents().size());
+        assertEquals(ComponentTypeEnum.INPUT_NUMBER, question.getComponents().getFirst().getComponentType());
+        // Label should be at the Question level
+        assertEquals("\"Question label.\"", question.getLabel().getValue());
+        assertEquals(LabelTypeEnum.VTL_MD, question.getLabel().getType());
+        assertNull(question.getComponents().getFirst().getLabel());
+        // Declarations too (plus "STATEMENT" should be changed to "HELP")
+        assertEquals(2, question.getDeclarations().size());
+        assertEquals(DeclarationTypeEnum.HELP, question.getDeclarations().get(0).getDeclarationType());
+        assertEquals(DeclarationTypeEnum.HELP, question.getDeclarations().get(1).getDeclarationType());
+        assertEquals(DeclarationPositionEnum.BEFORE_QUESTION_TEXT, question.getDeclarations().get(0).getPosition());
+        assertEquals(DeclarationPositionEnum.AFTER_QUESTION_TEXT, question.getDeclarations().get(1).getPosition());
+        assertEquals("\"Before question declaration.\"", question.getDeclarations().get(0).getLabel().getValue());
+        assertEquals("\"After question declaration.\"", question.getDeclarations().get(1).getLabel().getValue());
+        assertTrue(question.getComponents().getFirst().getDeclarations().isEmpty());
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponentTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticQuestionComponentTest.java
@@ -1,0 +1,68 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.lunatic.model.flat.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LunaticQuestionComponentTest {
+
+    @Test
+    void wrapQuestionnaireComponents() {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        //
+        Sequence sequence = new Sequence();
+        sequence.setId("sequence-id");
+        sequence.setComponentType(ComponentTypeEnum.SEQUENCE);
+        questionnaire.getComponents().add(sequence);
+        //
+        InputNumber inputNumber = new InputNumber();
+        inputNumber.setComponentType(ComponentTypeEnum.INPUT_NUMBER);
+        inputNumber.setPage("1");
+        inputNumber.setMin(0d);
+        inputNumber.setMax(10d);
+        questionnaire.getComponents().add(inputNumber);
+
+        //
+        new LunaticQuestionComponent().apply(questionnaire);
+
+        // Sequence component should not be changed
+        assertEquals(sequence, questionnaire.getComponents().get(0));
+        // Input number should be replaced by a Question component
+        assertEquals(ComponentTypeEnum.QUESTION, questionnaire.getComponents().get(1).getComponentType());
+    }
+
+    @Test
+    void wrapLoopComponents() {
+        //
+        Questionnaire questionnaire = new Questionnaire();
+        Loop loop = new Loop();
+        loop.setComponentType(ComponentTypeEnum.LOOP);
+        //
+        Sequence sequence = new Sequence();
+        sequence.setId("sequence-id");
+        sequence.setComponentType(ComponentTypeEnum.SEQUENCE);
+        loop.getComponents().add(sequence);
+        //
+        InputNumber inputNumber = new InputNumber();
+        inputNumber.setComponentType(ComponentTypeEnum.INPUT_NUMBER);
+        inputNumber.setPage("1");
+        inputNumber.setMin(0d);
+        inputNumber.setMax(10d);
+        loop.getComponents().add(inputNumber);
+        //
+        questionnaire.getComponents().add(loop);
+
+        //
+        new LunaticQuestionComponent().apply(questionnaire);
+
+        // Questionnaire first component should still be a loop
+        assertEquals(ComponentTypeEnum.LOOP, questionnaire.getComponents().getFirst().getComponentType());
+        // Sequence component should not be changed
+        assertEquals(sequence, loop.getComponents().get(0));
+        // Input number should be replaced by a Question component
+        assertEquals(ComponentTypeEnum.QUESTION, loop.getComponents().get(1).getComponentType());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/ComplexMultipleChoiceQuestionProcessingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/ComplexMultipleChoiceQuestionProcessingTest.java
@@ -96,7 +96,7 @@ class ComplexMultipleChoiceQuestionProcessingTest {
         assertEquals("\"Code 1\"",
                 lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getValue());
         assertEquals(LabelTypeEnum.VTL_MD,
-                lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getTypeEnum());
+                lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getType());
         // Only look at the modality value for the others
         assertEquals("c2", lunaticTable.getBodyLines().get(1).getBodyCells().get(0).getValue());
         assertEquals("c21", lunaticTable.getBodyLines().get(1).getBodyCells().get(1).getValue());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessingTest.java
@@ -46,8 +46,8 @@ class DynamicTableQuestionProcessingTest {
     void minAndMaxIterations() {
         assertEquals("1", lunaticDynamicTable.getLines().getMin().getValue());
         assertEquals("5", lunaticDynamicTable.getLines().getMax().getValue());
-        assertEquals(LabelTypeEnum.VTL, lunaticDynamicTable.getLines().getMin().getTypeEnum());
-        assertEquals(LabelTypeEnum.VTL, lunaticDynamicTable.getLines().getMax().getTypeEnum());
+        assertEquals(LabelTypeEnum.VTL, lunaticDynamicTable.getLines().getMin().getType());
+        assertEquals(LabelTypeEnum.VTL, lunaticDynamicTable.getLines().getMax().getType());
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/TableQuestionProcessingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/TableQuestionProcessingTest.java
@@ -95,16 +95,16 @@ class TableQuestionProcessingTest {
         assertEquals("h2", lunaticTable.getHeader().get(2).getLabel().getValue());
         assertEquals("h3", lunaticTable.getHeader().get(3).getLabel().getValue());
         lunaticTable.getHeader().forEach(headerType ->
-                assertEquals(LabelTypeEnum.VTL_MD, headerType.getLabel().getTypeEnum()));
+                assertEquals(LabelTypeEnum.VTL_MD, headerType.getLabel().getType()));
         //
         assertEquals("1", lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getValue());
         assertEquals("2", lunaticTable.getBodyLines().get(1).getBodyCells().get(0).getValue());
         assertEquals("l1", lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getValue());
         assertEquals("l2", lunaticTable.getBodyLines().get(1).getBodyCells().get(0).getLabel().getValue());
         assertEquals(LabelTypeEnum.VTL_MD,
-                lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getTypeEnum());
+                lunaticTable.getBodyLines().get(0).getBodyCells().get(0).getLabel().getType());
         assertEquals(LabelTypeEnum.VTL_MD,
-                lunaticTable.getBodyLines().get(1).getBodyCells().get(0).getLabel().getTypeEnum());
+                lunaticTable.getBodyLines().get(1).getBodyCells().get(0).getLabel().getType());
         //
         assertEquals(ComponentTypeEnum.CHECKBOX_BOOLEAN, lunaticTable.getBodyLines().get(0).getBodyCells().get(1).getComponentType());
         assertEquals(ComponentTypeEnum.CHECKBOX_BOOLEAN, lunaticTable.getBodyLines().get(1).getBodyCells().get(1).getComponentType());

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -53,7 +53,8 @@ public class GenerationStandardController {
             @Parameter(name = "specificTreatment", schema = @Schema(type="string", format="binary"))
             @RequestPart(value="specificTreatment", required = false) Mono<Part> specificTreatment,
             @PathVariable EnoParameters.Context context,
-            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter) {
+            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter,
+            @RequestParam(defaultValue = "false") boolean dsfr) {
         if (EnoParameters.ModeParameter.PAPI.equals(modeParameter))
             return Mono.error(new ModeParameterException("Lunatic format is not compatible with the mode 'PAPER'."));
 
@@ -67,6 +68,7 @@ public class GenerationStandardController {
         Mono<LunaticPostProcessing> lunaticPostProcessing = controllerUtils.generateLunaticPostProcessings(specificTreatment);
         //
         EnoParameters enoParameters = EnoParameters.of(context, modeParameter, Format.LUNATIC);
+        enoParameters.getLunaticParameters().setLunaticV3(dsfr);
         //
         return controllerUtils.ddiToLunaticJson(ddiFile, enoParameters, lunaticPostProcessing);
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         libs {
-            version('lunatic-model', '3.7.0')
+            version('lunatic-model', '3.7.0-SNAPSHOT')
             version('pogues-model', '1.3.3')
             library('lunatic-model', 'fr.insee.lunatic', 'lunatic-model').versionRef('lunatic-model')
             library('pogues-model', 'fr.insee.pogues', 'pogues-model').versionRef('pogues-model')

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         libs {
-            version('lunatic-model', '3.6.2')
+            version('lunatic-model', '3.7.0')
             version('pogues-model', '1.3.3')
             library('lunatic-model', 'fr.insee.lunatic', 'lunatic-model').versionRef('lunatic-model')
             library('pogues-model', 'fr.insee.pogues', 'pogues-model').versionRef('pogues-model')


### PR DESCRIPTION
## Summary

- #957 

Lunatic-DSFR introduced a `Question` component, which encapsulates response components such as Input, InputNumber, Table etc.

## Done

"Question" component feature:

- processing that wraps response components in `Question`
- add a `"dsfr"` parameter that activates this processing or not
- add a query param for this parameter in standard Lunatic generation controller `/questionnaire/{context}/lunatic-json/{mode}`

Refactor:

- remove usage of "FilterDescription" component which has been deleted in Lunatic-Model
- remove usage of `getTypeEnum() -> LabelTypeEnum` replaced by `getType() -> LabelTypeEnum` in Lunatic-Model
