### PR TITLE
fix: response in identification question

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.23.7'
+    version = '3.23.8-SNAPSHOT'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddIdentificationSection.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoAddIdentificationSection.java
@@ -4,6 +4,7 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.label.DynamicLabel;
 import fr.insee.eno.core.model.label.Label;
 import fr.insee.eno.core.model.question.TextQuestion;
+import fr.insee.eno.core.model.response.Response;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.sequence.StructureItemReference;
 import fr.insee.eno.core.model.sequence.StructureItemReference.StructureItemType;
@@ -49,7 +50,7 @@ public class EnoAddIdentificationSection implements ProcessingStep<EnoQuestionna
         sequence.getLabel().setType(LabelTypeEnum.VTL_MD.value());
         sequence.getSequenceStructure().add(
                 StructureItemReference.builder().id(IDENTIFICATION_SUBSEQUENCE_ID).type(StructureItemType.SUBSEQUENCE).build());
-        enoQuestionnaire.getSequences().add(0, sequence);
+        enoQuestionnaire.getSequences().addFirst(sequence);
         enoQuestionnaire.getIndex().put(IDENTIFICATION_SEQUENCE_ID, sequence);
         //
         Subsequence subsequence = new Subsequence();
@@ -59,7 +60,7 @@ public class EnoAddIdentificationSection implements ProcessingStep<EnoQuestionna
         subsequence.getLabel().setType(LabelTypeEnum.VTL_MD.value());
         subsequence.getSequenceStructure().add(
                 StructureItemReference.builder().id(IDENTIFICATION_QUESTION_ID).type(StructureItemType.QUESTION).build());
-        enoQuestionnaire.getSubsequences().add(0, subsequence);
+        enoQuestionnaire.getSubsequences().addFirst(subsequence);
         enoQuestionnaire.getIndex().put(IDENTIFICATION_SUBSEQUENCE_ID, subsequence);
         //
         TextQuestion question = new TextQuestion();
@@ -70,7 +71,9 @@ public class EnoAddIdentificationSection implements ProcessingStep<EnoQuestionna
         question.setLengthType(TextQuestion.qualifyLength(IDENTIFICATION_QUESTION_LENGTH));
         question.setMaxLength(BigInteger.valueOf(IDENTIFICATION_QUESTION_LENGTH));
         question.setMandatory(IDENTIFICATION_QUESTION_MANDATORY);
-        enoQuestionnaire.getSingleResponseQuestions().add(0, question);
+        question.setResponse(new Response());
+        question.getResponse().setVariableName(IDENTIFICATION_COMMENT_VARIABLE);
+        enoQuestionnaire.getSingleResponseQuestions().addFirst(question);
         enoQuestionnaire.getIndex().put(IDENTIFICATION_QUESTION_ID, question);
     }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -2,6 +2,7 @@ package fr.insee.eno.core.utils;
 
 import fr.insee.eno.core.exceptions.business.LunaticLoopException;
 import fr.insee.eno.core.exceptions.technical.LunaticPairwiseException;
+import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.lunatic.model.flat.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,6 +63,8 @@ public class LunaticUtils {
                     throw new IllegalArgumentException(String.format(
                             "Method to get response names cannot be called on a component of type %s.",
                             component.getComponentType()));
+                if (simpleResponseComponent.getResponse() == null)
+                    throw new MappingException("Lunatic component '" + component.getId() + "' has no response.");
                 names = List.of(simpleResponseComponent.getResponse().getName());
             }
         }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddIdentificationSectionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/common/steps/EnoAddIdentificationSectionTest.java
@@ -4,22 +4,16 @@ import fr.insee.eno.core.DDIToEno;
 import fr.insee.eno.core.DDIToLunatic;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
-import fr.insee.eno.core.model.label.DynamicLabel;
-import fr.insee.eno.core.model.question.TextQuestion;
 import fr.insee.eno.core.model.sequence.Sequence;
-import fr.insee.eno.core.model.sequence.StructureItemReference;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.Format;
-import fr.insee.eno.core.reference.EnoIndex;
 import fr.insee.lunatic.model.flat.ComponentType;
 import fr.insee.lunatic.model.flat.ComponentTypeEnum;
 import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.lunatic.model.flat.Textarea;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EnoAddIdentificationSectionTest {
 
@@ -34,7 +28,7 @@ class EnoAddIdentificationSectionTest {
                 this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-simple.xml"),
                 enoParameters);
         //
-        Sequence identificationSequence = enoQuestionnaire.getSequences().get(0);
+        Sequence identificationSequence = enoQuestionnaire.getSequences().getFirst();
         assertEquals(EnoAddIdentificationSection.IDENTIFICATION_SEQUENCE_ID, identificationSequence.getId());
     }
 
@@ -49,10 +43,19 @@ class EnoAddIdentificationSectionTest {
                 this.getClass().getClassLoader().getResourceAsStream("integration/ddi/ddi-simple.xml"),
                 enoParameters);
         //
-        ComponentType identificationSequence = lunaticQuestionnaire.getComponents().get(0);
-        assertTrue(identificationSequence instanceof fr.insee.lunatic.model.flat.Sequence);
+        ComponentType identificationSequence = lunaticQuestionnaire.getComponents().getFirst();
+        assertInstanceOf(fr.insee.lunatic.model.flat.Sequence.class, identificationSequence);
         assertEquals(ComponentTypeEnum.SEQUENCE, identificationSequence.getComponentType());
         assertEquals(EnoAddIdentificationSection.IDENTIFICATION_SEQUENCE_ID, identificationSequence.getId());
+        //
+        Textarea identificationQuestion = lunaticQuestionnaire.getComponents().stream()
+                .filter(Textarea.class::isInstance).map(Textarea.class::cast)
+                .filter(component -> "COMMENT-UE-QUESTION".equals(component.getId())).findAny().orElse(null);
+        assertNotNull(identificationQuestion);
+        assertEquals("COMMENT_UE", identificationQuestion.getResponse().getName());
+        //
+        assertTrue(lunaticQuestionnaire.getVariables().stream()
+                .anyMatch(variable -> variable.getName().equals("COMMENT_UE")));
     }
 
 }


### PR DESCRIPTION
Un oubli révélé par : 

- InseeFr/Public-Enemy-Back-Office#107

L'objet de réponse était manquant dans la question d' "identification" ajoutée pour les questionnaires en contexte "BUSINESS".