### PR TITLE
feat: roundabout controls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.27.3-SNAPSHOT"
+    version = "3.27.4-SNAPSHOT"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.27.4-SNAPSHOT"
+    version = "3.28.0-SNAPSHOT"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/navigation/Control.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/navigation/Control.java
@@ -66,6 +66,8 @@ public class Control extends EnoIdentifiableObject implements EnoObjectWithExpre
 
     public static ControlContextType convertContextToLunatic(Context context) {
         return switch (context) {
+            // Note: "simple" and null are equivalent in Lunatic
+            case null -> ControlContextType.SIMPLE;
             case SIMPLE -> ControlContextType.SIMPLE;
             case ROW -> ControlContextType.ROW;
         };
@@ -73,7 +75,7 @@ public class Control extends EnoIdentifiableObject implements EnoObjectWithExpre
 
     /** In DDI, there is only one concept for the type of controls.
      * The computation item type has a 'type of computation item' property.
-     * The value of this property determines the control's context. */
+     * If this property stats with 'line', it is a dynamic table line control that can be marked as a row control. */
     public static Context mapContextFromDDI(ComputationItemType computationItemType) {
         String ddiTypeOfComputationItem = computationItemType.getTypeOfComputationItem().getStringValue();
         //
@@ -96,9 +98,12 @@ public class Control extends EnoIdentifiableObject implements EnoObjectWithExpre
     @Lunatic("setTypeOfControl(T(fr.insee.eno.core.model.navigation.Control).convertTypeOfControlToLunatic(#param))")
     private TypeOfControl typeOfControl;
 
+    /** The context of a control is "simple" by default.
+     * In DDI, "row" controls are marked with both the mapping annotation and a processing step.
+     * @see fr.insee.eno.core.processing.in.steps.ddi.DDIMarkRowControls */
     @DDI("T(fr.insee.eno.core.model.navigation.Control).mapContextFromDDI(#this)")
     @Lunatic("setType(T(fr.insee.eno.core.model.navigation.Control).convertContextToLunatic(#param))")
-    private Context context;
+    private Context context = Context.SIMPLE;
 
     /** Label typed in Pogues, unused in Lunatic. */
     @DDI("getDescription()?.getContentArray(0)?.getStringValue()") // NOTE: getConstructNameArray(0).getStringArray(0).getStringValue() has the same information

--- a/eno-core/src/main/java/fr/insee/eno/core/model/sequence/RoundaboutSequence.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/sequence/RoundaboutSequence.java
@@ -3,9 +3,13 @@ package fr.insee.eno.core.model.sequence;
 import fr.insee.ddi.lifecycle33.datacollection.SequenceType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
+import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.parameter.Format;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Special kind of sequence that describes a "roundabout".
@@ -27,5 +31,14 @@ public class RoundaboutSequence extends AbstractSequence {
      * In DDI, this is modeled by the presence or not of a ComputationItem among the control construct references. */
     @DDI("!getControlConstructReferenceList().?[#this.getTypeOfObject().toString() == 'ComputationItem'].isEmpty()")
     private Boolean locked;
+
+    /**
+     * As dynamic tables, roundabouts can have controls (roundabout-level controls and/or occurrence-level controls).
+     * In DDI, the controls are mapped at the questionnaire level and are inserted here through a processing.
+     * @see fr.insee.eno.core.processing.in.steps.ddi.DDIInsertControls
+     * In Lunatic, the processing that transforms loops into roundabouts uses this list.
+     * @see fr.insee.eno.core.processing.out.steps.lunatic.LunaticRoundaboutLoops
+     */
+    private List<Control> controls = new ArrayList<>();
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/DDIInProcessing.java
@@ -14,6 +14,7 @@ public class DDIInProcessing {
         EnoIndex enoIndex = enoQuestionnaire.getIndex();
         processingPipeline.start(enoQuestionnaire)
                 .then(new DDICleanUpQuestionnaireId())
+                .then(new DDIMarkRowControls())
                 .then(new DDIMarkRoundaboutFilters())
                 .then(new DDIMoveUnitInQuestions())
                 .then(new DDIInsertResponseInTableCells())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertControls.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertControls.java
@@ -1,30 +1,36 @@
 package fr.insee.eno.core.processing.in.steps.ddi;
 
+import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.model.navigation.Filter;
 import fr.insee.eno.core.model.navigation.Loop;
 import fr.insee.eno.core.model.question.Question;
 import fr.insee.eno.core.model.sequence.ItemReference;
+import fr.insee.eno.core.model.sequence.RoundaboutSequence;
 import fr.insee.eno.core.model.sequence.Sequence;
 import fr.insee.eno.core.model.sequence.Subsequence;
 import fr.insee.eno.core.processing.ProcessingStep;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class DDIInsertControls implements ProcessingStep<EnoQuestionnaire> {
+
 
     /** Controls are mapped directly in a flat list in the questionnaire object.
      * This processing is intended to insert them into the objects to which they belong.
      * (Controls are placed after the object they belong to in the sequence items lists.)
      * Concerned objects : sequences, subsequences and questions. */
     public void apply(EnoQuestionnaire enoQuestionnaire) {
-        //
-        assert enoQuestionnaire.getIndex() != null;
-        //
         for (Sequence sequence : enoQuestionnaire.getSequences()) {
             List<ItemReference> sequenceItems = sequence.getSequenceItems();
             insertControlsInReferencedItems(enoQuestionnaire, sequenceItems);
+        }
+        Map<String, Control> controlMap = DDIMarkRowControls.mapQuestionnaireControls(enoQuestionnaire);
+        for (RoundaboutSequence roundaboutSequence : enoQuestionnaire.getRoundaboutSequences()) {
+            insertControlsInRoundabout(roundaboutSequence, enoQuestionnaire, controlMap);
         }
     }
 
@@ -72,6 +78,37 @@ public class DDIInsertControls implements ProcessingStep<EnoQuestionnaire> {
             i++;
         }
         return i;
+    }
+
+    private void insertControlsInRoundabout(RoundaboutSequence roundaboutSequence,
+                                            EnoQuestionnaire enoQuestionnaire,
+                                            Map<String, Control> controlMap) {
+        insertRoundaboutLevelControls(roundaboutSequence, controlMap);
+        insertRowLevelControls(roundaboutSequence, enoQuestionnaire, controlMap);
+    }
+
+    private static void insertRoundaboutLevelControls(RoundaboutSequence roundaboutSequence, Map<String, Control> controlMap) {
+        roundaboutSequence.getSequenceItems().stream()
+                .filter(itemReference -> ItemReference.ItemType.CONTROL.equals(itemReference.getType()))
+                .forEach(itemReference -> roundaboutSequence.getControls().add(controlMap.get(itemReference.getId())));
+    }
+
+    private static void insertRowLevelControls(RoundaboutSequence roundaboutSequence, EnoQuestionnaire enoQuestionnaire, Map<String, Control> controlMap) {
+        // Check that loop reference is not null to avoid null pointer exception
+        if (roundaboutSequence.getLoopReference() == null)
+            throw new MappingException(
+                    "Loop reference of roundabout sequence '" + roundaboutSequence.getId() + "' is null.");
+        // Get the corresponding loop
+        Optional<Loop> roundaboutLoop = enoQuestionnaire.getLoops().stream()
+                .filter(loop -> roundaboutSequence.getLoopReference().equals(loop.getId()))
+                .findAny();
+        // Make sure it is present
+        if (roundaboutLoop.isEmpty())
+            throw new MappingException("Cannot find loop '" + roundaboutSequence.getLoopReference() + "' " +
+                    "referenced in roundabout sequence '" + roundaboutSequence.getId() + "'");
+        // Insert all the controls that are referenced in the loop in the roundabout sequence object
+        DDIMarkRowControls.controlReferencesStream(roundaboutLoop.get())
+                .forEach(itemReference -> roundaboutSequence.getControls().add(controlMap.get(itemReference.getId())));
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRowControls.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRowControls.java
@@ -1,0 +1,40 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.navigation.Control;
+import fr.insee.eno.core.model.navigation.Loop;
+import fr.insee.eno.core.model.sequence.ItemReference;
+import fr.insee.eno.core.processing.ProcessingStep;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * In DDI, row-level controls (for dynamic tables lines or roundabout occurrences) are control construct references
+ * listed in the control construct references list in loop objects (more precisely in the virtual sequence that is
+ * associated with the loop).
+ * This processing step identifies these controls and marks them as "row" controls.
+ */
+public class DDIMarkRowControls implements ProcessingStep<EnoQuestionnaire> {
+
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        // index controls by id
+        Map<String, Control> controls = mapQuestionnaireControls(enoQuestionnaire);
+        // iterate on loop control references, to set the context of corresponding controls as "row"
+        enoQuestionnaire.getLoops().forEach(loop -> controlReferencesStream(loop)
+                .forEach(itemReference -> controls.get(itemReference.getId()).setContext(Control.Context.ROW))
+        );
+    }
+
+    static Map<String, Control> mapQuestionnaireControls(EnoQuestionnaire enoQuestionnaire) {
+        return enoQuestionnaire.getControls().stream().collect(Collectors.toMap(Control::getId, control -> control));
+    }
+
+    static Stream<ItemReference> controlReferencesStream(Loop loop) {
+        return loop.getLoopItems().stream()
+                .filter(itemReference -> ItemReference.ItemType.CONTROL.equals(itemReference.getType()));
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
@@ -2,6 +2,7 @@ package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.eno.core.exceptions.business.LunaticVariableConflictException;
 import fr.insee.eno.core.exceptions.technical.MappingException;
+import fr.insee.eno.core.mappers.LunaticMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.declaration.Instruction;
 import fr.insee.eno.core.model.navigation.Filter;
@@ -160,6 +161,13 @@ public class LunaticRoundaboutLoops implements ProcessingStep<Questionnaire> {
         lunaticRoundabout.getLabel().setValue(roundaboutSequence.getLabel().getValue());
         lunaticRoundabout.getLabel().setType(LabelTypeEnum.VTL_MD);
         lunaticRoundabout.setProgressVariable(progressVariableName);
+        //
+        LunaticMapper lunaticMapper = new LunaticMapper();
+        roundaboutSequence.getControls().forEach(enoControl -> {
+            ControlType lunaticControl = new ControlType();
+            lunaticMapper.mapEnoObject(enoControl, lunaticControl);
+            lunaticRoundabout.getControls().add(lunaticControl);
+        });
         //
         Roundabout.Item lunaticRoundaboutItem = new Roundabout.Item();
         lunaticRoundaboutItem.setLabel(new LabelType());

--- a/eno-core/src/main/java/fr/insee/eno/core/reference/EnoCatalog.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/reference/EnoCatalog.java
@@ -105,6 +105,9 @@ public class EnoCatalog {
         // Controls
         this.getQuestions().forEach(enoQuestion ->
                 labels.addAll(enoQuestion.getControls().stream().map(Control::getMessage).toList()));
+        enoQuestionnaire.getRoundaboutSequences().forEach(roundaboutSequence ->
+                labels.addAll(roundaboutSequence.getControls().stream()
+                        .map(Control::getMessage).filter(Objects::nonNull).toList()));
         // Cell label in no data cells
         enoQuestionnaire.getMultipleResponseQuestions().stream()
                 .filter(question -> question instanceof TableQuestion || question instanceof DynamicTableQuestion)

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/ControlTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/ddi/ControlTest.java
@@ -7,6 +7,7 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -14,42 +15,46 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ControlTest {
 
-    private Map<String, Control> controls;
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class IntegrationTest {
+        private Map<String, Control> controls;
 
-    @BeforeAll
-    void mapDDI() throws DDIParsingException {
-        //
-        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
-        DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
-                ControlTest.class.getClassLoader().getResourceAsStream("integration/ddi/ddi-controls.xml"));
-        //
-        DDIMapper ddiMapper = new DDIMapper();
-        ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
-        //
-        controls = new HashMap<>();
-        enoQuestionnaire.getControls().forEach(control -> controls.put(control.getId(), control));
-    }
+        @BeforeAll
+        void mapDDI() throws DDIParsingException {
+            //
+            EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+            DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
+                    ControlTest.class.getClassLoader().getResourceAsStream("integration/ddi/ddi-controls.xml"));
+            //
+            DDIMapper ddiMapper = new DDIMapper();
+            ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
+            //
+            controls = new HashMap<>();
+            enoQuestionnaire.getControls().forEach(control -> controls.put(control.getId(), control));
+        }
 
-    @Test
-    void controlsCount() {
-        assertEquals(3 , controls.size());
-    }
+        @Test
+        void controlsCount() {
+            assertEquals(3 , controls.size());
+        }
 
-    @Test
-    void typeOfControlTest() {
-        controls.values().forEach(control ->
-                assertEquals(Control.TypeOfControl.CONSISTENCY, control.getTypeOfControl()));
-    }
+        @Test
+        void typeOfControlTest() {
+            controls.values().forEach(control ->
+                    assertEquals(Control.TypeOfControl.CONSISTENCY, control.getTypeOfControl()));
+        }
 
-    @Test
-    void controlCriticalityTest() {
-        assertEquals(Control.Criticality.INFO, controls.get("ltx6cof9-CI-0").getCriticality());
-        assertEquals(Control.Criticality.WARN, controls.get("lu6xrmto-CI-0").getCriticality());
-        assertEquals(Control.Criticality.ERROR, controls.get("lu6y5e4z-CI-0").getCriticality());
+        @Test
+        void controlCriticalityTest() {
+            assertEquals(Control.Criticality.INFO, controls.get("ltx6cof9-CI-0").getCriticality());
+            assertEquals(Control.Criticality.WARN, controls.get("lu6xrmto-CI-0").getCriticality());
+            assertEquals(Control.Criticality.ERROR, controls.get("lu6y5e4z-CI-0").getCriticality());
+        }
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertControlsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertControlsTest.java
@@ -5,6 +5,7 @@ import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.model.question.Question;
+import fr.insee.eno.core.model.sequence.RoundaboutSequence;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import org.junit.jupiter.api.Test;
 
@@ -35,25 +36,43 @@ class DDIInsertControlsTest {
         assertTrue(questions.get(0).getControls().isEmpty());
         //
         assertEquals(1, questions.get(1).getControls().size());
-        assertEquals(Control.Criticality.INFO, questions.get(1).getControls().get(0).getCriticality());
+        assertEquals(Control.Criticality.INFO, questions.get(1).getControls().getFirst().getCriticality());
         //
         assertEquals(1, questions.get(2).getControls().size());
-        assertEquals(Control.Criticality.INFO, questions.get(2).getControls().get(0).getCriticality());
+        assertEquals(Control.Criticality.INFO, questions.get(2).getControls().getFirst().getCriticality());
         //
         assertEquals(2, questions.get(3).getControls().size());
         assertEquals(Control.Criticality.INFO, questions.get(3).getControls().get(0).getCriticality());
         assertEquals(Control.Criticality.INFO, questions.get(3).getControls().get(1).getCriticality());
         //
         assertEquals(1, questions.get(4).getControls().size());
-        assertEquals(Control.Criticality.INFO, questions.get(4).getControls().get(0).getCriticality());
+        assertEquals(Control.Criticality.INFO, questions.get(4).getControls().getFirst().getCriticality());
         //
         assertEquals(1, questions.get(5).getControls().size());
-        assertEquals(Control.Criticality.INFO, questions.get(5).getControls().get(0).getCriticality());
+        assertEquals(Control.Criticality.INFO, questions.get(5).getControls().getFirst().getCriticality());
         //
         assertEquals(1, questions.get(6).getControls().size());
-        assertEquals(Control.Criticality.INFO, questions.get(6).getControls().get(0).getCriticality());
+        assertEquals(Control.Criticality.INFO, questions.get(6).getControls().getFirst().getCriticality());
         //
         assertTrue(questions.get(7).getControls().isEmpty());
+    }
+
+    @Test
+    void questionnaireWithRoundabout() throws DDIParsingException {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        DDIMapper ddiMapper = new DDIMapper();
+        ddiMapper.mapDDI(
+                DDIDeserializer.deserialize(this.getClass().getClassLoader().getResourceAsStream(
+                        "integration/ddi/ddi-roundabout-controls.xml")),
+                enoQuestionnaire);
+
+        //
+        new DDIInsertControls().apply(enoQuestionnaire);
+
+        //
+        RoundaboutSequence roundaboutSequence = enoQuestionnaire.getRoundaboutSequences().getFirst();
+        assertEquals(2, roundaboutSequence.getControls().size());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRowControlsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRowControlsTest.java
@@ -1,0 +1,41 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.ddi.lifecycle33.instance.DDIInstanceDocument;
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.DDIMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.navigation.Control;
+import fr.insee.eno.core.serialize.DDIDeserializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DDIMarkRowControlsTest {
+
+    @Test
+    void roundaboutLevelControls() throws DDIParsingException {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        DDIInstanceDocument ddiInstance = DDIDeserializer.deserialize(
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "integration/ddi/ddi-roundabout-controls.xml"));
+        //
+        DDIMapper ddiMapper = new DDIMapper();
+        ddiMapper.mapDDI(ddiInstance, enoQuestionnaire);
+
+        // When
+        new DDIMarkRowControls().apply(enoQuestionnaire);
+
+        // Then
+        // The questionnaire should have two controls (that are created for a roundabout)
+        assertEquals(2, enoQuestionnaire.getControls().size());
+        assertTrue(enoQuestionnaire.getControls().stream().anyMatch(control ->
+                Control.Context.SIMPLE.equals(control.getContext())
+        ));
+        assertTrue(enoQuestionnaire.getControls().stream().anyMatch(control ->
+                Control.Context.ROW.equals(control.getContext())
+        ));
+    }
+
+}

--- a/eno-core/src/test/resources/integration/ddi/ddi-roundabout-controls.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-roundabout-controls.xml
@@ -1,0 +1,824 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+             xmlns:a="ddi:archive:3_3"
+             xmlns:d="ddi:datacollection:3_3"
+             xmlns:g="ddi:group:3_3"
+             xmlns:l="ddi:logicalproduct:3_3"
+             xmlns:r="ddi:reusable:3_3"
+             xmlns:s="ddi:studyunit:3_3"
+             xmlns:xhtml="http://www.w3.org/1999/xhtml"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+             isMaintainable="true"><!--Eno version : 2.10.2. Generation date : 28/10/2024 - 16:21:36-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-m2t7iyrt</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Roundabout controls</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-m2t7iyrt</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-OL</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">loop.instanceLabel</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Question 1 answer: " || ¤m2t83bbq-QOP-m2t8dmam¤ </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>m2t83bbq-QOP-m2t8dmam</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-CI-0-II-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">warning</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"There is less than 3 answers in the roundabout."</d:Text>
+               </d:LiteralText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-CI-1-II-1</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">warning</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Occurrence with question 1 = '" || ¤m2t83bbq-QOP-m2t8dmam¤ || "' answered 'bar' at question 2." </d:Text>
+               </d:LiteralText>
+               <d:ConditionalText>
+                  <r:SourceParameterReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>m2t83bbq-QOP-m2t8dmam</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                  </r:SourceParameterReference>
+               </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-m2t7iyrt</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Roundabout controls</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7t4yz</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Loop</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8ns57</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7o6y7</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence (main loop)"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t83bbq-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7urpg</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S2</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence (roundabout)"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7kage-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t8ns57</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S_LAST</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Last sequence"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8grnt-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Roundabout on S2"</r:Content>
+            </r:Label>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-OL</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">roundabout</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-ROUNDABOUT_LOOP</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Loop</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-CI-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>ComputationItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Loop>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7t4yz</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">MAIN_LOOP</r:String>
+            </d:ConstructName>
+            <d:InitialValue>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:CommandContent>1</r:CommandContent>
+               </r:Command>
+            </d:InitialValue>
+            <d:LoopWhile>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:CommandContent>5</r:CommandContent>
+               </r:Command>
+            </d:LoopWhile>
+            <d:StepValue>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:CommandContent>1</r:CommandContent>
+               </r:Command>
+            </d:StepValue>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7t4yz-SEQ</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Loop>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7t4yz-SEQ</r:ID>
+            <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7o6y7</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Loop>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-ROUNDABOUT_LOOP</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">ROUNDABOUT_LOOP</r:String>
+            </d:ConstructName>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-ROUNDABOUT_LOOP-SEQ</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Loop>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-ROUNDABOUT_LOOP-SEQ</r:ID>
+            <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7urpg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-CI-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>ComputationItem</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t83bbq-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t83bbq</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7kage-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7kage</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t8grnt-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q_LAST</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8grnt</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:ComputationItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-CI-0</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">"Roundabout-level control"</r:String>
+            </d:ConstructName>
+            <r:Description>
+               <r:Content xml:lang="fr-FR">"Roundabout-level control"</r:Content>
+            </r:Description>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-CI-0-II-0</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfComputationItem controlledVocabularyID="INSEE-TOCI-CL-1">informational</d:TypeOfComputationItem>
+            <r:CommandCode>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:InParameter isArray="false">
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>m2t82uvw-CI-0-IP-1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:ParameterName>
+                        <r:String xml:lang="fr-FR">Q2</r:String>
+                     </r:ParameterName>
+                  </r:InParameter>
+                  <r:Binding>
+                     <r:SourceParameterReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>m2t7kage-QOP-m2t8a82i</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                     </r:SourceParameterReference>
+                     <r:TargetParameterReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>m2t82uvw-CI-0-IP-1</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>InParameter</r:TypeOfObject>
+                     </r:TargetParameterReference>
+                  </r:Binding>
+                  <r:CommandContent>sum(m2t82uvw-CI-0-IP-1) &lt;= 3</r:CommandContent>
+               </r:Command>
+            </r:CommandCode>
+         </d:ComputationItem>
+         <d:ComputationItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t82uvw-CI-1</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">"Occurrence-level control"</r:String>
+            </d:ConstructName>
+            <r:Description>
+               <r:Content xml:lang="fr-FR">"Occurrence-level control"</r:Content>
+            </r:Description>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t82uvw-CI-1-II-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:TypeOfComputationItem controlledVocabularyID="INSEE-TOCI-CL-1">informational</d:TypeOfComputationItem>
+            <r:CommandCode>
+               <r:Command>
+                  <r:ProgramLanguage>vtl</r:ProgramLanguage>
+                  <r:InParameter isArray="false">
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>m2t82uvw-CI-1-IP-1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:ParameterName>
+                        <r:String xml:lang="fr-FR">Q2</r:String>
+                     </r:ParameterName>
+                  </r:InParameter>
+                  <r:Binding>
+                     <r:SourceParameterReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>m2t7kage-QOP-m2t8a82i</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>OutParameter</r:TypeOfObject>
+                     </r:SourceParameterReference>
+                     <r:TargetParameterReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>m2t82uvw-CI-1-IP-1</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>InParameter</r:TypeOfObject>
+                     </r:TargetParameterReference>
+                  </r:Binding>
+                  <r:CommandContent>m2t82uvw-CI-1-IP-1 = "bar"</r:CommandContent>
+               </r:Command>
+            </r:CommandCode>
+         </d:ComputationItem>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t83bbq</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t83bbq-QOP-m2t8dmam</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q1</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t83bbq-RDOP-m2t8dmam</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t83bbq-QOP-m2t8dmam</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Question 1"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t83bbq-RDOP-m2t8dmam</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7kage</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7kage-QOP-m2t8a82i</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q2</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t7kage-RDOP-m2t8a82i</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t7kage-QOP-m2t8a82i</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Question 2"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t7kage-RDOP-m2t8a82i</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t8grnt</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q_LAST</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8grnt-QOP-m2t8h4yv</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q_LAST</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t8grnt-RDOP-m2t8h4yv</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t8grnt-QOP-m2t8h4yv</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Last question"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t8grnt-RDOP-m2t8h4yv</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENO_ROUNDABOUT_CONTROLS-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENO_ROUNDABOUT_CONTROLS</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7w51m</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q1</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q1 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t83bbq-QOP-m2t8dmam</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t83bbq</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t84knv</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q2</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q2 label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7kage-QOP-m2t8a82i</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7kage</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t8b1xv</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q_LAST</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q_LAST label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8grnt-QOP-m2t8h4yv</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8grnt</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m2t7t4yz-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t7t4yz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Loop</r:TypeOfObject>
+               </r:BasedOnReference>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m2t82uvw-ROUNDABOUT_LOOP</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Loop</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Loop</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>MAIN_LOOP</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7w51m</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t84knv</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-m2t7iyrt-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-m2t7iyrt</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENO_ROUNDABOUT_CONTROLS</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t8b1xv</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <l:VariableGroupReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m2t7t4yz-vg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+            </l:VariableGroupReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+                            l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-m2t7iyrt</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-m2t7iyrt</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-m2t7iyrt</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-m2t7iyrt</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-m2t7iyrt</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-m2t7iyrt</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                          xmlns:cm="ddi:comparative:3_3"
+                          xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                          xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-m2t7iyrt</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENO_ROUNDABOUT_CONTROLS</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Roundabout controls questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-m2t7iyrt</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>

--- a/eno-core/src/test/resources/integration/pogues/pogues-roundabout-controls.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-roundabout-controls.json
@@ -1,0 +1,339 @@
+{
+  "id": "m2t7iyrt",
+  "Name": "ENO_ROUNDABOUT_CONTROLS",
+  "Child": [
+    {
+      "id": "m2t7o6y7",
+      "Name": "S1",
+      "type": "SequenceType",
+      "Child": [
+        {
+          "id": "m2t83bbq",
+          "Name": "Q1",
+          "type": "QuestionType",
+          "Label": [
+            "\"Question 1\""
+          ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "m2t8dmam",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 249
+              },
+              "mandatory": false,
+              "CollectedVariableReference": "m2t7w51m"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [],
+          "questionType": "SIMPLE"
+        }
+      ],
+      "Label": [
+        "\"Sequence (main loop)\""
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "m2t82uvw",
+      "Loop": {
+        "Name": "ROUNDABOUT_LOOP",
+        "MemberReference": [
+          "m2t7urpg",
+          "m2t7urpg"
+        ],
+        "IterableReference": "m2t7t4yz"
+      },
+      "Name": "ROUNDABOUT",
+      "type": "RoundaboutType",
+      "Label": [
+        "\"Roundabout on S2\""
+      ],
+      "depth": 1,
+      "Locked": false,
+      "Control": [
+        {
+          "id": "m2t88c01",
+          "scope": false,
+          "criticity": "INFO",
+          "Expression": "sum($Q2$) <= 3",
+          "Description": "\"Roundabout-level control\"",
+          "FailMessage": "\"There is less than 3 answers in the roundabout.\"",
+          "post_collect": false,
+          "during_collect": false
+        },
+        {
+          "id": "m2t883p8",
+          "scope": "occurrence",
+          "criticity": "INFO",
+          "Expression": "$Q2$ = \"bar\"",
+          "Description": "\"Occurrence-level control\"",
+          "FailMessage": "\"Occurrence with question 1 = '\" || $Q1$ || \"' answered 'bar' at question 2.\"",
+          "post_collect": false,
+          "during_collect": false
+        }
+      ],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "OccurrenceLabel": "\"Question 1 answer: \" || $Q1$",
+      "OccurrenceDescription": ""
+    },
+    {
+      "id": "m2t7urpg",
+      "Name": "S2",
+      "type": "SequenceType",
+      "Child": [
+        {
+          "id": "m2t7kage",
+          "Name": "Q2",
+          "type": "QuestionType",
+          "Label": [
+            "\"Question 2\""
+          ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "m2t8a82i",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 249
+              },
+              "mandatory": false,
+              "CollectedVariableReference": "m2t84knv"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [],
+          "questionType": "SIMPLE"
+        }
+      ],
+      "Label": [
+        "\"Sequence (roundabout)\""
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "m2t8ns57",
+      "Name": "S_LAST",
+      "type": "SequenceType",
+      "Child": [
+        {
+          "id": "m2t8grnt",
+          "Name": "Q_LAST",
+          "type": "QuestionType",
+          "Label": [
+            "\"Last question\""
+          ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "m2t8hr0x",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 249
+              },
+              "mandatory": false,
+              "CollectedVariableReference": "m2t8b1xv"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [],
+          "questionType": "SIMPLE"
+        }
+      ],
+      "Label": [
+        "\"Last sequence\""
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "idendquest",
+      "Name": "QUESTIONNAIRE_END",
+      "type": "SequenceType",
+      "Child": [],
+      "Label": [
+        "QUESTIONNAIRE_END"
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    }
+  ],
+  "Label": [
+    "Eno - Roundabout controls"
+  ],
+  "final": false,
+  "owner": "ENO-INTEGRATION-TESTS",
+  "agency": "fr.insee",
+  "CodeLists": {
+    "CodeList": []
+  },
+  "Variables": {
+    "Variable": [
+      {
+        "id": "m2t7w51m",
+        "Name": "Q1",
+        "type": "CollectedVariableType",
+        "Label": "Q1 label",
+        "Scope": "m2t7t4yz",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 249
+        }
+      },
+      {
+        "id": "m2t84knv",
+        "Name": "Q2",
+        "type": "CollectedVariableType",
+        "Label": "Q2 label",
+        "Scope": "m2t7t4yz",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 249
+        }
+      },
+      {
+        "id": "m2t8b1xv",
+        "Name": "Q_LAST",
+        "type": "CollectedVariableType",
+        "Label": "Q_LAST label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 249
+        }
+      }
+    ]
+  },
+  "flowLogic": "FILTER",
+  "Iterations": {
+    "Iteration": [
+      {
+        "id": "m2t7t4yz",
+        "Name": "MAIN_LOOP",
+        "Step": "1",
+        "type": "DynamicIterationType",
+        "Maximum": "5",
+        "Minimum": "1",
+        "MemberReference": [
+          "m2t7o6y7",
+          "m2t7o6y7"
+        ]
+      }
+    ]
+  },
+  "TargetMode": [
+    "CAPI",
+    "CATI",
+    "CAWI",
+    "PAPI"
+  ],
+  "FlowControl": [],
+  "genericName": "QUESTIONNAIRE",
+  "ComponentGroup": [
+    {
+      "id": "m2t7zd6c",
+      "Name": "PAGE_1",
+      "Label": [
+        "Components for page 1"
+      ],
+      "MemberReference": [
+        "m2t7o6y7",
+        "m2t83bbq",
+        "m2t7urpg",
+        "m2t7kage",
+        "idendquest",
+        "m2t8ns57",
+        "m2t8grnt"
+      ]
+    }
+  ],
+  "DataCollection": [
+    {
+      "id": "s2106-dc",
+      "uri": "http://ddi:fr.insee:DataCollection.s2106-dc",
+      "Name": "Enquête capacité à innover et stratégie 2022"
+    }
+  ],
+  "lastUpdatedDate": "Mon Oct 28 2024 17:21:33 GMT+0100 (heure normale d’Europe centrale)",
+  "formulasLanguage": "VTL",
+  "childQuestionnaireRef": []
+}


### PR DESCRIPTION
- #1119 

Todo : j'ai la doc mais à intégrer et push

- #1120 

Questionnaire de test d'intégration `ddi-roundabout-controls.xml` et la source `pogues-roundabout-controls.json`

- #1121 

Il a fallu modifier les processing steps côté lecture DDI pour prendre en compte les control construct references des contrôles de rondpoint.

Plus léger sur la partie Lunatic où il a suffit de mapper les contrôles dans le composant `"Roundabout"` (fait en réutilisant le mapper).
