### PR TITLE
fix: update detail response processing with roundabout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.23.1-SNAPSHOT'
+    version = '3.23.2-SNAPSHOT'
 }
 
 subprojects {


### PR DESCRIPTION
## Summary

When a questionnaire contains a roundabout that has a unique choice question in its components, the Lunatic generation fails.

## Done

The Lunatic processing step for detail responses tries to link Eno unique choice questions with the corresponding Lunatic component. The problem was that the function that makes this link didn't look in Lunatic roudabouts.

Also, this fix:

- improves this step to only process questions that actually have details responses, 
- and also makes detail responses in the pairwise component possible.