### PR TITLE
test: lunatic dynamic table row control inversion

### DIFF
--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ControlRowTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/ControlRowTest.java
@@ -5,8 +5,12 @@ import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.mappers.LunaticMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.processing.out.steps.lunatic.LunaticReverseConsistencyControlLabel;
 import fr.insee.lunatic.model.flat.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.List;
 
@@ -16,10 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /** Class to test the mapping of row-level control in a dynamic table. */
 class ControlRowTest {
 
-    @Test
-    void mappingFromDDITest() throws DDIParsingException {
+    private Questionnaire lunaticQuestionnaire;
+
+    @BeforeEach
+    void mapDDIToLunatic() throws DDIParsingException {
         //
-        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        lunaticQuestionnaire = new Questionnaire();
         EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(
                 this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-controls-line.xml"),
                 EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI));
@@ -27,7 +33,10 @@ class ControlRowTest {
         //
         LunaticMapper lunaticMapper = new LunaticMapper();
         lunaticMapper.mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+    }
 
+    @Test
+    void mappingFromDDITest() {
         // This questionnaire has a single sequence with a dynamic table question
         RosterForLoop rosterForLoop = lunaticQuestionnaire.getComponents().stream()
                 .filter(RosterForLoop.class::isInstance).map(RosterForLoop.class::cast).findAny().orElse(null);
@@ -48,6 +57,26 @@ class ControlRowTest {
         assertEquals("\"Sum of percentages cannot be > 100%.\"",
                 rowControl.getErrorMessage().getValue());
         assertEquals(LabelTypeEnum.VTL_MD, rowControl.getErrorMessage().getType());
+    }
+
+    @Test
+    void reverseControlExpressions() {
+        //
+        new LunaticReverseConsistencyControlLabel().apply(lunaticQuestionnaire);
+
+        //
+        RosterForLoop rosterForLoop = lunaticQuestionnaire.getComponents().stream()
+                .filter(RosterForLoop.class::isInstance).map(RosterForLoop.class::cast).findAny().orElse(null);
+        assertNotNull(rosterForLoop);
+        //
+        List<ControlType> rowControls = rosterForLoop.getControls().stream()
+                .filter(controlType -> ControlContextType.ROW.equals(controlType.getType()))
+                .toList();
+        assertEquals(1, rowControls.size());
+        //
+        ControlType rowControl = rowControls.getFirst();
+        assertEquals("not(cast(DYNAMIC_TABLE1, integer) + cast(DYNAMIC_TABLE2, integer) > 100)",
+                rowControl.getControl().getValue());
     }
 
 }


### PR DESCRIPTION
## Summary

- #1020 
- #1045

Actually fixed by:

- #1047 

The controls at row level in dynamic tables (roster for loop components in Lunatic) were mapped with the `"typeOfControl"` `"ROW"`.

These should instaed have `"typeofControl"` = `"CONSISTENCY"`, with a separate property `"type"` with the value `"ROW"`. The PR 1047 fixed this.

By rebound, this has also fixed the _inversion_ of these controls, since [the processing class that does it](https://github.com/InseeFr/Eno/blob/a205c2320aeed64b396ac8ff2ea57ce6063bb3b5/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabel.java) filters controls that have the `typeOfControl` property equal to `CONSISTENCY`.

## Done

Added a test case for this.
