### PR TITLE
fix: duration components in resizing

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -117,8 +117,8 @@ public class LunaticUtils {
         List<String> result = new ArrayList<>();
         loop.getComponents().forEach(component -> {
             switch (component.getComponentType()) {
-                case CHECKBOX_BOOLEAN, INPUT_NUMBER, INPUT, TEXTAREA, DATEPICKER, RADIO, CHECKBOX_ONE, DROPDOWN,
-                        CHECKBOX_GROUP, TABLE ->
+                case CHECKBOX_BOOLEAN, INPUT_NUMBER, INPUT, TEXTAREA, DATEPICKER, DURATION, RADIO,
+                        CHECKBOX_ONE, DROPDOWN, CHECKBOX_GROUP, TABLE ->
                         result.addAll(getDirectResponseNames(component));
                 case ROSTER_FOR_LOOP ->
                         throw new LunaticLoopException(String.format(
@@ -133,8 +133,8 @@ public class LunaticUtils {
                                 "Pairwise components are forbidden in loops: loop '%s' contains a pairwise component.",
                                 loop.getId()));
                 default ->
-                        log.debug("(Variables in Lunatic loop) Component of type {} has no response.",
-                                component.getComponentType());
+                        throw new IllegalArgumentException(
+                                "Unexpected component type '" + component.getComponentType() + "'.");
             }
         });
         return result;

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/LunaticUtils.java
@@ -117,9 +117,13 @@ public class LunaticUtils {
         List<String> result = new ArrayList<>();
         loop.getComponents().forEach(component -> {
             switch (component.getComponentType()) {
-                case CHECKBOX_BOOLEAN, INPUT_NUMBER, INPUT, TEXTAREA, DATEPICKER, DURATION, RADIO,
+                case CHECKBOX_BOOLEAN, INPUT_NUMBER, INPUT, TEXTAREA, SUGGESTER, DATEPICKER, DURATION, RADIO,
                         CHECKBOX_ONE, DROPDOWN, CHECKBOX_GROUP, TABLE ->
                         result.addAll(getDirectResponseNames(component));
+                case QUESTIONNAIRE, SEQUENCE, SUBSEQUENCE, TEXT, ACCORDION ->
+                        doNothing();
+                case QUESTION ->
+                        throw new IllegalStateException("This method does not support the question component.");
                 case ROSTER_FOR_LOOP ->
                         throw new LunaticLoopException(String.format(
                                 "Dynamic tables are forbidden in loops: loop '%s' contains a dynamic table.",
@@ -132,12 +136,13 @@ public class LunaticUtils {
                         throw new LunaticLoopException(String.format(
                                 "Pairwise components are forbidden in loops: loop '%s' contains a pairwise component.",
                                 loop.getId()));
-                default ->
-                        throw new IllegalArgumentException(
-                                "Unexpected component type '" + component.getComponentType() + "'.");
             }
         });
         return result;
+    }
+
+    private static void doNothing() {
+        /* No-op method */
     }
 
     /**

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
@@ -136,6 +136,11 @@ class LunaticLoopResizingLogicTest {
         datepicker.setResponse(new ResponseType());
         datepicker.getResponse().setName("DATE_VAR");
         lunaticLoop.getComponents().add(datepicker);
+        Duration duration = new Duration();
+        duration.setComponentType(ComponentTypeEnum.DURATION);
+        duration.setResponse(new ResponseType());
+        duration.getResponse().setName("DURATION_VAR");
+        lunaticLoop.getComponents().add(duration);
         Dropdown dropdown = new Dropdown();
         dropdown.setComponentType(ComponentTypeEnum.DROPDOWN);
         dropdown.setResponse(new ResponseType());
@@ -160,7 +165,7 @@ class LunaticLoopResizingLogicTest {
         // Then
         assertThat(lunaticResizing.getResizingEntry("LOOP_SIZE_VAR").getVariables())
                 .containsExactlyInAnyOrderElementsOf(Set.of(
-                        "BOOLEAN_VAR", "INPUT_VAR", "TEXT_VAR", "NUMBER_VAR", "DATE_VAR",
+                        "BOOLEAN_VAR", "INPUT_VAR", "TEXT_VAR", "NUMBER_VAR", "DATE_VAR", "DURATION_VAR",
                         "DROPDOWN_VAR", "RADIO_VAR", "CHECKBOX_VAR"));
     }
 

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
@@ -121,6 +121,10 @@ class LunaticLoopResizingLogicTest {
         input.setResponse(new ResponseType());
         input.getResponse().setName("INPUT_VAR");
         lunaticLoop.getComponents().add(input);
+        Suggester suggester = new Suggester(); // The suggester component type is set by the constructor
+        suggester.setResponse(new ResponseType());
+        suggester.getResponse().setName("SUGGESTER_VAR");
+        lunaticLoop.getComponents().add(suggester);
         Textarea textarea = new Textarea();
         textarea.setComponentType(ComponentTypeEnum.TEXTAREA);
         textarea.setResponse(new ResponseType());
@@ -165,8 +169,8 @@ class LunaticLoopResizingLogicTest {
         // Then
         assertThat(lunaticResizing.getResizingEntry("LOOP_SIZE_VAR").getVariables())
                 .containsExactlyInAnyOrderElementsOf(Set.of(
-                        "BOOLEAN_VAR", "INPUT_VAR", "TEXT_VAR", "NUMBER_VAR", "DATE_VAR", "DURATION_VAR",
-                        "DROPDOWN_VAR", "RADIO_VAR", "CHECKBOX_VAR"));
+                        "BOOLEAN_VAR", "INPUT_VAR", "SUGGESTER_VAR", "TEXT_VAR", "NUMBER_VAR",
+                        "DATE_VAR", "DURATION_VAR", "DROPDOWN_VAR", "RADIO_VAR", "CHECKBOX_VAR"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- #1157 

## Done

Les composants de type `DURATION` étaient ignorés dans la méthode des `LunaticUtils` qui va chercher la liste des réponses d'une boucle.

L'erreur était silencieuse car le cas `default` dans le switch d'une des méthodes se contentait d'un `log.debug` 😶 

---

**NB** : Les composants de type `SUGGESTER` étaient ignorés aussi. On avait donc le même bug pour les suggester saisis depuis Pogues dans une boucle. Mais ça ne concerne pas les suggester créés avec un traitement spécifique (le cas le plus utilisé aujourd'hui encore j'imagine).

C'est corrigé au passage.