### PR TITLE
refactor: improve exception handling in ddi insert labels step

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/model/code/CodeList.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/code/CodeList.java
@@ -134,4 +134,11 @@ public class CodeList extends EnoIdentifiableObject {
         }
     }
 
+    @Override
+    public String toString() {
+        return "CodeList[" +
+                "id='" + this.getId() + '\'' +
+                ", name='" + name + '\'' +
+                ']';
+    }
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/Question.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/Question.java
@@ -57,7 +57,7 @@ public abstract class Question extends EnoIdentifiableObject implements EnoCompo
 
     @Override
     public String toString() {
-        return this.getClass() + "[id="+this.getId()+", name="+getName()+"]";
+        return this.getClass().getSimpleName() + "[id="+this.getId()+", name="+getName()+"]";
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabels.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabels.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.processing.in.steps.ddi;
 
+import fr.insee.eno.core.exceptions.business.IllegalDDIElementException;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.code.CodeItem;
 import fr.insee.eno.core.model.code.CodeList;
@@ -37,7 +38,14 @@ public class DDIInsertMultipleChoiceLabels implements ProcessingStep<EnoQuestion
 
     private void insertModalityLabels(SimpleMultipleChoiceQuestion simpleMultipleChoiceQuestion) {
         CodeList codeList = codeListMap.get(simpleMultipleChoiceQuestion.getCodeListReference());
-        for (int i = 0; i < codeList.size(); i ++) {
+        int codeListSize = codeList.size();
+        int responsesSize = simpleMultipleChoiceQuestion.getCodeResponses().size();
+        if (codeListSize != responsesSize)
+            throw new IllegalDDIElementException(String.format(
+                    "Code list '%s' (id=%s) has %s codes, and is used in multiple choice question '%s' (id=%s) that has %s responses.",
+                    codeList.getName(), codeList.getId(), codeListSize,
+                    simpleMultipleChoiceQuestion.getName(), simpleMultipleChoiceQuestion.getId(), responsesSize));
+        for (int i = 0; i < codeListSize; i ++) {
             CodeItem codeItem = codeList.getCodeItems().get(i);
             CodeResponse codeResponse = simpleMultipleChoiceQuestion.getCodeResponses().get(i);
             codeResponse.setLabel(codeItem.getLabel());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabelsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertMultipleChoiceLabelsTest.java
@@ -2,17 +2,50 @@ package fr.insee.eno.core.processing.in.steps.ddi;
 
 import fr.insee.ddi.lifecycle33.instance.DDIInstanceDocument;
 import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.exceptions.business.IllegalDDIElementException;
 import fr.insee.eno.core.mappers.DDIMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.code.CodeItem;
+import fr.insee.eno.core.model.code.CodeList;
 import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import fr.insee.eno.core.model.response.CodeResponse;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DDIInsertMultipleChoiceLabelsTest {
+
+    @Test
+    void failingCase_tooManyCodes() {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        CodeList codeList = new CodeList();
+        codeList.setId("code-list-id");
+        codeList.setName("CODE_LIST_NAME");
+        codeList.getCodeItems().add(new CodeItem());
+        codeList.getCodeItems().add(new CodeItem());
+        enoQuestionnaire.getCodeLists().add(codeList);
+        //
+        SimpleMultipleChoiceQuestion simpleMCQ = new SimpleMultipleChoiceQuestion();
+        simpleMCQ.setId("question-id");
+        simpleMCQ.setName("QUESTION_NAME");
+        simpleMCQ.setCodeListReference("code-list-id");
+        simpleMCQ.getCodeResponses().add(new CodeResponse());
+        enoQuestionnaire.getMultipleResponseQuestions().add(simpleMCQ);
+        // When + Then
+        DDIInsertMultipleChoiceLabels processing = new DDIInsertMultipleChoiceLabels();
+        assertThatThrownBy(() -> processing.apply(enoQuestionnaire))
+                .isInstanceOf(IllegalDDIElementException.class)
+                .hasMessageContaining("code-list-id")
+                .hasMessageContaining("CODE_LIST_NAME")
+                .hasMessageContaining("question-id")
+                .hasMessageContaining("QUESTION_NAME");
+    }
 
     @Test
     void integrationTest() throws DDIParsingException {


### PR DESCRIPTION
## Summary

cf.

- https://github.com/InseeFr/Pogues/issues/883

Quand une liste de code utilisée dans une question a choix multiples a plus de codes que la question à choix multiple n'a de réponses, on avait une exception assez générique `IndexOutOfBoundsException` avec un message pas suffisamment précis pour comprendre l'origine de l'erreur.

## Done

Ajout d'une vérification sur la taille des deux listes, renvoi d'une exception si les deux diffèrent.
