### PR TITLE
fix(roundabout): disabled condition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.23.6'
+    version = '3.23.7'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFilters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFilters.java
@@ -2,15 +2,19 @@ package fr.insee.eno.core.processing.in.steps.ddi;
 
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.navigation.Filter;
 import fr.insee.eno.core.model.navigation.Loop;
 import fr.insee.eno.core.model.sequence.ItemReference;
 import fr.insee.eno.core.model.sequence.RoundaboutSequence;
 import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.eno.core.utils.VtlSyntaxUtils;
 
 import java.util.Optional;
 
 /**
  * Temporary processing step to mark filters that correspond to a roundabout filter.
+ * This processing also inverts the roundabout occurrence filter expression (which is in the opposite way in DDI
+ * compared to Pogues and Lunatic).
  * @see fr.insee.eno.core.model.navigation.Filter
  */
 public class DDIMarkRoundaboutFilters implements ProcessingStep<EnoQuestionnaire> {
@@ -29,7 +33,10 @@ public class DDIMarkRoundaboutFilters implements ProcessingStep<EnoQuestionnaire
             return;
         enoQuestionnaire.getFilters().stream()
                 .filter(enoFilter -> itemReference.getId().equals(enoFilter.getId()))
-                .forEach(enoFilter -> enoFilter.setRoundaboutFilter(true));
+                .forEach(enoFilter -> {
+                    invertFilterExpression(enoFilter);
+                    enoFilter.setRoundaboutFilter(true);
+                });
     }
 
     private static Loop findRoundaboutLoop(EnoQuestionnaire enoQuestionnaire, RoundaboutSequence roundaboutSequence) {
@@ -40,6 +47,13 @@ public class DDIMarkRoundaboutFilters implements ProcessingStep<EnoQuestionnaire
                     "Unable to find loop '%s' associated to DDI roundabout sequence '%s'.",
                     roundaboutSequence.getLoopReference(), roundaboutSequence.getId()));
         return enoLoop.get();
+    }
+
+    private static void invertFilterExpression(Filter enoFilter) {
+        if (enoFilter.getExpression() == null)
+            throw new MappingException("Eno filter object '" + enoFilter.getId() + "' has no expression.");
+        String stringExpression = enoFilter.getExpression().getValue();
+        enoFilter.getExpression().setValue(VtlSyntaxUtils.invertBooleanExpression(stringExpression));
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
@@ -8,6 +8,7 @@ import fr.insee.eno.core.model.navigation.Filter;
 import fr.insee.eno.core.model.navigation.LinkedLoop;
 import fr.insee.eno.core.model.sequence.RoundaboutSequence;
 import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.eno.core.utils.VtlSyntaxUtils;
 import fr.insee.lunatic.model.flat.*;
 import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
 import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
@@ -173,7 +174,8 @@ public class LunaticRoundaboutLoops implements ProcessingStep<Questionnaire> {
         String occurrenceFilterExpression = getOccurrenceFilterExpression(enoLoop);
         if (occurrenceFilterExpression != null) {
             lunaticRoundaboutItem.setDisabled(new LabelType());
-            lunaticRoundaboutItem.getDisabled().setValue(occurrenceFilterExpression);
+            lunaticRoundaboutItem.getDisabled().setValue(
+                    VtlSyntaxUtils.invertBooleanExpression(occurrenceFilterExpression));
             lunaticRoundaboutItem.getDisabled().setType(LabelTypeEnum.VTL);
         }
         lunaticRoundabout.setItem(lunaticRoundaboutItem);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
@@ -174,8 +174,7 @@ public class LunaticRoundaboutLoops implements ProcessingStep<Questionnaire> {
         String occurrenceFilterExpression = getOccurrenceFilterExpression(enoLoop);
         if (occurrenceFilterExpression != null) {
             lunaticRoundaboutItem.setDisabled(new LabelType());
-            lunaticRoundaboutItem.getDisabled().setValue(
-                    VtlSyntaxUtils.invertBooleanExpression(occurrenceFilterExpression));
+            lunaticRoundaboutItem.getDisabled().setValue(occurrenceFilterExpression);
             lunaticRoundaboutItem.getDisabled().setType(LabelTypeEnum.VTL);
         }
         lunaticRoundabout.setItem(lunaticRoundaboutItem);

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/VtlSyntaxUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/VtlSyntaxUtils.java
@@ -19,4 +19,19 @@ public class VtlSyntaxUtils {
         return vtlString1 + " " + VTL_CONCATENATION_OPERATOR + " " + vtlString2;
     }
 
+    /**
+     * Inverts the given expression (which is supposed to be a VTL expression that returns a boolean)
+     * by adding a 'not()' around it, or eventually removing one if the entire expression is in a "not".
+     * @param expression VTL boolean expression.
+     * @return The inverted VTL expression.
+     */
+    public static String invertBooleanExpression(String expression) {
+        String trimmed = expression.trim();
+        // If the whole expression is within a not(), remove it
+        if (trimmed.startsWith("not(") && trimmed.endsWith(")"))
+            return trimmed.substring(4, trimmed.length() - 1);
+        // Otherwise, add a not() around the expression
+        return "not(" + trimmed + ")";
+    }
+
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFiltersTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFiltersTest.java
@@ -3,11 +3,11 @@ package fr.insee.eno.core.processing.in.steps.ddi;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.navigation.Filter;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DDIMarkRoundaboutFiltersTest {
 
@@ -25,7 +25,9 @@ class DDIMarkRoundaboutFiltersTest {
         // Then
         // this questionnaire has no filters except the "occurrence" filter added for the roundabout
         assertEquals(1, enoQuestionnaire.getFilters().size());
-        assertTrue(enoQuestionnaire.getFilters().getFirst().isRoundaboutFilter());
+        Filter enoFilter = enoQuestionnaire.getFilters().getFirst();
+        assertTrue(enoFilter.isRoundaboutFilter());
+        assertFalse(enoFilter.getExpression().getValue().startsWith("not"));
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -17,7 +17,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static fr.insee.lunatic.model.flat.ComponentTypeEnum.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LunaticRoundaboutLoopsTest {
@@ -81,7 +82,7 @@ class LunaticRoundaboutLoopsTest {
         assertEquals("\"Occurrence description of \" || FIRST_NAME",
                 roundaboutItem.getDescription().getValue().stripTrailing());
         assertEquals(LabelTypeEnum.VTL_MD, roundaboutItem.getDescription().getType());
-        assertEquals("not(FIRST_NAME <> FIRST_NAME_REF)",
+        assertEquals("FIRST_NAME <> FIRST_NAME_REF",
                 roundaboutItem.getDisabled().getValue().stripTrailing());
         assertEquals(LabelTypeEnum.VTL, roundaboutItem.getDisabled().getType());
     }

--- a/eno-core/src/test/java/fr/insee/eno/core/utils/VtlSyntaxUtilsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/utils/VtlSyntaxUtilsTest.java
@@ -1,0 +1,18 @@
+package fr.insee.eno.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VtlSyntaxUtilsTest {
+
+    @Test
+    void invertExpressions() {
+        assertEquals("FOO", VtlSyntaxUtils.invertBooleanExpression("not(FOO)"));
+        assertEquals("not(FOO)", VtlSyntaxUtils.invertBooleanExpression("FOO"));
+        assertEquals("not(FOO)", VtlSyntaxUtils.invertBooleanExpression("not(not(FOO))"));
+        assertEquals("FOO = 1", VtlSyntaxUtils.invertBooleanExpression("not(FOO = 1)"));
+        assertEquals("not(FOO = 1)", VtlSyntaxUtils.invertBooleanExpression("FOO = 1"));
+    }
+
+}


### PR DESCRIPTION
## Summary

In roundabouts, the "disabled" condition in Lunatic must be the same as the "_Sauf_" (_except_) condition inputted by the used in Pogues.

Yet this condition is inverted in the DDI.

## Done

At first, I inverted the "disabled" condition in the Lunatic processing that generates roundabout loops, but this would have needed refactor when doing the Pogues -> Lunatic transformation (since the condition is the same in both formats).

=> Inverted the filter expression of roundabout filters in a DDI processing (used the one that identify roundabout filters and marks them).
