### PR TITLE
fix(hotfix): vtl inversion regression

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Get previous final release tag
         id: previousTag
-        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[3-9]\.[0-9]\+\.[0-9]\+$" | tail -1)" >> $GITHUB_OUTPUT
+        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[3-9]\.[0-9]+\.[0-9]+(-hotfix\.\d+)?$" | tail -1)" >> $GITHUB_OUTPUT
         # Note: the regex works for single digit major version, to be updated if the version goes 10.0.0 or more
 
       - name: Create tag

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.29.0"
+    version = "3.29.0-hotfix.1"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.sonarqube.gradle.SonarTask
 
 plugins {
-    id("org.springframework.boot") version "3.3.5" apply false
+    id("org.springframework.boot") version "3.4.0" apply false
     id("io.spring.dependency-management") version "1.1.6" apply false
     id("application")
     id("jacoco-report-aggregation")

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/VtlSyntaxUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/VtlSyntaxUtils.java
@@ -24,17 +24,12 @@ public class VtlSyntaxUtils {
 
     /**
      * Inverts the given expression (which is supposed to be a VTL expression that returns a boolean)
-     * by adding a 'not()' around it, or eventually removing one if the entire expression is in a "not".
+     * by adding a 'not()' around it.
      * @param expression VTL boolean expression.
      * @return The inverted VTL expression.
      */
     public static String invertBooleanExpression(String expression) {
-        String trimmed = expression.trim();
-        // If the whole expression is within a not(), remove it
-        if (trimmed.startsWith("not(") && trimmed.endsWith(")"))
-            return trimmed.substring(4, trimmed.length() - 1);
-        // Otherwise, add a not() around the expression
-        return "not(" + trimmed + ")";
+        return "not(" + expression + ")";
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFiltersTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIMarkRoundaboutFiltersTest.java
@@ -27,7 +27,7 @@ class DDIMarkRoundaboutFiltersTest {
         assertEquals(1, enoQuestionnaire.getFilters().size());
         Filter enoFilter = enoQuestionnaire.getFilters().getFirst();
         assertTrue(enoFilter.isRoundaboutFilter());
-        assertFalse(enoFilter.getExpression().getValue().startsWith("not"));
+        assertTrue(enoFilter.getExpression().getValue().startsWith("not"));
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -80,7 +80,7 @@ class LunaticRoundaboutLoopsTest {
             assertEquals("\"Occurrence description of \" || FIRST_NAME",
                     roundaboutItem.getDescription().getValue().stripTrailing());
             assertEquals(LabelTypeEnum.VTL_MD, roundaboutItem.getDescription().getType());
-            assertEquals("FIRST_NAME <> FIRST_NAME_REF",
+            assertEquals("not(not(FIRST_NAME <> FIRST_NAME_REF))",
                     roundaboutItem.getDisabled().getValue().stripTrailing());
             assertEquals(LabelTypeEnum.VTL, roundaboutItem.getDisabled().getType());
         }

--- a/eno-core/src/test/java/fr/insee/eno/core/utils/VtlSyntaxUtilsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/utils/VtlSyntaxUtilsTest.java
@@ -8,10 +8,10 @@ class VtlSyntaxUtilsTest {
 
     @Test
     void invertExpressions() {
-        assertEquals("FOO", VtlSyntaxUtils.invertBooleanExpression("not(FOO)"));
+        assertEquals("not(not(FOO))", VtlSyntaxUtils.invertBooleanExpression("not(FOO)"));
         assertEquals("not(FOO)", VtlSyntaxUtils.invertBooleanExpression("FOO"));
-        assertEquals("not(FOO)", VtlSyntaxUtils.invertBooleanExpression("not(not(FOO))"));
-        assertEquals("FOO = 1", VtlSyntaxUtils.invertBooleanExpression("not(FOO = 1)"));
+        assertEquals("not(not(not(FOO)))", VtlSyntaxUtils.invertBooleanExpression("not(not(FOO))"));
+        assertEquals("not(FOO = 1)", VtlSyntaxUtils.invertBooleanExpression("not(FOO = 1)"));
         assertEquals("not(FOO = 1)", VtlSyntaxUtils.invertBooleanExpression("FOO = 1"));
     }
 


### PR DESCRIPTION
## Contexte

Ce commit : 608fcac2f487d6f1a05ebbfc3f3067f868dc34ed (correction sur les contrôles de rondpoint) introduit une grave régression sur l'inversion des expressions VTL dans Eno.

_Rappel_ : Les contrôles saisis dans Pogues sont inversés dans Lunatic, c'est fait au moment de la transfo DDI -> Lunatic.

En appliquant l'inversion sur les contrôles de rondpoint, j'avais dé-dupliquer le code qui inverse les expressions VTL, **mais** la méthode que j'ai conservée a un problème de logique, exemple : 

`not(condition A) and not(condition B)` devient `(condition A) and not(condition B` => ❌ 💀 

## Fait

Correction de la méthode qui inverse les expressions VTL pour simplement ajouter un "`not(...)`" autour de l'expression initiale.
