### PR TITLE
feat(eno-ws): pogues plus ddi transformation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.32.2"
+    version = "3.33.0-SNAPSHOT"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.33.0-SNAPSHOT"
+    version = "3.33.0-SNAPSHOT.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/PoguesDDIToEno.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/PoguesDDIToEno.java
@@ -43,7 +43,7 @@ public class PoguesDDIToEno implements InToEno {
      * @deprecated For this class, the old transform method is not implemented.
      */
     @Override
-    @Deprecated(since = "3.23.0", forRemoval = true)
+    @Deprecated(since = "3.33.0", forRemoval = true)
     public EnoQuestionnaire transform(InputStream inputStream, EnoParameters enoParameters) throws ParsingException {
         throw new UnsupportedOperationException("Use the other transform method.");
     }

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
@@ -35,7 +35,6 @@ public class GenerationCustomController {
 	@Value("${eno.direct.pogues.lunatic}")
 	private Boolean directPoguesToLunatic;
 
-	private final PoguesToDDIService poguesToDDIService;
 	private final PoguesToLunaticService poguesToLunaticService;
 	private final DDIToLunaticService ddiToLunaticService;
 	private final DDIToXformsService ddiToXformsService;

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
@@ -6,7 +6,6 @@ import fr.insee.eno.treatments.LunaticPostProcessing;
 import fr.insee.eno.ws.controller.utils.ResponseUtils;
 import fr.insee.eno.ws.exception.DDIToLunaticException;
 import fr.insee.eno.ws.exception.EnoControllerException;
-import fr.insee.eno.ws.exception.EnoRedirectionException;
 import fr.insee.eno.ws.service.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,9 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBody;
 
@@ -66,14 +63,18 @@ public class GenerationCustomController {
 				poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
 	}
 
+	/**
+	 * @deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
+	 * */
 	@Operation(
 			summary = "[Eno Java service] Lunatic questionnaire generation from DDI.",
-			description= "**This endpoint uses the 'Java' version of Eno.** " +
+			description= "**This endpoint is deprecated: use the `pogues-2-lunatic` endpoint.** " +
 					"Generation a Lunatic questionnaire from the given DDI, using a custom parameters `json` file " +
 					"_(required)_ and a specific treatment `json` file _(optional)_. " +
 					"You can get a parameters file by using the endpoint `/parameters/java/{context}/LUNATIC/{mode}`")
 	@PostMapping(value = "ddi-2-lunatic-json",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Deprecated(since = "3.33.0")
 	public ResponseEntity<byte[]> generateLunaticCustomParams(
 			@RequestPart(value="in") MultipartFile ddiFile,
 			@RequestPart(value="params") MultipartFile parametersFile,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
@@ -33,7 +33,6 @@ import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBod
 @RequestMapping("/questionnaire")
 @RequiredArgsConstructor
 @Slf4j
-@SuppressWarnings("unused")
 public class GenerationCustomController {
 
 	@Value("${eno.direct.pogues.lunatic}")
@@ -63,17 +62,8 @@ public class GenerationCustomController {
 		EnoParameters enoParameters = parameterService.parse(parametersFile);
 		LunaticPostProcessing lunaticPostProcessing = specificTreatmentsService.generateFrom(specificTreatment);
 
-		if (Boolean.TRUE.equals(directPoguesToLunatic))
-			return ResponseUtils.okFromFileDto(poguesToLunaticService.transform(
-					poguesFile, enoParameters, lunaticPostProcessing));
-
-		byte[] ddiContent = poguesToDDIService.transform(poguesFile).getContent();
-		if (ddiContent == null)
-			throw new EnoRedirectionException("Result of the Pogues to DDI transformation is null.");
-
-		InputStream ddiStream = new ByteArrayInputStream(ddiContent);
 		return ResponseUtils.okFromFileDto(
-				ddiToLunaticService.transform(ddiStream, enoParameters, lunaticPostProcessing));
+				poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
 	}
 
 	@Operation(

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationPoguesController.java
@@ -27,11 +27,9 @@ import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBod
 @RequestMapping("/questionnaire")
 @RequiredArgsConstructor
 @Slf4j
-@SuppressWarnings("unused")
 public class GenerationPoguesController {
 
     private final PoguesToDDIService poguesToDDIService;
-    private final PoguesToLunaticService poguesToLunaticService;
 
     @Operation(
             summary = "[Eno Xml service] DDI Generation from Pogues xml questionnaire.",

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -30,7 +30,6 @@ import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBod
 @Slf4j
 public class GenerationStandardController {
 
-    private final PoguesToDDIService poguesToDDIService;
     private final PoguesToLunaticService poguesToLunaticService;
     private final DDIToLunaticService ddiToLunaticService;
     private final SpecificTreatmentsService specificTreatmentsService;
@@ -44,7 +43,7 @@ public class GenerationStandardController {
                     "parameters, in function of context and mode. An optional specific treatment `json` file can be " +
                     "added.")
     @PostMapping(value = "pogues-2-lunatic/{context}/{mode}",
-            produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<byte[]> generateLunaticFromPogues(
             @RequestPart(value="in") MultipartFile poguesFile,
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -32,11 +32,7 @@ import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBod
 @RequestMapping("/questionnaire")
 @RequiredArgsConstructor
 @Slf4j
-@SuppressWarnings("unused")
 public class GenerationStandardController {
-
-    @Value("${eno.direct.pogues.lunatic}")
-    private Boolean directPoguesToLunatic;
 
     private final PoguesToDDIService poguesToDDIService;
     private final PoguesToLunaticService poguesToLunaticService;
@@ -68,17 +64,9 @@ public class GenerationStandardController {
         enoParameters.getLunaticParameters().setDsfr(dsfr);
         //
         LunaticPostProcessing lunaticPostProcessing = specificTreatmentsService.generateFrom(specificTreatment);
-
         //
-        if (Boolean.TRUE.equals(directPoguesToLunatic))
-            return ResponseUtils.okFromFileDto(poguesToLunaticService.transform(
-                    poguesFile, enoParameters, lunaticPostProcessing));
-
-        //
-        FileDto ddiFileDto = poguesToDDIService.transform(poguesFile);
-        InputStream ddiStream = new ByteArrayInputStream(ddiFileDto.getContent());
         return ResponseUtils.okFromFileDto(
-                ddiToLunaticService.transform(ddiStream, enoParameters, lunaticPostProcessing));
+                poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
     }
 
     @Operation(

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -5,7 +5,6 @@ import fr.insee.eno.core.parameter.EnoParameters.Context;
 import fr.insee.eno.core.parameter.Format;
 import fr.insee.eno.treatments.LunaticPostProcessing;
 import fr.insee.eno.ws.controller.utils.ResponseUtils;
-import fr.insee.eno.ws.dto.FileDto;
 import fr.insee.eno.ws.exception.*;
 import fr.insee.eno.ws.legacy.parameters.CaptureEnum;
 import fr.insee.eno.ws.service.*;
@@ -13,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.MultipartBodyBuilder;
@@ -21,9 +19,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 import static fr.insee.eno.ws.controller.utils.ControllerUtils.addMultipartToBody;
 
@@ -69,13 +65,17 @@ public class GenerationStandardController {
                 poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
     }
 
+    /**
+     * @deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
+     * */
     @Operation(
             summary = "[Eno Java service] Lunatic questionnaire generation from DDI.",
-            description = "**This endpoint uses the 'Java' version of Eno.** " +
+            description = "**This endpoint is deprecated: use the `pogues-2-lunatic` endpoint.** " +
                     "Generation a Lunatic questionnaire from the given DDI with standard parameters, " +
                     "in function of context and mode. An optional specific treatment `json` file can be added.")
     @PostMapping(value = "{context}/lunatic-json/{mode}",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Deprecated(since = "3.33.0")
     public ResponseEntity<byte[]> generateLunatic(
             @RequestPart(value="in") MultipartFile ddiFile,
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToFOService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/DDIToFOService.java
@@ -17,7 +17,7 @@ public class DDIToFOService {
 
     public FileDto transform(
             MultipartBodyBuilder multipartBodyBuilder, EnoParameters.Context context,
-            int numberOfColumns, CaptureEnum captureMode, boolean multiModel) {
+            Integer numberOfColumns, CaptureEnum captureMode, boolean multiModel) {
         URI uri = enoXmlClient.newUriBuilder()
                 .path("/questionnaire/{context}/fo")
                 .queryParam("Format-column", numberOfColumns)

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/LunaticGenerationService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/LunaticGenerationService.java
@@ -25,31 +25,7 @@ public abstract class LunaticGenerationService {
      * Transform given input stream to a Lunatic questionnaire.
      * @param inputStream Input stream, e.g. of a DDI or Pogues questionnaire.
      * @param enoParameters Eno parameters object.
-     * @return String Lunatic questionnaire.
-     */
-    public final FileDto transform(InputStream inputStream, EnoParameters enoParameters) {
-        try {
-            Questionnaire lunaticQuestionnaire = mainTransformation(inputStream, enoParameters);
-            lunaticQuestionnaire.setEnoCoreVersion(enoVersion);
-            lunaticQuestionnaire.setLunaticModelVersion(lunaticModelVersion);
-            return FileDto.builder()
-                    .name(LUNATIC_JSON_FILE_NAME)
-                    .content(LunaticSerializer.serializeToJson(lunaticQuestionnaire).getBytes())
-                    .build();
-        } catch (Exception e) {
-            handleException(e);
-            return null;
-        }
-    }
-    public final FileDto transform(MultipartFile inputFile, EnoParameters enoParameters) throws IOException {
-        return transform(inputFile.getInputStream(), enoParameters);
-    }
-
-    /**
-     * Transform given input stream to a Lunatic questionnaire.
-     * @param inputStream Input stream, e.g. of a DDI or Pogues questionnaire.
-     * @param enoParameters Eno parameters object.
-     * @param lunaticPostProcessing Specific treatments to be applied.
+     * @param lunaticPostProcessing Specific treatments to be applied. Can be null.
      * @return String Lunatic questionnaire.
      */
     public FileDto transform(InputStream inputStream, EnoParameters enoParameters, LunaticPostProcessing lunaticPostProcessing) {

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToDDIService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToDDIService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 
 import static fr.insee.eno.ws.controller.utils.ControllerUtils.addStringToMultipartBody;
@@ -26,6 +27,7 @@ public class PoguesToDDIService {
             JSONToXMLTranslator jsonToXmlTranslator = new JSONToXMLTranslator();
             return jsonToXmlTranslator.translate(poguesJson);
         } catch (Exception e) {
+            log.error("Pogues json to xml conversion failed.");
             throw new PoguesToLunaticException(e);
         }
     }
@@ -37,14 +39,12 @@ public class PoguesToDDIService {
                 .build();
     }
 
-    public FileDto transform(MultipartFile poguesFile) {
-        String poguesXml;
-        try {
-            poguesXml = poguesJsonToXml(new String(poguesFile.getBytes()));
-        } catch (IOException e) {
-            log.error("Pogues json to xml conversion failed.");
-            throw new PoguesToLunaticException(e);
-        }
+    public FileDto transform(MultipartFile poguesFile) throws IOException {
+        String poguesXml = poguesJsonToXml(new String(poguesFile.getBytes()));
+        return sendPoguesXmlToDDIRequest(poguesXml);
+    }
+    public FileDto transform(InputStream poguesStream) throws IOException {
+        String poguesXml = poguesJsonToXml(new String(poguesStream.readAllBytes()));
         return sendPoguesXmlToDDIRequest(poguesXml);
     }
 

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToLunaticService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/PoguesToLunaticService.java
@@ -1,21 +1,57 @@
 package fr.insee.eno.ws.service;
 
+import fr.insee.eno.core.PoguesDDIToLunatic;
 import fr.insee.eno.core.PoguesToLunatic;
 import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.ws.controller.utils.ResponseUtils;
+import fr.insee.eno.ws.dto.FileDto;
 import fr.insee.eno.ws.exception.PoguesToLunaticException;
 import fr.insee.lunatic.model.flat.Questionnaire;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 @Service
 @PropertySource("classpath:/version.properties")
+@RequiredArgsConstructor
+@Slf4j
 public class PoguesToLunaticService extends LunaticGenerationService {
+
+    private final PoguesToDDIService poguesToDDIService;
+
+    /** Flag that determines if the service should use the direct Eno Java Pogues to Lunatic transformation.
+     * If not, the service uses Eno Xml for Pogues to Lunatic, then uses the Eno Java DDI to Lunatic transformation.
+     * */
+    @Value("${eno.direct.pogues.lunatic}")
+    private Boolean directPoguesToLunatic;
 
     @Override
     Questionnaire mainTransformation(InputStream poguesInputStream, EnoParameters enoParameters) throws Exception {
-        return PoguesToLunatic.fromInputStream(poguesInputStream).transform(enoParameters);
+        // If Eno Java direct Pogues to Lunatic is enabled
+        if (Boolean.TRUE.equals(directPoguesToLunatic)) {
+            log.warn("Direct Pogues to Lunatic transformation is in work in progress state.");
+            return PoguesToLunatic.fromInputStream(poguesInputStream).transform(enoParameters);
+        }
+
+        // Otherwise
+        // The workflow is as follows:
+        // - Eno Xml is called to generate the DDI from the Pogues questionnaire
+        // - Eno Java uses both the given Pogues questionnaire and the generated DDI to generate the Lunatic questionnaire
+        // Reminder: some features are described in Pogues but not in DDI.
+        // So while Pogues mapping may be incomplete, we read the information for these features in the Pogues questionnaire.
+
+        // Doing a string copy of the Pogues input since it will be consumed twice.
+        String poguesContent = new String(poguesInputStream.readAllBytes());
+        FileDto ddiFileDto = poguesToDDIService.transform(new ByteArrayInputStream(poguesContent.getBytes()));
+        InputStream ddiStream = new ByteArrayInputStream(ddiFileDto.getContent());
+        return PoguesDDIToLunatic
+                .fromInputStreams(new ByteArrayInputStream(poguesContent.getBytes()), ddiStream)
+                .transform(enoParameters);
     }
 
     @Override

--- a/eno-ws/src/main/java/fr/insee/eno/ws/service/SpecificTreatmentsService.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/service/SpecificTreatmentsService.java
@@ -28,6 +28,9 @@ public class SpecificTreatmentsService {
 
     public LunaticPostProcessing generateFrom(MultipartFile specificTreatmentsFile)
             throws EnoControllerException, IOException {
+        if (specificTreatmentsFile == null)
+            return null;
+
         validatePostProcessingFile(specificTreatmentsFile);
 
         LunaticPostProcessing lunaticPostProcessings = new LunaticPostProcessing();

--- a/eno-ws/src/test/java/fr/insee/eno/ws/service/DDIToLunaticServiceTest.java
+++ b/eno-ws/src/test/java/fr/insee/eno/ws/service/DDIToLunaticServiceTest.java
@@ -38,8 +38,9 @@ class DDIToLunaticServiceTest {
         //
         DDIToLunaticService ddiToLunaticService = new DDIToLunaticService();
         FileDto result = ddiToLunaticService.transform(
-                        this.getClass().getClassLoader().getResourceAsStream("non-regression/ddi-"+questionnaireId+".xml"),
-                        EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
+                this.getClass().getClassLoader().getResourceAsStream("non-regression/ddi-"+questionnaireId+".xml"),
+                EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC),
+                null);
         //
         assertNotNull(result);
         assertNotNull(result.getContent());
@@ -85,8 +86,9 @@ class DDIToLunaticServiceTest {
         //
         DDIToLunaticService ddiToLunaticService = new DDIToLunaticService();
         FileDto result = ddiToLunaticService.transform(
-                        this.getClass().getClassLoader().getResourceAsStream("non-regression/group-processing/ddi-lhpz68wp.xml"),
-                        EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC));
+                this.getClass().getClassLoader().getResourceAsStream("non-regression/group-processing/ddi-lhpz68wp.xml"),
+                EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI, Format.LUNATIC),
+                lunaticPostProcessing);
 
         //
         assertNotNull(result);


### PR DESCRIPTION
Modification de la classe de service `PoguesToLunaticService` pour faire : 

- "Pogues to Lunatic" direct si la property qui correspond est à true
- sinon "Pogues to DDI" avec Eno Xml, puis "Pogues + DDI to Lunatic"

c'était l'occasion de déporter cette logique qui était côté _controller_

Comme certaines fonctionnalités ne sont pas complètement décrites en DDI, la transformation "DDI to Lunatic" est désormais dépréciée côté web-service Eno.