### PR TITLE
feat(ws): direct pogues to lunatic endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.26.0-SNAPSHOT'
+    version = '3.26.1-SNAPSHOT'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ tasks.withType(JavaCompile).configureEach {
 
 allprojects {
     group = 'fr.insee.eno'
-    version = '3.25.1-SNAPSHOT'
+    version = '3.26.0-SNAPSHOT'
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/DDIToLunatic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/DDIToLunatic.java
@@ -1,11 +1,8 @@
 package fr.insee.eno.core;
 
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
-import fr.insee.eno.core.exceptions.business.LunaticSerializationException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.parameter.EnoParameters;
-import fr.insee.eno.core.processing.ProcessingStep;
-import fr.insee.eno.core.serialize.LunaticSerializer;
 import fr.insee.lunatic.model.flat.Questionnaire;
 
 import java.io.InputStream;
@@ -29,37 +26,6 @@ public class DDIToLunatic {
         EnoQuestionnaire enoQuestionnaire = DDIToEno.transform(ddiInputStream, enoParameters);
         //
         return EnoToLunatic.transform(enoQuestionnaire, enoParameters);
-    }
-
-    /**
-     * Transform given DDI input stream into a Lunatic questionnaire as a json string, using parameters given.
-     * @param ddiInputStream Input stream of a DDI document.
-     * @param enoParameters Eno parameters object.
-     * @return Lunatic questionnaire serialized in a json string.
-     * @throws DDIParsingException if the input stream given cannot be parsed to a DDI object.
-     */
-    public static String transformToJson(InputStream ddiInputStream, EnoParameters enoParameters)
-            throws DDIParsingException, LunaticSerializationException {
-        Questionnaire lunaticQuestionnaire = transform(ddiInputStream, enoParameters);
-
-        // Handle missing/resizing (sic) as lunatic model can't support this at this time, really ugly :\
-        return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
-    }
-
-    /**
-     * Transform given DDI input stream into a Lunatic questionnaire as a json string, using parameters given.
-     * @param ddiInputStream Input stream of a DDI document.
-     * @param enoParameters Eno parameters object.
-     * @return Lunatic questionnaire serialized in a json string.
-     * @throws DDIParsingException if the input stream given cannot be parsed to a DDI object.
-     */
-    public static String transformToJson(InputStream ddiInputStream, EnoParameters enoParameters, ProcessingStep<Questionnaire> lunaticPostProcessings)
-            throws DDIParsingException, LunaticSerializationException {
-        Questionnaire lunaticQuestionnaire = transform(ddiInputStream, enoParameters);
-        lunaticPostProcessings.apply(lunaticQuestionnaire);
-
-        // Handle missing/resizing (sic) as lunatic model can't support this at this time, really ugly :\
-        return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/PoguesToEno.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/PoguesToEno.java
@@ -1,0 +1,39 @@
+package fr.insee.eno.core;
+
+import fr.insee.eno.core.exceptions.business.PoguesDeserializationException;
+import fr.insee.eno.core.mappers.PoguesMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.processing.common.EnoProcessing;
+import fr.insee.eno.core.serialize.PoguesDeserializer;
+import fr.insee.pogues.model.Questionnaire;
+
+import java.io.InputStream;
+
+public class PoguesToEno {
+
+    private PoguesToEno() {}
+
+    /**
+     * Transform given Pogues input stream into a Eno questionnaire object using parameters given.
+     * @param poguesInputStream Input stream of a Pogues json questionnaire.
+     * @param enoParameters Eno parameters object.
+     * @return Lunatic questionnaire object.
+     * @throws PoguesDeserializationException if the input stream given cannot be parsed to a Pogues questionnaire.
+     */
+    public static EnoQuestionnaire transform(InputStream poguesInputStream, EnoParameters enoParameters)
+            throws PoguesDeserializationException {
+        //
+        Questionnaire poguesQuestionnaire = PoguesDeserializer.deserialize(poguesInputStream);
+        //
+        PoguesMapper poguesMapper = new PoguesMapper();
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        EnoProcessing enoProcessing = new EnoProcessing(enoParameters);
+        enoProcessing.applyProcessing(enoQuestionnaire);
+        //
+        return enoQuestionnaire;
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/PoguesToLunatic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/PoguesToLunatic.java
@@ -1,0 +1,29 @@
+package fr.insee.eno.core;
+
+import fr.insee.eno.core.exceptions.business.PoguesDeserializationException;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.lunatic.model.flat.Questionnaire;
+
+import java.io.InputStream;
+
+public class PoguesToLunatic {
+
+    private PoguesToLunatic() {}
+
+    /**
+     * Transform given Pogues input stream into a Lunatic questionnaire object using parameters given.
+     * @param ddiInputStream Input stream of a Pogues json questionnaire.
+     * @param enoParameters Eno parameters object.
+     * @return Lunatic questionnaire object.
+     * @throws PoguesDeserializationException if the input stream given cannot be parsed to a Pogues questionnaire.
+     */
+    public static Questionnaire transform(InputStream ddiInputStream, EnoParameters enoParameters)
+            throws PoguesDeserializationException {
+        //
+        EnoQuestionnaire enoQuestionnaire = PoguesToEno.transform(ddiInputStream, enoParameters);
+        //
+        return EnoToLunatic.transform(enoQuestionnaire, enoParameters);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/PoguesMapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/PoguesMapper.java
@@ -1,0 +1,17 @@
+package fr.insee.eno.core.mappers;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.parameter.Format;
+import fr.insee.pogues.model.Questionnaire;
+
+public class PoguesMapper extends Mapper {
+
+    public PoguesMapper() {
+        this.format = Format.POGUES;
+    }
+
+    public void mapPoguesQuestionnaire(Questionnaire poguesQuestionnaire, EnoQuestionnaire enoQuestionnaire) {
+        throw new UnsupportedOperationException("Pogues mapping is not implemented yet.");
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/serialize/PoguesDeserializer.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/serialize/PoguesDeserializer.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -18,6 +19,24 @@ import java.nio.file.Path;
 public class PoguesDeserializer {
 
     private PoguesDeserializer() {}
+
+    /**
+     * Deserializes the Pogues json file from given input stream.
+     * @param poguesInputStream Input stream of a Pogues json questionnaire.
+     * @return A Pogues-Model questionnaire.
+     * @throws PoguesDeserializationException if deserialization fails.
+     */
+    public static Questionnaire deserialize(InputStream poguesInputStream) throws PoguesDeserializationException {
+        JSONDeserializer poguesDeserializer = new JSONDeserializer();
+        log.info("Deserializing Pogues json questionnaire from input stream given.");
+        try {
+            Questionnaire poguesQuestionnaire = poguesDeserializer.deserialize(poguesInputStream);
+            log.info("Successfully deserialized Pogues questionnaire from input stream.");
+            return poguesQuestionnaire;
+        } catch (JAXBException e) {
+            throw new PoguesDeserializationException("Unable to parse Pogues file  from input stream given.", e);
+        }
+    }
 
     /**
      * Deserializes the Pogues json file from given URL.

--- a/eno-ws/build.gradle
+++ b/eno-ws/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation project(':eno-treatments')
 	// Lunatic
 	implementation libs.lunatic.model
+	implementation libs.pogues.model
 	// Spring Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	// Web Client

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
@@ -3,6 +3,8 @@ package fr.insee.eno.ws.controller;
 import fr.insee.eno.legacy.parameters.OutFormat;
 import fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils;
 import fr.insee.eno.ws.exception.EnoControllerException;
+import fr.insee.eno.ws.exception.PoguesToLunaticException;
+import fr.insee.eno.ws.service.PoguesToLunaticService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +17,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.net.URI;
 
-import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.addMultipartToBody;
-import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.questionnaireFilename;
+import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.*;
 
 @Tag(name = "Generation of DDI")
 @Controller
@@ -27,9 +29,13 @@ import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.questionnai
 @SuppressWarnings("unused")
 public class GenerationPoguesController {
 
+    private final PoguesToLunaticService poguesToLunaticService;
     private final EnoXmlControllerUtils xmlControllerUtils;
 
-    public GenerationPoguesController(EnoXmlControllerUtils xmlControllerUtils) {
+    public GenerationPoguesController(
+            PoguesToLunaticService poguesToLunaticService,
+            EnoXmlControllerUtils xmlControllerUtils) {
+        this.poguesToLunaticService = poguesToLunaticService;
         this.xmlControllerUtils = xmlControllerUtils;
     }
 
@@ -39,12 +45,37 @@ public class GenerationPoguesController {
                     "Generation of a DDI from a Pogues questionnaire (in the xml format).")
     @PostMapping(value="poguesxml-2-ddi",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> generateDDIQuestionnaire(
-            @RequestPart(value="in") MultipartFile in) throws EnoControllerException {
+    public ResponseEntity<String> generateDDIQuestionnaireFromXml(
+            @RequestPart(value="in") MultipartFile poguesXmlFile) throws EnoControllerException {
         //
         MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
-        addMultipartToBody(multipartBodyBuilder, in, "in");
+        addMultipartToBody(multipartBodyBuilder, poguesXmlFile, "in");
         //
+        URI uri = xmlControllerUtils.newUriBuilder().path("questionnaire/poguesxml-2-ddi").build().toUri();
+        String outFilename = questionnaireFilename(OutFormat.DDI, false);
+        return xmlControllerUtils.sendPostRequest(uri, multipartBodyBuilder, outFilename);
+    }
+
+    @Operation(
+            summary = "[Eno Xml service] DDI Generation from Pogues xml questionnaire.",
+            description = "**This endpoint uses the 'Xml' version of Eno.** " +
+                    "Generation of a DDI from a Pogues questionnaire (in the json format).")
+    @PostMapping(value="pogues-2-ddi",
+            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> generateDDIQuestionnaire(
+            @RequestPart(value="in") MultipartFile poguesJsonFile) {
+        // Convert json to xml
+        String poguesXml;
+        try {
+            poguesXml = poguesToLunaticService.poguesJsonToXml(new String(poguesJsonFile.getBytes()));
+        } catch (IOException e) {
+            log.error("Pogues json to xml conversion failed.");
+            throw new PoguesToLunaticException(e);
+        }
+        // Attach Pogues xml content in a multipart
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        addStringToMultipartBody(multipartBodyBuilder, poguesXml, "pogues.xml", "in");
+        // Send request to the legacy pogues xml to ddi endpoint
         URI uri = xmlControllerUtils.newUriBuilder().path("questionnaire/poguesxml-2-ddi").build().toUri();
         String outFilename = questionnaireFilename(OutFormat.DDI, false);
         return xmlControllerUtils.sendPostRequest(uri, multipartBodyBuilder, outFilename);

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.addMultipartToBody;
 import static fr.insee.eno.ws.controller.utils.EnoXmlControllerUtils.questionnaireFilename;
 
-@Tag(name = "Generation from Pogues")
+@Tag(name = "Generation of DDI")
 @Controller
 @RequestMapping("/questionnaire")
 @Slf4j
@@ -46,7 +46,7 @@ public class GenerationPoguesController {
         addMultipartToBody(multipartBodyBuilder, in, "in");
         //
         URI uri = xmlControllerUtils.newUriBuilder().path("questionnaire/poguesxml-2-ddi").build().toUri();
-        String outFilename = questionnaireFilename(OutFormat.XFORMS, false);
+        String outFilename = questionnaireFilename(OutFormat.DDI, false);
         return xmlControllerUtils.sendPostRequest(uri, multipartBodyBuilder, outFilename);
     }
 

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/EnoJavaControllerUtils.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/EnoJavaControllerUtils.java
@@ -3,9 +3,8 @@ package fr.insee.eno.ws.controller.utils;
 import fr.insee.eno.core.exceptions.business.EnoParametersException;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.treatments.LunaticPostProcessing;
-import fr.insee.eno.ws.exception.DDIToLunaticException;
 import fr.insee.eno.ws.exception.EnoControllerException;
-import fr.insee.eno.ws.service.DDIToLunaticService;
+import fr.insee.eno.ws.service.LunaticGenerationService;
 import fr.insee.eno.ws.service.ParameterService;
 import fr.insee.eno.ws.service.SpecificTreatmentsService;
 import org.springframework.http.ResponseEntity;
@@ -23,14 +22,11 @@ public class EnoJavaControllerUtils {
 
     public static final String LUNATIC_JSON_FILE_NAME = "lunatic-form.json";
 
-    private final DDIToLunaticService ddiToLunaticService;
     private final ParameterService parameterService;
     private final SpecificTreatmentsService specificTreatmentsService;
 
-    public EnoJavaControllerUtils(DDIToLunaticService ddiToLunaticService,
-                                  ParameterService parameterService,
+    public EnoJavaControllerUtils(ParameterService parameterService,
                                   SpecificTreatmentsService specificTreatmentsService) {
-        this.ddiToLunaticService = ddiToLunaticService;
         this.parameterService = parameterService;
         this.specificTreatmentsService = specificTreatmentsService;
     }
@@ -59,35 +55,39 @@ public class EnoJavaControllerUtils {
         return specificTreatmentsService.generateFrom(new ByteArrayInputStream(specificTreatmentsFile.getBytes()));
     }
 
-    public ResponseEntity<String> ddiToLunaticJson(MultipartFile ddiFile, MultipartFile parametersFile,
-                                                   MultipartFile specificTreatmentsFile)
-            throws EnoParametersException, IOException, EnoControllerException, DDIToLunaticException {
+    public ResponseEntity<String> transformToLunatic(MultipartFile inFile, MultipartFile parametersFile,
+                                                     MultipartFile specificTreatmentsFile,
+                                                     LunaticGenerationService generationService)
+            throws EnoParametersException, IOException, EnoControllerException {
         EnoParameters enoParameters = readEnoJavaParametersFile(parametersFile);
         LunaticPostProcessing lunaticPostProcessing = createLunaticPostProcessing(specificTreatmentsFile);
-        return ddiToLunaticJson(ddiFile.getBytes(), enoParameters, lunaticPostProcessing);
+        return transformToLunatic(inFile.getBytes(), enoParameters, lunaticPostProcessing, generationService);
     }
 
-    public ResponseEntity<String> ddiToLunaticJson(MultipartFile ddiFile, EnoParameters enoParameters,
-                                                   MultipartFile specificTreatmentsFile)
-            throws IOException, EnoControllerException, DDIToLunaticException {
+    public ResponseEntity<String> transformToLunatic(MultipartFile inFile, EnoParameters enoParameters,
+                                                     MultipartFile specificTreatmentsFile,
+                                                     LunaticGenerationService generationService)
+            throws IOException, EnoControllerException {
         LunaticPostProcessing lunaticPostProcessing = createLunaticPostProcessing(specificTreatmentsFile);
-        return ddiToLunaticJson(ddiFile.getBytes(), enoParameters, lunaticPostProcessing);
+        return transformToLunatic(inFile.getBytes(), enoParameters, lunaticPostProcessing, generationService);
     }
 
-    public ResponseEntity<String> ddiToLunaticJson(String ddiContent, EnoParameters enoParameters,
-                                                   MultipartFile specificTreatmentsFile)
-            throws IOException, EnoControllerException, DDIToLunaticException {
+    public ResponseEntity<String> transformToLunatic(String inputContent, EnoParameters enoParameters,
+                                                     MultipartFile specificTreatmentsFile,
+                                                     LunaticGenerationService generationService)
+            throws IOException, EnoControllerException {
         LunaticPostProcessing lunaticPostProcessing = createLunaticPostProcessing(specificTreatmentsFile);
-        return ddiToLunaticJson(ddiContent.getBytes(), enoParameters, lunaticPostProcessing);
+        return transformToLunatic(inputContent.getBytes(), enoParameters, lunaticPostProcessing, generationService);
     }
 
-    private ResponseEntity<String> ddiToLunaticJson(byte[] ddiBytes, EnoParameters enoParameters,
-                                                    LunaticPostProcessing lunaticPostProcessing)
-            throws EnoControllerException, DDIToLunaticException {
-        if (ddiBytes == null || ddiBytes.length == 0)
-            throw new EnoControllerException("DDI content is missing.");
-        String lunaticJson = ddiToLunaticService.transformToJson(
-                new ByteArrayInputStream(ddiBytes), enoParameters, lunaticPostProcessing);
+    private ResponseEntity<String> transformToLunatic(byte[] inputBytes, EnoParameters enoParameters,
+                                                      LunaticPostProcessing lunaticPostProcessing,
+                                                      LunaticGenerationService generationService)
+            throws EnoControllerException {
+        if (inputBytes == null || inputBytes.length == 0)
+            throw new EnoControllerException("Input file given is empty.");
+        String lunaticJson = generationService.transform(
+                new ByteArrayInputStream(inputBytes), enoParameters, lunaticPostProcessing);
         return ResponseEntity.ok()
                 .headers(HeadersUtils.with(LUNATIC_JSON_FILE_NAME))
                 .body(lunaticJson);

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/EnoXmlControllerUtils.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/utils/EnoXmlControllerUtils.java
@@ -63,19 +63,24 @@ public class EnoXmlControllerUtils {
     public static void addMultipartToBody(MultipartBodyBuilder multipartBodyBuilder, MultipartFile multipartFile,
                                           String partName) throws EnoControllerException {
         try {
-            multipartBodyBuilder.part(partName, multipartFileToByteArray(multipartFile));
+            multipartBodyBuilder.part(partName, byteArrayResourceWithFileName(multipartFile.getBytes(), multipartFile.getOriginalFilename()));
         } catch (IOException e) {
             throw new EnoControllerException(
                     "Unable to access content of given file " + multipartFile.getOriginalFilename());
         }
     }
 
-    private static ByteArrayResource multipartFileToByteArray(MultipartFile multipartFile) throws IOException {
+    public static void addStringToMultipartBody(
+            MultipartBodyBuilder multipartBodyBuilder, String content, String fileName, String partName) {
+        multipartBodyBuilder.part(partName, byteArrayResourceWithFileName(content.getBytes(), fileName));
+    }
+
+    private static ByteArrayResource byteArrayResourceWithFileName(byte[] bytes, String fileName) {
         // Ugly but I didn't find anything better
-        return new ByteArrayResource(multipartFile.getBytes()) {
+        return new ByteArrayResource(bytes) {
             @Override
             public String getFilename() {
-                return multipartFile.getOriginalFilename();
+                return fileName;
             }
         };
     }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/exception/DDIToLunaticException.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/exception/DDIToLunaticException.java
@@ -3,7 +3,7 @@ package fr.insee.eno.ws.exception;
 /**
  * Generic error to be thrown when an exception occurs during the DDI to Lunatic transformation.
  */
-public class DDIToLunaticException extends Exception {
+public class DDIToLunaticException extends RuntimeException {
 
     public DDIToLunaticException(Exception e) {
         super(e);

--- a/eno-ws/src/main/java/fr/insee/eno/ws/exception/PoguesToLunaticException.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/exception/PoguesToLunaticException.java
@@ -1,0 +1,12 @@
+package fr.insee.eno.ws.exception;
+
+/**
+ * Generic error to be thrown when an exception occurs during the Pogues to Lunatic transformation.
+ */
+public class PoguesToLunaticException extends RuntimeException {
+
+    public PoguesToLunaticException(Exception e) {
+        super(e);
+    }
+
+}

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToLunaticService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToLunaticService.java
@@ -2,11 +2,8 @@ package fr.insee.eno.ws.service;
 
 import fr.insee.eno.core.DDIToLunatic;
 import fr.insee.eno.core.parameter.EnoParameters;
-import fr.insee.eno.core.serialize.LunaticSerializer;
-import fr.insee.eno.treatments.LunaticPostProcessing;
 import fr.insee.eno.ws.exception.DDIToLunaticException;
 import fr.insee.lunatic.model.flat.Questionnaire;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 
@@ -14,37 +11,16 @@ import java.io.InputStream;
 
 @Service
 @PropertySource("classpath:/version.properties")
-public class DDIToLunaticService {
+public class DDIToLunaticService extends LunaticGenerationService {
 
-    @Value("${version.eno}")
-    String enoVersion;
-    @Value("${version.lunatic.model}")
-    String lunaticModelVersion;
-
-    public String transformToJson(InputStream ddiInputStream, EnoParameters enoParameters, LunaticPostProcessing lunaticPostProcessing)
-            throws DDIToLunaticException {
-        try {
-            Questionnaire lunaticQuestionnaire = DDIToLunatic.transform(ddiInputStream, enoParameters);
-            lunaticQuestionnaire.setEnoCoreVersion(enoVersion);
-            lunaticQuestionnaire.setLunaticModelVersion(lunaticModelVersion);
-            if (lunaticPostProcessing != null)
-                lunaticPostProcessing.apply(lunaticQuestionnaire);
-            return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
-        } catch (Exception e) {
-            throw new DDIToLunaticException(e);
-        }
+    @Override
+    Questionnaire mainTransformation(InputStream ddiInputStream, EnoParameters enoParameters) throws Exception {
+        return DDIToLunatic.transform(ddiInputStream, enoParameters);
     }
 
-    public String transformToJson(InputStream ddiInputStream, EnoParameters enoParameters)
-            throws DDIToLunaticException {
-        try {
-            Questionnaire lunaticQuestionnaire = DDIToLunatic.transform(ddiInputStream, enoParameters);
-            lunaticQuestionnaire.setEnoCoreVersion(enoVersion);
-            lunaticQuestionnaire.setLunaticModelVersion(lunaticModelVersion);
-            return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
-        } catch (Exception e) {
-            throw new DDIToLunaticException(e);
-        }
+    @Override
+    void handleException(Exception e) {
+        throw new DDIToLunaticException(e);
     }
 
 }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/LunaticGenerationService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/LunaticGenerationService.java
@@ -1,0 +1,62 @@
+package fr.insee.eno.ws.service;
+
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.serialize.LunaticSerializer;
+import fr.insee.eno.treatments.LunaticPostProcessing;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.InputStream;
+
+public abstract class LunaticGenerationService {
+
+    @Value("${version.eno}")
+    String enoVersion;
+
+    @Value("${version.lunatic.model}")
+    String lunaticModelVersion;
+
+    /**
+     * Transform given input stream to a Lunatic questionnaire.
+     * @param inputStream Input stream, e.g. of a DDI or Pogues questionnaire.
+     * @param enoParameters Eno parameters object.
+     * @return String Lunatic questionnaire.
+     */
+    public final String transform(InputStream inputStream, EnoParameters enoParameters) {
+        try {
+            Questionnaire lunaticQuestionnaire = mainTransformation(inputStream, enoParameters);
+            lunaticQuestionnaire.setEnoCoreVersion(enoVersion);
+            lunaticQuestionnaire.setLunaticModelVersion(lunaticModelVersion);
+            return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
+        } catch (Exception e) {
+            handleException(e);
+            return null;
+        }
+    }
+
+    /**
+     * Transform given input stream to a Lunatic questionnaire.
+     * @param inputStream Input stream, e.g. of a DDI or Pogues questionnaire.
+     * @param enoParameters Eno parameters object.
+     * @param lunaticPostProcessing Specific treatments to be applied.
+     * @return String Lunatic questionnaire.
+     */
+    public String transform(InputStream inputStream, EnoParameters enoParameters, LunaticPostProcessing lunaticPostProcessing) {
+        try {
+            Questionnaire lunaticQuestionnaire = mainTransformation(inputStream, enoParameters);
+            lunaticQuestionnaire.setEnoCoreVersion(enoVersion);
+            lunaticQuestionnaire.setLunaticModelVersion(lunaticModelVersion);
+            if (lunaticPostProcessing != null)
+                lunaticPostProcessing.apply(lunaticQuestionnaire);
+            return LunaticSerializer.serializeToJson(lunaticQuestionnaire);
+        } catch (Exception e) {
+            handleException(e);
+            return null;
+        }
+    }
+
+    abstract Questionnaire mainTransformation(InputStream inputStream, EnoParameters enoParameters) throws Exception;
+
+    abstract void handleException(Exception e);
+
+}

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToLunaticService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToLunaticService.java
@@ -1,0 +1,36 @@
+package fr.insee.eno.ws.service;
+
+import fr.insee.eno.core.PoguesToLunatic;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.ws.exception.PoguesToLunaticException;
+import fr.insee.lunatic.model.flat.Questionnaire;
+import fr.insee.pogues.conversion.JSONToXMLTranslator;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+
+@Service
+@PropertySource("classpath:/version.properties")
+public class PoguesToLunaticService extends LunaticGenerationService {
+
+    @Override
+    Questionnaire mainTransformation(InputStream poguesInputStream, EnoParameters enoParameters) throws Exception {
+        return PoguesToLunatic.transform(poguesInputStream, enoParameters);
+    }
+
+    @Override
+    void handleException(Exception e) {
+        throw new PoguesToLunaticException(e);
+    }
+
+    public String poguesJsonToXml(String poguesJson) {
+        try {
+            JSONToXMLTranslator jsonToXmlTranslator = new JSONToXMLTranslator();
+            return jsonToXmlTranslator.translate(poguesJson);
+        } catch (Exception e) {
+            throw new PoguesToLunaticException(e);
+        }
+    }
+
+}

--- a/eno-ws/src/main/resources/application.properties
+++ b/eno-ws/src/main/resources/application.properties
@@ -23,6 +23,9 @@ eno.release.note.url=
 # URL of a Eno "xml" web-service where some requests are redirected
 eno.legacy.ws.url=https://eno-url.insee.fr
 
+# Flag to allow the direct Pogues to Lunatic transformation
+eno.direct.pogues.lunatic=false
+
 # Timeout for the web-client
 eno.webclient.timeout=600
 

--- a/eno-ws/src/test/java/fr/insee/eno/ws/service/DDIToLunaticServiceTest.java
+++ b/eno-ws/src/test/java/fr/insee/eno/ws/service/DDIToLunaticServiceTest.java
@@ -36,7 +36,7 @@ class DDIToLunaticServiceTest {
     void nonRegression_DefaultCAWI(String questionnaireId) throws Exception {
         //
         DDIToLunaticService ddiToLunaticService = new DDIToLunaticService();
-        String result = ddiToLunaticService.transformToJson(
+        String result = ddiToLunaticService.transform(
                         this.getClass().getClassLoader().getResourceAsStream("non-regression/ddi-"+questionnaireId+".xml"),
                         EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
         //
@@ -55,7 +55,7 @@ class DDIToLunaticServiceTest {
 
         //
         DDIToLunaticService ddiToLunaticService = new DDIToLunaticService();
-        String result = ddiToLunaticService.transformToJson(
+        String result = ddiToLunaticService.transform(
                         this.getClass().getClassLoader().getResourceAsStream("non-regression/suggester-processing/ddi-l7ugetj0.xml"),
                         EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC),
                         lunaticPostProcessing);
@@ -81,7 +81,7 @@ class DDIToLunaticServiceTest {
 
         //
         DDIToLunaticService ddiToLunaticService = new DDIToLunaticService();
-        String result = ddiToLunaticService.transformToJson(
+        String result = ddiToLunaticService.transform(
                         this.getClass().getClassLoader().getResourceAsStream("non-regression/group-processing/ddi-lhpz68wp.xml"),
                         EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
 


### PR DESCRIPTION
Create direct Pogues to Lunatic endpoints.

Rearranged API swagger documentation a bit.

Tiny fix on the way: generated DDI files from the poguesxml-2-ddi controller had the wrong name.
