### PR TITLE
feat(pogues mapping): questionnaire properties

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/exceptions/business/IllegalPoguesElementException.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/exceptions/business/IllegalPoguesElementException.java
@@ -1,0 +1,9 @@
+package fr.insee.eno.core.exceptions.business;
+
+public class IllegalPoguesElementException extends RuntimeException {
+
+    public IllegalPoguesElementException(String message) {
+        super(message);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -48,6 +48,7 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
     private String agency;
 
     /** Short description of the questionnaire. */
+    @Pogues("!getLabel().isEmpty() ? #this : null")
     @DDI("getCitation()?.getTitle()")
     @Lunatic("setLabel(#param)")
     private QuestionnaireLabel label;

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -43,6 +43,10 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
     @Lunatic("setModele(#param)")
     private String questionnaireModel;
 
+    /** Agency producing the questionnaire. */
+    @Pogues("getAgency()")
+    private String agency;
+
     /** Short description of the questionnaire. */
     @DDI("getCitation()?.getTitle()")
     @Lunatic("setLabel(#param)")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -53,6 +53,16 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
     @Lunatic("setLabel(#param)")
     private QuestionnaireLabel label;
 
+    /** Metadata that is specific to Pogues and indicates how filters are described in the questionnaire.
+     * Mapped to be used as a safety net (only 'FILTER' mode is allowed) in a processing step. */
+    @Pogues("getFlowLogic()?.value()")
+    private String filterMode;
+
+    /** Metadata that is specific to Pogues and indicates which language is used for expressions.
+     * Mapped to be used as a safety net (only 'VTL' is allowed) in a processing step. */
+    @Pogues("getFormulasLanguage()?.value()")
+    private String expressionLanguage;
+
     /** Questionnaire variables. Note: variables can have different "scope" (questionnaire-level, loop or dynamic
      * table level), yet all variables are defined in this list. */
     @DDI("getResourcePackageArray(0).getVariableSchemeArray(0).getVariableList()")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -3,6 +3,7 @@ package fr.insee.eno.core.model;
 import fr.insee.ddi.lifecycle33.instance.DDIInstanceType;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
+import fr.insee.eno.core.annotations.Pogues;
 import fr.insee.eno.core.model.code.CodeList;
 import fr.insee.eno.core.model.declaration.Declaration;
 import fr.insee.eno.core.model.label.QuestionnaireLabel;
@@ -36,6 +37,7 @@ import static fr.insee.eno.core.annotations.Contexts.Context;
 public class EnoQuestionnaire extends EnoIdentifiableObject {
 
     /** Name of the questionnaire model. */
+    @Pogues("getName()")
     @DDI("getResourcePackageArray(0).getCodeListSchemeArray(0)" +
             ".getCodeListSchemeNameArray(0).getStringArray(0).getStringValue()") //TODO: see if it's that one
     @Lunatic("setModele(#param)")

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/QuestionnaireLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/QuestionnaireLabel.java
@@ -3,10 +3,12 @@ package fr.insee.eno.core.model.label;
 import fr.insee.ddi.lifecycle33.reusable.InternationalStringType;
 import fr.insee.eno.core.annotations.DDI;
 import fr.insee.eno.core.annotations.Lunatic;
+import fr.insee.eno.core.annotations.Pogues;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.lunatic.model.flat.LabelType;
 import fr.insee.lunatic.model.flat.LabelTypeEnum;
+import fr.insee.pogues.model.Questionnaire;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -17,6 +19,7 @@ import static fr.insee.eno.core.annotations.Contexts.Context;
  * @see Label */
 @Getter
 @Setter
+@Context(format = Format.POGUES, type = Questionnaire.class)
 @Context(format = Format.DDI, type = InternationalStringType.class)
 @Context(format = Format.LUNATIC, type = LabelType.class)
 public class QuestionnaireLabel extends EnoObject implements EnoLabel {
@@ -24,6 +27,7 @@ public class QuestionnaireLabel extends EnoObject implements EnoLabel {
     /** Label content.
      * @see Label for details.
      */
+    @Pogues("getLabel().getFirst()")
     @DDI("getStringArray(0).getStringValue()")
     @Lunatic("setValue(#param)")
     String value;

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckExpressionLanguage.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckExpressionLanguage.java
@@ -1,0 +1,16 @@
+package fr.insee.eno.core.processing.in.steps.pogues;
+
+import fr.insee.eno.core.exceptions.business.IllegalPoguesElementException;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.processing.ProcessingStep;
+
+public class PoguesCheckExpressionLanguage implements ProcessingStep<EnoQuestionnaire> {
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        String expressionLanguage = enoQuestionnaire.getExpressionLanguage();
+        if (expressionLanguage == null) // if this property is missing it's alright, might be removed later on anyway
+            return;
+        if (!"VTL".equals(expressionLanguage))
+            throw new IllegalPoguesElementException("'" + expressionLanguage + "' expression language is not allowed.");
+    }
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckFilterMode.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckFilterMode.java
@@ -1,0 +1,16 @@
+package fr.insee.eno.core.processing.in.steps.pogues;
+
+import fr.insee.eno.core.exceptions.business.IllegalPoguesElementException;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.processing.ProcessingStep;
+
+public class PoguesCheckFilterMode implements ProcessingStep<EnoQuestionnaire> {
+    @Override
+    public void apply(EnoQuestionnaire enoQuestionnaire) {
+        String filterMode = enoQuestionnaire.getFilterMode();
+        if (filterMode == null) // if this property is missing it's alright, might be removed later on anyway
+            return;
+        if (!"FILTER".equals(filterMode))
+            throw new IllegalPoguesElementException("'" + filterMode + "' filter mode is not allowed.");
+    }
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
@@ -1,7 +1,9 @@
 package fr.insee.eno.core.mapping.in.pogues;
 
+import fr.insee.eno.core.exceptions.business.PoguesDeserializationException;
 import fr.insee.eno.core.mappers.PoguesMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.serialize.PoguesDeserializer;
 import fr.insee.pogues.model.Questionnaire;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +61,21 @@ class EnoQuestionnaireTest {
         poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
         //
         assertEquals("QUESTIONNAIRE_MODEL", enoQuestionnaire.getQuestionnaireModel());
+    }
+
+    @Test
+    void integrationTest() throws PoguesDeserializationException {
+        //
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        new PoguesMapper().mapPoguesQuestionnaire(
+                PoguesDeserializer.deserialize(this.getClass().getClassLoader().getResourceAsStream(
+                        "integration/pogues/pogues-simple.json")),
+                enoQuestionnaire);
+        //
+        assertEquals("lmyoceix", enoQuestionnaire.getId());
+        assertEquals("fr.insee", enoQuestionnaire.getAgency());
+        assertEquals("ENO_SIMPLE", enoQuestionnaire.getQuestionnaireModel());
+        assertEquals("Eno - Simple questionnaire", enoQuestionnaire.getLabel().getValue());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
@@ -23,6 +23,19 @@ class EnoQuestionnaireTest {
     }
 
     @Test
+    void mapAgencyFromPogues() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setAgency("fr.insee");
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        PoguesMapper poguesMapper = new PoguesMapper();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        assertEquals("fr.insee", enoQuestionnaire.getAgency());
+    }
+
+    @Test
     void mapQuestionnaireModelFromPogues() {
         //
         Questionnaire poguesQuestionnaire = new Questionnaire();

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
@@ -23,6 +23,19 @@ class EnoQuestionnaireTest {
     }
 
     @Test
+    void mapQuestionnaireLabelFromPogues() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.getLabel().add("Questionnaire label");
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        PoguesMapper poguesMapper = new PoguesMapper();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        assertEquals("Questionnaire label", enoQuestionnaire.getLabel().getValue());
+    }
+
+    @Test
     void mapAgencyFromPogues() {
         //
         Questionnaire poguesQuestionnaire = new Questionnaire();

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/EnoQuestionnaireTest.java
@@ -22,4 +22,17 @@ class EnoQuestionnaireTest {
         assertEquals("foo-questionnaire-id", enoQuestionnaire.getId());
     }
 
+    @Test
+    void mapQuestionnaireModelFromPogues() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setName("QUESTIONNAIRE_MODEL");
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        PoguesMapper poguesMapper = new PoguesMapper();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        assertEquals("QUESTIONNAIRE_MODEL", enoQuestionnaire.getQuestionnaireModel());
+    }
+
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckExpressionLanguageTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckExpressionLanguageTest.java
@@ -1,0 +1,41 @@
+package fr.insee.eno.core.processing.in.steps.pogues;
+
+import fr.insee.eno.core.exceptions.business.IllegalPoguesElementException;
+import fr.insee.eno.core.mappers.PoguesMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.pogues.model.FormulasLanguageEnum;
+import fr.insee.pogues.model.Questionnaire;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PoguesCheckExpressionLanguageTest {
+
+    @Test
+    void validValue() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setFormulasLanguage(FormulasLanguageEnum.VTL);
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        PoguesCheckExpressionLanguage processing = new PoguesCheckExpressionLanguage();
+        assertDoesNotThrow(() -> processing.apply(enoQuestionnaire));
+    }
+
+    @Test
+    void invalidValue_shouldThrow() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setFormulasLanguage(FormulasLanguageEnum.XPATH);
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        PoguesCheckExpressionLanguage processing = new PoguesCheckExpressionLanguage();
+        assertThrows(IllegalPoguesElementException.class, () -> processing.apply(enoQuestionnaire));
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckFilterModeTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/pogues/PoguesCheckFilterModeTest.java
@@ -1,0 +1,41 @@
+package fr.insee.eno.core.processing.in.steps.pogues;
+
+import fr.insee.eno.core.exceptions.business.IllegalPoguesElementException;
+import fr.insee.eno.core.mappers.PoguesMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.pogues.model.FlowLogicEnum;
+import fr.insee.pogues.model.Questionnaire;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PoguesCheckFilterModeTest {
+
+    @Test
+    void validValue() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setFlowLogic(FlowLogicEnum.FILTER);
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        PoguesCheckFilterMode processing = new PoguesCheckFilterMode();
+        assertDoesNotThrow(() -> processing.apply(enoQuestionnaire));
+    }
+
+    @Test
+    void invalidValue_shouldThrow() {
+        //
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire.setFlowLogic(FlowLogicEnum.REDIRECTION);
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        //
+        new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        //
+        PoguesCheckFilterMode processing = new PoguesCheckFilterMode();
+        assertThrows(IllegalPoguesElementException.class, () -> processing.apply(enoQuestionnaire));
+    }
+
+}

--- a/eno-core/src/test/resources/integration/ddi/ddi-simple.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-simple.xml
@@ -152,10 +152,10 @@
       </l:CategoryScheme>
       <l:CodeListScheme>
          <r:Agency>fr.insee</r:Agency>
-         <r:ID>ENOSIMPLE-CLS</r:ID>
+         <r:ID>ENO_SIMPLE-CLS</r:ID>
          <r:Version>1</r:Version>
          <l:CodeListSchemeName>
-            <r:String xml:lang="en-IE">ENOSIMPLE</r:String>
+            <r:String xml:lang="en-IE">ENO_SIMPLE</r:String>
          </l:CodeListSchemeName>
          <l:CodeList>
             <r:Agency>fr.insee</r:Agency>
@@ -229,7 +229,7 @@
             </r:BasedOnObject>
             <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
             <l:VariableGroupName>
-               <r:String>ENOSIMPLE</r:String>
+               <r:String>ENO_SIMPLE</r:String>
             </l:VariableGroupName>
             <r:VariableReference>
                <r:Agency>fr.insee</r:Agency>
@@ -300,7 +300,7 @@
                <r:ID>Instrument-lmyoceix</r:ID>
                <r:Version>1</r:Version>
                <d:InstrumentName>
-                  <r:String>ENOSIMPLE</r:String>
+                  <r:String>ENO_SIMPLE</r:String>
                </d:InstrumentName>
                <r:Label>
                   <r:Content xml:lang="fr-FR">Eno - Simple questionnaire questionnaire</r:Content>

--- a/eno-core/src/test/resources/integration/pogues/pogues-simple.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-simple.json
@@ -21,7 +21,7 @@
     "Eno - Simple questionnaire"
   ],
   "childQuestionnaireRef": [],
-  "Name": "ENOSIMPLE",
+  "Name": "ENO_SIMPLE",
   "Variables": {
     "Variable": [
       {


### PR DESCRIPTION
Mapping des propriétés de niveau questionnaire de Pogues vers Eno.

J'ai utilisé les propriétés "flowLogic" et "formulasLanguage" pour contrôler qu'Eno java n'est pas appelé avec un questionnaire en "go to" (déprécié) ou en "xpath" (pas de génération autre que Lunatic dans Eno java pour l'instant). Pas indispensable mais une sécurité qui peut pas faire de mal.
