### PR TITLE
fix: roundabout controls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.28.0-SNAPSHOT"
+    version = "3.28.0-SNAPSHOT.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/sequence/RoundaboutSequence.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/sequence/RoundaboutSequence.java
@@ -1,15 +1,18 @@
 package fr.insee.eno.core.model.sequence;
 
+import fr.insee.ddi.lifecycle33.datacollection.ComputationItemType;
 import fr.insee.ddi.lifecycle33.datacollection.SequenceType;
 import fr.insee.eno.core.annotations.Contexts.Context;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.model.navigation.Control;
 import fr.insee.eno.core.parameter.Format;
+import fr.insee.eno.core.reference.DDIIndex;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Special kind of sequence that describes a "roundabout".
@@ -22,6 +25,8 @@ import java.util.List;
 @Context(format = Format.DDI, type = SequenceType.class)
 public class RoundaboutSequence extends AbstractSequence {
 
+    private static final String DDI_LOCKED_CONTROL_TYPE = "roundabout-locked";
+
     /** DDI reference of the loop.
      * Note: mapped as the id of the first control construct reference. */
     @DDI("getControlConstructReferenceArray(0).getIDArray(0).getStringValue()")
@@ -29,7 +34,7 @@ public class RoundaboutSequence extends AbstractSequence {
 
     /** Boolean that describes if the completed occurrences should be locked or not.
      * In DDI, this is modeled by the presence or not of a ComputationItem among the control construct references. */
-    @DDI("!getControlConstructReferenceList().?[#this.getTypeOfObject().toString() == 'ComputationItem'].isEmpty()")
+    @DDI("T(fr.insee.eno.core.model.sequence.RoundaboutSequence).ddiLockedProperty(#this, #index)")
     private Boolean locked;
 
     /**
@@ -40,5 +45,16 @@ public class RoundaboutSequence extends AbstractSequence {
      * @see fr.insee.eno.core.processing.out.steps.lunatic.LunaticRoundaboutLoops
      */
     private List<Control> controls = new ArrayList<>();
+
+    public static boolean ddiLockedProperty(SequenceType ddiRoundaboutSequence, DDIIndex ddiIndex) {
+        return ddiRoundaboutSequence.getControlConstructReferenceList().stream()
+                .filter(reference -> "ComputationItem".equals(reference.getTypeOfObject().toString()))
+                .map(reference -> ddiIndex.get(reference.getIDArray(0).getStringValue()))
+                .filter(Objects::nonNull)
+                .filter(ComputationItemType.class::isInstance)
+                .map(ComputationItemType.class::cast)
+                .anyMatch(computationItem ->
+                        DDI_LOCKED_CONTROL_TYPE.equals(computationItem.getTypeOfComputationItem().getStringValue()));
+    }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabel.java
@@ -1,6 +1,7 @@
 package fr.insee.eno.core.processing.out.steps.lunatic;
 
 import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.eno.core.utils.VtlSyntaxUtils;
 import fr.insee.lunatic.model.flat.*;
 
 import java.util.Collection;
@@ -27,7 +28,7 @@ public class LunaticReverseConsistencyControlLabel implements ProcessingStep<Que
                 .filter(control -> control.getTypeOfControl().equals(ControlTypeEnum.CONSISTENCY))
                 .forEach(control -> {
                     LabelType label = control.getControl();
-                    label.setValue("not(" + label.getValue() + ")");
+                    label.setValue(VtlSyntaxUtils.invertBooleanExpression(label.getValue()));
                 });
 
         components.stream()
@@ -35,4 +36,5 @@ public class LunaticReverseConsistencyControlLabel implements ProcessingStep<Que
                 .map(ComponentNestingType.class::cast)
                 .forEach(componentNesting -> processComponents(componentNesting.getComponents()));
     }
+
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoops.java
@@ -9,6 +9,7 @@ import fr.insee.eno.core.model.navigation.Filter;
 import fr.insee.eno.core.model.navigation.LinkedLoop;
 import fr.insee.eno.core.model.sequence.RoundaboutSequence;
 import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.eno.core.utils.VtlSyntaxUtils;
 import fr.insee.lunatic.model.flat.*;
 import fr.insee.lunatic.model.flat.variable.CollectedVariableType;
 import fr.insee.lunatic.model.flat.variable.CollectedVariableValues;
@@ -167,6 +168,9 @@ public class LunaticRoundaboutLoops implements ProcessingStep<Questionnaire> {
             ControlType lunaticControl = new ControlType();
             lunaticMapper.mapEnoObject(enoControl, lunaticControl);
             lunaticRoundabout.getControls().add(lunaticControl);
+            // Control expressions have to be inverted in Lunatic
+            lunaticControl.getControl().setValue(
+                    VtlSyntaxUtils.invertBooleanExpression(lunaticControl.getControl().getValue()));
         });
         //
         Roundabout.Item lunaticRoundaboutItem = new Roundabout.Item();

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -221,7 +221,7 @@ class LunaticRoundaboutLoopsTest {
                     .toList();
             assertEquals(1, roundaboutControls.size());
             ControlType roundaboutControl = roundaboutControls.getFirst();
-            assertEquals("count(Q2) < 3", roundaboutControl.getControl().getValue());
+            assertEquals("not(count(Q2) < 3)", roundaboutControl.getControl().getValue());
             assertEquals(LabelTypeEnum.VTL, roundaboutControl.getControl().getType());
             assertEquals("\"There is less than 3 answers in the roundabout.\"",
                     roundaboutControl.getErrorMessage().getValue());
@@ -237,7 +237,7 @@ class LunaticRoundaboutLoopsTest {
                     .toList();
             assertEquals(1, occurrenceControls.size());
             ControlType occurrenceControl = occurrenceControls.getFirst();
-            assertEquals("Q2 = \"bar\"", occurrenceControl.getControl().getValue());
+            assertEquals("not(Q2 = \"bar\")", occurrenceControl.getControl().getValue());
             assertEquals(LabelTypeEnum.VTL, occurrenceControl.getControl().getType());
             assertEquals("\"Occurrence with question 1 = '\" || Q1 || \"' answered 'bar' at question 2.\"",
                     occurrenceControl.getErrorMessage().getValue().stripTrailing());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -210,6 +210,11 @@ class LunaticRoundaboutLoopsTest {
         }
 
         @Test
+        void lockedPropertyTest() {
+            assertFalse(roundabout.getLocked());
+        }
+
+        @Test
         void controlsCount() {
             assertEquals(2, roundabout.getControls().size());
         }


### PR DESCRIPTION
## Summary

- https://github.com/InseeFr/Concevoir-Workplace/issues/41#issuecomment-2461818639

## Done

- Il y avait bien un problème sur la property Lunatic `locked` en présence de contrôles sur un rondpoint : la property était à `true` même si non cochée dans Pogues. La raison : cette information est modélisée comme un type spécial de contrôle en DDI, avoir d'autres contrôles a nécessité un mapping un peu plus fin pour ne pas mélanger ce type de contrôle avec les autres.
- Les contrôles sont inversés entre DDI et Lunatic, cette inversion n'était pas appliquée sur les contrôles de rondpoint. C'est corrigé.
