### PR TITLE
fix: roundabout description

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.31.4-SNAPSHOT"
+    version = "3.31.5-SNAPSHOT"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.31.5-SNAPSHOT"
+    version = "3.31.5"
 }
 
 subprojects {

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -64,6 +64,8 @@ class LunaticRoundaboutLoopsTest {
             assertEquals("4", roundabout.getPage());
             assertEquals("\"Roundabout on S2\"", roundabout.getLabel().getValue());
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getLabel().getType());
+            assertEquals("\"Roundabout declaration\"", roundabout.getDescription().getValue());
+            assertEquals(LabelTypeEnum.VTL_MD, roundabout.getDescription().getType());
             assertEquals("true", roundabout.getConditionFilter().getValue());
             // roundabout specific ones
             assertEquals("count(FIRST_NAME)", roundabout.getIterations().getValue());

--- a/eno-core/src/test/resources/integration/ddi/ddi-roundabout.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-roundabout.xml
@@ -10,7 +10,7 @@
              xmlns:xs="http://www.w3.org/2001/XMLSchema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
-             isMaintainable="true"><!--Eno version : 2.9.10. Generation date : 24/06/2024 - 13:32:16-->
+             isMaintainable="true"><!--Eno version : 2.12.1. Generation date : 26/12/2024 - 12:24:17-->
    <r:Agency>fr.insee</r:Agency>
    <r:ID>INSEE-lxsxhihx</r:ID>
    <r:Version>1</r:Version>
@@ -70,6 +70,31 @@
                      <r:TypeOfObject>OutParameter</r:TypeOfObject>
                   </r:SourceParameterReference>
                </d:ConditionalText>
+            </d:InstructionText>
+         </d:Instruction>
+         <d:Instruction>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m55ba6zt</r:ID>
+            <r:Version>1</r:Version>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">help</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.WebBased</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">SelfAdministeredQuestionnaire.Paper</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.Telephone.CATI</r:String>
+            </d:InstructionName>
+            <d:InstructionName>
+               <r:String xml:lang="fr-FR">Interview.FaceToFace.CAPIorCAMI</r:String>
+            </d:InstructionName>
+            <d:InstructionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Roundabout declaration"</d:Text>
+               </d:LiteralText>
             </d:InstructionText>
          </d:Instruction>
       </d:InterviewerInstructionScheme>
@@ -198,6 +223,12 @@
             <d:InterviewerInstructionReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>lxsy3t24-OD</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Instruction</r:TypeOfObject>
+            </d:InterviewerInstructionReference>
+            <d:InterviewerInstructionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m55ba6zt</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Instruction</r:TypeOfObject>
             </d:InterviewerInstructionReference>

--- a/eno-core/src/test/resources/integration/pogues/pogues-roundabout.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-roundabout.json
@@ -133,7 +133,20 @@
         "CAWI",
         "PAPI"
       ],
-      "Declaration": [],
+      "Declaration": [
+        {
+          "id": "m55ba6zt",
+          "Text": "\"Roundabout declaration\"",
+          "position": "AFTER_QUESTION_TEXT",
+          "DeclarationMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "declarationType": "HELP"
+        }
+      ],
       "FlowControl": [],
       "OccurrenceLabel": "$FIRST_NAME$",
       "OccurrenceDescription": "\"Occurrence description of \" || $FIRST_NAME$"


### PR DESCRIPTION
## Summary

Comme pour les séquences, Pogues permet à l'utilisateur de saisir des déclarations dans un rondpoint.

Ces déclarations étaient ignorées dans la transformation DDI vers Lunatic.

## Done

À l'instar de ce qui est fait pour les séquences, j'ai transformé la déclaration saisie dans Pogues en description du composant rondpoint.

Question Lunatic : j'ai mis le type de la description en `VTL_MD`, c'est ok @laurentC35 @QRuhier ?

### Pour les relecteurs 

Doc DDI sur le rondpoint (il y a des types d'instructions particuliers dans le rondpoint, je suis pas mécontent d'avoir fait cette doc pour ce coup là 😄 ) https://inseefr.github.io/ddi-questionnaire-modeling/roundabout/

rappel du vocabulaire DDI : 

- _Instruction_ = déclaration saisie dans Pogues pour l'enquêté (concrètement c'est une déclaration "après la question")
- _Declaration_ = déclaration saisie dans Pogues pour l'enquêteur (déclaration "avant la question")

Détail "métier" : Les _declaration_ au sens DDI ne concernent que les questions
