### PR TITLE
fix(pogues2ddi): arbitrary response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
-	<version>2.12.2</version>
+	<version>2.12.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Eno – Questionnaire generator</name>

--- a/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H24M50S</meta:editing-duration><meta:editing-cycles>783</meta:editing-cycles><meta:generator>LibreOffice/7.6.6.3$Windows_X86_64 LibreOffice_project/d97b2716a9a4a2ce1391dee1765565ea469b0ae7</meta:generator><dc:date>2024-04-26T09:32:58.744000000</dc:date><dc:creator>François Bulot</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="494" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H25M33S</meta:editing-duration><meta:editing-cycles>784</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-10T17:45:57.980000000</dc:date><dc:creator>Nicolas Senave</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="562" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaLeft" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaWidth" config:type="int">61045</config:config-item>
-   <config:config-item config:name="VisibleAreaHeight" config:type="int">74380</config:config-item>
+   <config:config-item config:name="VisibleAreaHeight" config:type="int">82479</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
-       <config:config-item config:name="CursorPositionX" config:type="int">2</config:config-item>
+       <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
        <config:config-item config:name="CursorPositionY" config:type="int">130</config:config-item>
        <config:config-item config:name="ActiveSplitRange" config:type="short">2</config:config-item>
        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
-       <config:config-item config:name="PositionBottom" config:type="int">99</config:config-item>
+       <config:config-item config:name="PositionBottom" config:type="int">108</config:config-item>
        <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
        <config:config-item config:name="ZoomValue" config:type="int">95</config:config-item>
        <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -31,7 +31,7 @@
       </config:config-item-map-entry>
      </config:config-item-map-named>
      <config:config-item config:name="ActiveTable" config:type="string">Sheet1</config:config-item>
-     <config:config-item config:name="HorizontalScrollbarWidth" config:type="int">1597</config:config-item>
+     <config:config-item config:name="HorizontalScrollbarWidth" config:type="int">1855</config:config-item>
      <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
      <config:config-item config:name="ZoomValue" config:type="int">95</config:config-item>
      <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -151,7 +151,7 @@
   </style:default-style>
   <style:default-style style:family="graphic">
    <style:graphic-properties svg:stroke-color="#3465a4" draw:fill-color="#729fcf" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.3cm" draw:shadow-offset-y="0.3cm" style:writing-mode="page"/>
-   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:punctuation-wrap="simple" style:line-break="strict" style:writing-mode="page" style:font-independent-line-spacing="false">
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:punctuation-wrap="simple" style:line-break="strict" loext:tab-stop-distance="0cm" style:writing-mode="page" style:font-independent-line-spacing="false">
     <style:tab-stops/>
    </style:paragraph-properties>
    <style:text-properties style:use-window-font-color="true" loext:opacity="0%" fo:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable" fo:font-size="12pt" fo:language="fr" fo:country="FR" style:letter-kerning="true" style:font-family-asian="&apos;Segoe UI&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="12pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Tahoma" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN"/>
@@ -524,6 +524,22 @@
   </style:style>
   <style:style style:name="Result2" style:family="table-cell" style:parent-style-name="Result" style:data-style-name="N115"/>
   <draw:marker draw:name="Extrémités_20_de_20_flèche_20_1" draw:display-name="Extrémités de flèche 1" svg:viewBox="0 0 20 30" svg:d="M10 0l-10 30h20z"/>
+  <loext:theme loext:name="Office">
+   <loext:theme-colors loext:name="LibreOffice">
+    <loext:color loext:name="dark1" loext:color="#000000"/>
+    <loext:color loext:name="light1" loext:color="#ffffff"/>
+    <loext:color loext:name="dark2" loext:color="#000000"/>
+    <loext:color loext:name="light2" loext:color="#ffffff"/>
+    <loext:color loext:name="accent1" loext:color="#18a303"/>
+    <loext:color loext:name="accent2" loext:color="#0369a3"/>
+    <loext:color loext:name="accent3" loext:color="#a33e03"/>
+    <loext:color loext:name="accent4" loext:color="#8e03a3"/>
+    <loext:color loext:name="accent5" loext:color="#c99c00"/>
+    <loext:color loext:name="accent6" loext:color="#c9211e"/>
+    <loext:color loext:name="hyperlink" loext:color="#0000ee"/>
+    <loext:color loext:name="followed-hyperlink" loext:color="#551a8b"/>
+   </loext:theme-colors>
+  </loext:theme>
  </office:styles>
  <office:automatic-styles>
   <style:style style:name="co1" style:family="table-column">
@@ -601,7 +617,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2024-04-26">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="08:52:01.188000000">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-10">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="17:45:16.917000000">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -821,7 +837,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Dimension[contains(@dynamic,&apos;-&apos;)]</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-minimum-lines</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -836,7 +852,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Dimension[contains(@dynamic,&apos;-&apos;)]</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-maximum-lines</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -851,7 +867,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Dimension[@dynamic=&apos;DYNAMIC_LENGTH&apos;]</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-minimum-lines</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -866,7 +882,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Dimension[@dynamic=&apos;DYNAMIC_LENGTH&apos;]</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-maximum-lines</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -881,7 +897,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Dimension[@dynamic=&apos;FIXED_LENGTH&apos;]</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce3" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-fixed-lines</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -890,7 +906,7 @@
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>with-tag</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>Returns the formula for the fixed number of lines for a dynamic table</text:p>
      </table:table-cell>
     </table:table-row>
@@ -2478,13 +2494,25 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>pogues:ArbitraryResponse</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>enopogues:is-not-collected</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>&apos;false&apos;</text:p>
+     </table:table-cell>
+     <table:table-cell table:number-columns-repeated="2"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro2">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Variable</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:is-not-collected</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>@xsi:type= &apos;CollectedVariableType&apos; and enopogues:is-not-collected(//pogues:Response[pogues:CollectedVariableReference=current()/@id])</text:p>
+      <text:p>@xsi:type= &apos;CollectedVariableType&apos; and enopogues:is-not-collected(//pogues:Response[pogues:CollectedVariableReference=current()/@id]|//pogues:ArbitraryResponse[pogues:CollectedVariableReference=current()/@id])</text:p>
      </table:table-cell>
      <table:table-cell/>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -2687,7 +2715,7 @@
       <text:p>Return all Roundabouts elements of the survey. <text:s/>The with-tag of the Match_Mode column means that this template is hard-coded in the src\main\resources\xslt\inputs\pogues-xml\source-fixed.xml. This is to keep the tags as well as their content by making a sequence instead of a value-of</text:p>
      </table:table-cell>
     </table:table-row>
-    <table:table-row table:style-name="ro2" table:number-rows-repeated="30">
+    <table:table-row table:style-name="ro2" table:number-rows-repeated="29">
      <table:table-cell table:number-columns-repeated="5"/>
     </table:table-row>
     <table:table-row table:style-name="ro2">

--- a/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -1769,7 +1769,7 @@
       <text:p>enopogues:get-related-response</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>//pogues:Response[pogues:CollectedVariableReference = current()/@id]</text:p>
+      <text:p>//pogues:Response[pogues:CollectedVariableReference = current()/@id]|//pogues:ArbitraryResponse[pogues:CollectedVariableReference = current()/@id]</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>with-tag</text:p>

--- a/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H40M14S</meta:editing-duration><meta:editing-cycles>787</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-12T16:22:48.508000000</dc:date><dc:creator>Laurent Caouissin</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="570" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H41M14S</meta:editing-duration><meta:editing-cycles>788</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-14T18:04:11.749000000</dc:date><dc:creator>Laurent Caouissin</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="570" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
@@ -13,13 +13,13 @@
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
-       <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">114</config:config-item>
+       <config:config-item config:name="CursorPositionX" config:type="int">3</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">115</config:config-item>
        <config:config-item config:name="ActiveSplitRange" config:type="short">2</config:config-item>
-       <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
+       <config:config-item config:name="PositionLeft" config:type="int">1</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
-       <config:config-item config:name="PositionBottom" config:type="int">96</config:config-item>
+       <config:config-item config:name="PositionBottom" config:type="int">108</config:config-item>
        <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
        <config:config-item config:name="ZoomValue" config:type="int">95</config:config-item>
        <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -620,7 +620,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-12">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="15:55:46.608000000">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-14">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="18:03:14.103000000">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -1772,7 +1772,7 @@
       <text:p>enopogues:get-related-response</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>//pogues:Response[pogues:CollectedVariableReference = current()/@id]|//pogues:ArbitraryResponse[pogues:CollectedVariableReference = current()/@id]</text:p>
+      <text:p>//pogues:Response[pogues:CollectedVariableReference = current()/@id] | //pogues:ArbitraryResponse[pogues:CollectedVariableReference = current()/@id]</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>with-tag</text:p>
@@ -2544,7 +2544,7 @@
       <text:p>enopogues:is-not-collected</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>@xsi:type= &apos;CollectedVariableType&apos; and enopogues:is-not-collected(//pogues:Response[pogues:CollectedVariableReference=current()/@id]|//pogues:ArbitraryResponse[pogues:CollectedVariableReference=current()/@id])</text:p>
+      <text:p>@xsi:type= &apos;CollectedVariableType&apos; and enopogues:is-not-collected(//pogues:Response[pogues:CollectedVariableReference=current()/@id] | //pogues:ArbitraryResponse[pogues:CollectedVariableReference=current()/@id])</text:p>
      </table:table-cell>
      <table:table-cell/>
      <table:table-cell office:value-type="string" calcext:value-type="string">

--- a/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H33M19S</meta:editing-duration><meta:editing-cycles>785</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-10T18:43:09.441000000</dc:date><dc:creator>Nicolas Senave</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="562" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H40M14S</meta:editing-duration><meta:editing-cycles>787</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-12T16:22:48.508000000</dc:date><dc:creator>Laurent Caouissin</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="570" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
    <config:config-item config:name="VisibleAreaLeft" config:type="int">0</config:config-item>
-   <config:config-item config:name="VisibleAreaWidth" config:type="int">61045</config:config-item>
-   <config:config-item config:name="VisibleAreaHeight" config:type="int">82479</config:config-item>
+   <config:config-item config:name="VisibleAreaWidth" config:type="int">79026</config:config-item>
+   <config:config-item config:name="VisibleAreaHeight" config:type="int">83637</config:config-item>
    <config:config-item-map-indexed config:name="Views">
     <config:config-item-map-entry>
      <config:config-item config:name="ViewId" config:type="string">view1</config:config-item>
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
        <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">149</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">114</config:config-item>
        <config:config-item config:name="ActiveSplitRange" config:type="short">2</config:config-item>
        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
-       <config:config-item config:name="PositionBottom" config:type="int">113</config:config-item>
+       <config:config-item config:name="PositionBottom" config:type="int">96</config:config-item>
        <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
        <config:config-item config:name="ZoomValue" config:type="int">95</config:config-item>
        <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -42,7 +42,7 @@
      <config:config-item config:name="ShowGrid" config:type="boolean">true</config:config-item>
      <config:config-item config:name="GridColor" config:type="int">12632256</config:config-item>
      <config:config-item config:name="ShowPageBreaks" config:type="boolean">true</config:config-item>
-     <config:config-item config:name="FormulaBarHeight" config:type="short">1</config:config-item>
+     <config:config-item config:name="FormulaBarHeight" config:type="short">6</config:config-item>
      <config:config-item config:name="HasSheetTabs" config:type="boolean">true</config:config-item>
      <config:config-item config:name="IsOutlineSymbolsSet" config:type="boolean">true</config:config-item>
      <config:config-item config:name="IsValueHighlightingEnabled" config:type="boolean">false</config:config-item>
@@ -543,7 +543,7 @@
  </office:styles>
  <office:automatic-styles>
   <style:style style:name="co1" style:family="table-column">
-   <style:table-column-properties fo:break-before="auto" style:column-width="15.506cm"/>
+   <style:table-column-properties fo:break-before="auto" style:column-width="33.487cm"/>
   </style:style>
   <style:style style:name="co2" style:family="table-column">
    <style:table-column-properties fo:break-before="auto" style:column-width="6.371cm"/>
@@ -597,6 +597,9 @@
     </style:header-footer-properties>
    </style:footer-style>
   </style:page-layout>
+  <style:style style:name="T1" style:family="text">
+   <style:text-properties style:font-name="Arial" fo:font-size="10pt" fo:font-weight="normal" style:text-underline-style="none" style:text-underline-color="font-color" style:text-line-through-type="none" fo:font-style="normal" style:text-outline="false" fo:text-shadow="none" style:text-line-through-mode="continuous" fo:language="zxx" fo:country="none" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none" style:font-name-asian="Andale Sans UI" style:font-name-complex="Tahoma" style:font-size-asian="10pt" style:font-size-complex="10pt" style:font-weight-asian="normal" style:font-weight-complex="normal" style:font-style-asian="normal" style:font-style-complex="normal" style:text-emphasize="none" style:font-relief="none" style:text-overline-style="none" style:text-overline-color="font-color"/>
+  </style:style>
  </office:automatic-styles>
  <office:master-styles>
   <style:master-page style:name="Default" style:page-layout-name="pm1">
@@ -617,7 +620,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-10">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="18:35:25.476000000">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-12">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="15:55:46.608000000">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -2285,6 +2288,20 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>pogues:Variable[@xsi:type=&apos;CollectedVariableType&apos; and (not(pogues:Scope) or pogues:Scope=&apos;&apos;) and //pogues:Child[pogues:ArbitraryResponse/pogues:CollectedVariableReference=current()/@id][pogues:ResponseStructure/pogues:Dimension[@dimensionType=&quot;PRIMARY&quot; and @dynamic != &apos;0&apos; and @dynamic != &apos;NON_DYNAMIC&apos;]]]</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>enopogues:get-variable-group</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>//pogues:Child[pogues:ArbitraryResponse/pogues:CollectedVariableReference=current()/@id]/@id</text:p>
+     </table:table-cell>
+     <table:table-cell/>
+     <table:table-cell office:value-type="string" calcext:value-type="string"><text:p><text:span text:style-name="T1">Variable collected from ArbitraryResponse </text:span>in a dynamic array : returns its question id</text:p>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="ro2">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>pogues:Variable[@xsi:type=&apos;CollectedVariableType&apos; and (not(pogues:Scope) or pogues:Scope=&apos;&apos;) and //pogues:Child[pogues:Response/pogues:CollectedVariableReference=current()/@id][not(pogues:ResponseStructure/pogues:Dimension[@dimensionType=&quot;PRIMARY&quot; and @dynamic != &apos;0&apos; and @dynamic != &apos;NON_DYNAMIC&apos;]) and not(@questionType=&apos;PAIRWISE&apos;)]]</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
@@ -2296,6 +2313,21 @@
      <table:table-cell/>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>Variable collected out of a dynamic array or a pairwise : returns questionnaire id</text:p>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="ro2">
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>pogues:Variable[@xsi:type=&apos;CollectedVariableType&apos; and (not(pogues:Scope) or pogues:Scope=&apos;&apos;) and //pogues:Child[pogues:ArbitraryResponse/pogues:CollectedVariableReference=current()/@id][not(pogues:ResponseStructure/pogues:Dimension[@dimensionType=&quot;PRIMARY&quot; and @dynamic != &apos;0&apos; and @dynamic != &apos;NON_DYNAMIC&apos;]) and not(@questionType=&apos;PAIRWISE&apos;)]]</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>enopogues:get-variable-group</text:p>
+     </table:table-cell>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>/pogues:Questionnaire/@id</text:p>
+     </table:table-cell>
+     <table:table-cell/>
+     <table:table-cell office:value-type="string" calcext:value-type="string">
+      <text:p>Variable collected from ArbitraryResponse out of a dynamic array or a pairwise : returns questionnaire id</text:p>
      </table:table-cell>
     </table:table-row>
     <table:table-row table:style-name="ro2">

--- a/src/main/resources/xslt/inputs/pogues-xml/templates.fods
+++ b/src/main/resources/xslt/inputs/pogues-xml/templates.fods
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
- <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H25M33S</meta:editing-duration><meta:editing-cycles>784</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-10T17:45:57.980000000</dc:date><dc:creator>Nicolas Senave</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="562" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
+ <office:meta><meta:creation-date>2009-04-16T11:32:48.39</meta:creation-date><meta:editing-duration>P13DT7H33M19S</meta:editing-duration><meta:editing-cycles>785</meta:editing-cycles><meta:generator>LibreOffice/24.2.6.2$Windows_X86_64 LibreOffice_project/ef66aa7e36a1bb8e65bfbc63aba53045a14d0871</meta:generator><dc:date>2025-02-10T18:43:09.441000000</dc:date><dc:creator>Nicolas Senave</dc:creator><meta:document-statistic meta:table-count="1" meta:cell-count="562" meta:object-count="0"/><meta:user-defined meta:name="Info 1"/><meta:user-defined meta:name="Info 2"/><meta:user-defined meta:name="Info 3"/><meta:user-defined meta:name="Info 4"/></office:meta>
  <office:settings>
   <config:config-item-set config:name="ooo:view-settings">
    <config:config-item config:name="VisibleAreaTop" config:type="int">0</config:config-item>
@@ -14,12 +14,12 @@
      <config:config-item-map-named config:name="Tables">
       <config:config-item-map-entry config:name="Sheet1">
        <config:config-item config:name="CursorPositionX" config:type="int">0</config:config-item>
-       <config:config-item config:name="CursorPositionY" config:type="int">130</config:config-item>
+       <config:config-item config:name="CursorPositionY" config:type="int">149</config:config-item>
        <config:config-item config:name="ActiveSplitRange" config:type="short">2</config:config-item>
        <config:config-item config:name="PositionLeft" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionRight" config:type="int">0</config:config-item>
        <config:config-item config:name="PositionTop" config:type="int">0</config:config-item>
-       <config:config-item config:name="PositionBottom" config:type="int">108</config:config-item>
+       <config:config-item config:name="PositionBottom" config:type="int">113</config:config-item>
        <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
        <config:config-item config:name="ZoomValue" config:type="int">95</config:config-item>
        <config:config-item config:name="PageViewZoomValue" config:type="int">60</config:config-item>
@@ -617,7 +617,7 @@
      <text:p><text:sheet-name>???</text:sheet-name><text:s/>(<text:title>???</text:title>)</text:p>
     </style:region-left>
     <style:region-right>
-     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-10">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="17:45:16.917000000">00:00:00</text:time></text:p>
+     <text:p><text:date style:data-style-name="N2" text:date-value="2025-02-10">00/00/0000</text:date>, <text:time style:data-style-name="N2" text:time-value="18:35:25.476000000">00:00:00</text:time></text:p>
     </style:region-right>
    </style:header>
    <style:header-left style:display="false"/>
@@ -1478,7 +1478,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>pogues:Response</text:p>
+      <text:p>pogues:Response | pogues:ArbitraryResponse</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-qop-id</text:p>
@@ -1673,7 +1673,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>pogues:Response</text:p>
+      <text:p>pogues:Response | pogues:ArbitraryResponse</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-rdop-id</text:p>
@@ -1856,7 +1856,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>pogues:Response</text:p>
+      <text:p>pogues:Response | pogues:ArbitraryResponse</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-type</text:p>
@@ -1940,7 +1940,7 @@
     </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell office:value-type="string" calcext:value-type="string">
-      <text:p>pogues:Response</text:p>
+      <text:p>pogues:Response | pogues:ArbitraryResponse</text:p>
      </table:table-cell>
      <table:table-cell office:value-type="string" calcext:value-type="string">
       <text:p>enopogues:get-type-name</text:p>

--- a/src/test/java/fr/insee/eno/test/TestPoguesXMLToDDI.java
+++ b/src/test/java/fr/insee/eno/test/TestPoguesXMLToDDI.java
@@ -25,17 +25,32 @@ public class TestPoguesXMLToDDI {
 
 	@Test
 	public void simpleDiffTest() {
+		String basePath = "src/test/resources/pogues-xml-to-ddi";
+		testTransformationInOut(String.format("%s/in.xml", basePath), String.format("%s/out.xml", basePath));
+	}
+
+	@Test
+	public void arbitrarySuggesterResponseTest() {
+		String basePath = "src/test/resources/pogues-xml-to-ddi/suggester-arbitrary";
+		testTransformationInOut(String.format("%s/in.xml", basePath), String.format("%s/out.xml", basePath));
+	}
+
+	@Test
+	public void arbitrarySuggesterResponseInLoopTest() {
+		String basePath = "src/test/resources/pogues-xml-to-ddi/suggester-arbitrary";
+		testTransformationInOut(String.format("%s/in-loop.xml", basePath), String.format("%s/out-loop.xml", basePath));
+	}
+
+	private void testTransformationInOut(String inPath, String outPath){
 		try {
-			String basePath = "src/test/resources/pogues-xml-to-ddi";
-			
 			Preprocessor[] preprocessors = {
 					new PoguesXmlInsertFilterLoopIntoQuestionTree(),
 					new PoguesXMLPreprocessorGoToTreatment()};
 			Postprocessor[] postprocessors = {new NoopPostprocessor()};
-			
+
 			GenerationService genService = new GenerationService(preprocessors, poguesXML2DDI, postprocessors);
 
-			File in = new File(String.format("%s/in.xml", basePath));
+			File in = new File(inPath);
 			ByteArrayInputStream inputStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(in));
 			File outputFile = createTempEnoFile();
 			ByteArrayOutputStream output = genService.generateQuestionnaire(inputStream, "xml-pogues-2-ddi-test");
@@ -43,9 +58,9 @@ public class TestPoguesXMLToDDI {
 				fos.write(output.toByteArray());
 			}
 			output.close();
-			File expectedFile = new File(String.format("%s/out.xml", basePath));
+			File expectedFile = new File(outPath);
 			Diff diff = xmlDiff.getDiff(outputFile, expectedFile);
-			Assertions.assertFalse(diff::hasDifferences, ()->getDiffMessage(diff, basePath));
+			Assertions.assertFalse(diff::hasDifferences, ()->getDiffMessage(diff));
 
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -59,8 +74,8 @@ public class TestPoguesXMLToDDI {
 		}
 	}
 
-	private String getDiffMessage(Diff diff, String path) {
-		return String.format("Transformed output for %s should match expected XML document:\n %s", path,
+	private String getDiffMessage(Diff diff) {
+		return String.format("Transformed output should match expected XML document:\n %s",
 				diff.toString());
 	}
 }

--- a/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/in-loop.xml
+++ b/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/in-loop.xml
@@ -1,0 +1,396 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Questionnaire xmlns="http://xml.insee.fr/schema/applis/pogues" id="m721awnn" genericName="QUESTIONNAIRE" agency="fr.insee" final="false" flowLogic="FILTER" formulasLanguage="VTL" lastUpdatedDate="Wed Feb 12 2025 17:02:54 GMT+0100 (heure normale d’Europe centrale)" owner="ENO-INTEGRATION-TESTS">
+   <Name>ENO_SUGGESTER_ARBITRARY</Name>
+   <Label>Eno - Suggester with arbitrary inside Loop</Label>
+   <TargetMode>CAPI</TargetMode>
+   <TargetMode>CATI</TargetMode>
+   <TargetMode>CAWI</TargetMode>
+   <TargetMode>PAPI</TargetMode>
+   <Child id="m6uwl291" depth="1" genericName="MODULE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+      <Name>S1</Name>
+      <Label>&quot;Sequence&quot;</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Child id="m6uw3z0d" questionType="SINGLE_CHOICE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>COUNTRY</Name>
+         <Label>&quot;Suggester question (country)&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m6uw9cka" mandatory="false">
+            <CodeListReference>L_PAYS-1-2-0</CodeListReference>
+            <Datatype typeName="TEXT" visualizationHint="SUGGESTER" allowArbitraryResponse="false" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>1</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m6uxkrge</CollectedVariableReference>
+         </Response>
+      </Child>
+      <Child id="m6uwmbzo" questionType="SINGLE_CHOICE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>ACTIVITY</Name>
+         <Label>&quot;Suggester question (activity) with arbitrary response&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m6uw7qbe" mandatory="false">
+            <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+            <Datatype typeName="TEXT" visualizationHint="SUGGESTER" allowArbitraryResponse="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>1</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m6uxo8wf</CollectedVariableReference>
+         </Response>
+         <ArbitraryResponse id="m723w1qs" mandatory="false">
+            <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>249</MaxLength>
+            </Datatype>
+            <CollectedVariableReference>m6uxax4o</CollectedVariableReference>
+         </ArbitraryResponse>
+      </Child>
+   </Child>
+   <Child id="m721c9xk" depth="1" genericName="MODULE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+      <Name>HABITANT</Name>
+      <Label>&quot;Habitant&quot;</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Child id="m721kwx3" questionType="TABLE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>LISTEDESHA</Name>
+         <Label>&quot;Liste des habitants&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m7233p81">
+            <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>249</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m72170v3</CollectedVariableReference>
+         </Response>
+         <ResponseStructure>
+            <Dimension dimensionType="PRIMARY" dynamic="DYNAMIC_LENGTH">
+               <MinLines>1</MinLines>
+               <MaxLines>2</MaxLines>
+            </Dimension>
+            <Dimension dimensionType="MEASURE">
+               <Label>&quot;Prénom ?&quot;</Label>
+            </Dimension>
+            <Mapping>
+               <MappingSource>m7233p81</MappingSource>
+               <MappingTarget>1 1</MappingTarget>
+            </Mapping>
+         </ResponseStructure>
+      </Child>
+   </Child>
+   <Child id="m721eos5" depth="1" genericName="MODULE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+      <Name>BONJOURPRE</Name>
+      <Label>&quot;Bonjour &quot; || PRENOM</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Child id="m721l8n5" questionType="SINGLE_CHOICE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>ACTIVITY_LOOP</Name>
+         <Label>&quot;LOOP Suggester question (activity) with arbitrary response&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m7214v7q" mandatory="false">
+            <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+            <Datatype typeName="TEXT" visualizationHint="SUGGESTER" allowArbitraryResponse="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>1</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m721avl2</CollectedVariableReference>
+         </Response>
+         <ArbitraryResponse id="m723qv7z" mandatory="false">
+            <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>249</MaxLength>
+            </Datatype>
+            <CollectedVariableReference>m721dstu</CollectedVariableReference>
+         </ArbitraryResponse>
+      </Child>
+      <Child id="m722vlnr" questionType="SIMPLE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>AGE</Name>
+         <Label>&quot;Quel âge as-tu ?&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m722uy45" mandatory="false">
+            <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>249</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m722wgb3</CollectedVariableReference>
+         </Response>
+      </Child>
+   </Child>
+   <Child id="m6uxuwt1" depth="1" genericName="MODULE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+      <Name>END</Name>
+      <Label>&quot;End&quot;</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Child id="m723ou03" questionType="SIMPLE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+         <Name>Q_END</Name>
+         <Label>&quot;Q_END&quot;</Label>
+         <TargetMode>CAPI</TargetMode>
+         <TargetMode>CATI</TargetMode>
+         <TargetMode>CAWI</TargetMode>
+         <TargetMode>PAPI</TargetMode>
+         <Response id="m723hzer" mandatory="false">
+            <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+               <MaxLength>249</MaxLength>
+               <Pattern></Pattern>
+            </Datatype>
+            <CollectedVariableReference>m723babu</CollectedVariableReference>
+         </Response>
+      </Child>
+   </Child>
+   <Child id="idendquest" depth="1" genericName="MODULE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+      <Name>QUESTIONNAIRE_END</Name>
+      <Label>QUESTIONNAIRE_END</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+   </Child>
+   <DataCollection id="s2106-dc" uri="http://ddi:fr.insee:DataCollection.s2106-dc"/>
+   <ComponentGroup id="m6uwp0c8">
+      <Name>PAGE_1</Name>
+      <Label>Components for page 1</Label>
+      <MemberReference>m6uwl291</MemberReference>
+      <MemberReference>m6uw3z0d</MemberReference>
+      <MemberReference>m6uwmbzo</MemberReference>
+      <MemberReference>m721c9xk</MemberReference>
+      <MemberReference>m721kwx3</MemberReference>
+      <MemberReference>m721eos5</MemberReference>
+      <MemberReference>m721l8n5</MemberReference>
+      <MemberReference>m722vlnr</MemberReference>
+      <MemberReference>m6uxuwt1</MemberReference>
+      <MemberReference>m723ou03</MemberReference>
+      <MemberReference>idendquest</MemberReference>
+   </ComponentGroup>
+   <CodeLists>
+      <CodeList id="L_PAYS-1-2-0" Urn="urn:ddi:fr.insee:l_pays-1-2-0:1">
+         <Name>L_PAYS-1-2-0</Name>
+         <Label>Pays</Label>
+         <SuggesterParameters>
+            <fields>
+               <name>label</name>
+               <rules>[\w]+</rules>
+               <language>French</language>
+               <min>3</min>
+               <stemmer>false</stemmer>
+            </fields>
+            <queryParser>
+               <type>tokenized</type>
+               <params>
+                  <language>French</language>
+                  <min>3</min>
+                  <pattern>[\w.]+</pattern>
+                  <stemmer>false</stemmer>
+               </params>
+            </queryParser>
+            <version>1</version>
+         </SuggesterParameters>
+      </CodeList>
+      <CodeList id="L_ACTIVITES-2-0-0" Urn="urn:ddi:fr.insee:l_activites-2-0-0:1">
+         <Name>L_ACTIVITES-2-0-0</Name>
+         <Label>Activités</Label>
+         <SuggesterParameters>
+            <fields>
+               <name>label</name>
+               <rules>[\w]+</rules>
+               <language>French</language>
+               <min>3</min>
+               <stemmer>false</stemmer>
+               <synonyms>
+                  <source>EHPAD</source>
+                  <target>EPHAD</target>
+                  <target>HEPAD</target>
+                  <target>EPAD</target>
+                  <target>EPAHD</target>
+                  <target>EPADH</target>
+               </synonyms>
+               <synonyms>
+                  <source>URSSAF</source>
+                  <target>URSAF</target>
+                  <target>URSAFF</target>
+               </synonyms>
+               <synonyms>
+                  <source>ascenseurs</source>
+                  <target>ASCENCEUR</target>
+                  <target>ASSENCEUR</target>
+                  <target>ACSENCEUR</target>
+               </synonyms>
+               <synonyms>
+                  <source>joaillerie</source>
+                  <target>JOAILLIER</target>
+               </synonyms>
+               <synonyms>
+                  <source>alimentaire</source>
+                  <target>ALIMANTAIRE</target>
+               </synonyms>
+               <synonyms>
+                  <source>briqueterie</source>
+                  <target>BRIQUETTERIE</target>
+               </synonyms>
+               <synonyms>
+                  <source>prestations</source>
+                  <target>PRESTATAIRE</target>
+               </synonyms>
+               <synonyms>
+                  <source>alimentaires</source>
+                  <target>ALIMANTAIRES</target>
+               </synonyms>
+               <synonyms>
+                  <source>echafaudages</source>
+                  <target>ECHAFFAUDAGE</target>
+                  <target>ECHAFFAUDEUR</target>
+               </synonyms>
+               <synonyms>
+                  <source>plaquisterie</source>
+                  <target>PLACO</target>
+                  <target>PLACOPLATRE</target>
+               </synonyms>
+               <synonyms>
+                  <source>pneumatiques</source>
+                  <target>PNEUS</target>
+               </synonyms>
+               <synonyms>
+                  <source>agroalimentaire</source>
+                  <target>AGGROALIMANTAIRE</target>
+                  <target>AGROALIMANTAIRE</target>
+               </synonyms>
+               <synonyms>
+                  <source>agroalimentaires</source>
+                  <target>AGGROALIMANTAIRES</target>
+                  <target>AGROALIMENTAIRES</target>
+               </synonyms>
+            </fields>
+            <stopWords>a</stopWords>
+            <stopWords>au</stopWords>
+            <stopWords>dans</stopWords>
+            <stopWords>de</stopWords>
+            <stopWords>des</stopWords>
+            <stopWords>du</stopWords>
+            <stopWords>en</stopWords>
+            <stopWords>et</stopWords>
+            <stopWords>la</stopWords>
+            <stopWords>le</stopWords>
+            <stopWords>ou</stopWords>
+            <stopWords>sur</stopWords>
+            <stopWords>d</stopWords>
+            <stopWords>l</stopWords>
+            <stopWords>aux</stopWords>
+            <stopWords>dans</stopWords>
+            <stopWords>un</stopWords>
+            <stopWords>une</stopWords>
+            <stopWords>pour</stopWords>
+            <stopWords>avec</stopWords>
+            <stopWords>chez</stopWords>
+            <stopWords>par</stopWords>
+            <stopWords>les</stopWords>
+            <queryParser>
+               <type>tokenized</type>
+               <params>
+                  <language>French</language>
+                  <min>3</min>
+                  <pattern>[\w.]+</pattern>
+                  <stemmer>false</stemmer>
+               </params>
+            </queryParser>
+            <version>1</version>
+         </SuggesterParameters>
+      </CodeList>
+   </CodeLists>
+   <Variables>
+      <Variable id="m6uxkrge" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <CodeListReference>L_PAYS-1-2-0</CodeListReference>
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>1</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>COUNTRY</Name>
+         <Label>COUNTRY label</Label>
+      </Variable>
+      <Variable id="m6uxo8wf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>1</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>ACTIVITY</Name>
+         <Label>ACTIVITY label</Label>
+      </Variable>
+      <Variable id="m6uxax4o" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>249</MaxLength>
+         </Datatype>
+         <Name>ACTIVITY_ARBITRARY</Name>
+         <Label>ACTIVITY_ARBITRARY label</Label>
+      </Variable>
+      <Variable id="m72170v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>249</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>PRENOM</Name>
+         <Label>Prénom ?</Label>
+         <Scope>m721kwx3</Scope>
+      </Variable>
+      <Variable id="m721avl2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>1</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>ACTIVITY_LOOP</Name>
+         <Label>ACTIVITY_LOOP label</Label>
+         <Scope>m721kwx3</Scope>
+      </Variable>
+      <Variable id="m721dstu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>249</MaxLength>
+         </Datatype>
+         <Name>ACTIVITY_LOOP_ARBITRARY</Name>
+         <Label>ACTIVITY_LOOP_ARBITRARY label</Label>
+         <Scope>m721kwx3</Scope>
+      </Variable>
+      <Variable id="m722wgb3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>249</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>AGE</Name>
+         <Label>AGE label</Label>
+         <Scope>m721kwx3</Scope>
+      </Variable>
+      <Variable id="m723babu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CollectedVariableType">
+         <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+            <MaxLength>249</MaxLength>
+            <Pattern></Pattern>
+         </Datatype>
+         <Name>Q_END</Name>
+         <Label>Q_END label</Label>
+      </Variable>
+   </Variables>
+   <Iterations>
+      <Iteration id="m721ydpl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="DynamicIterationType">
+         <Name>BOUCLE_PRENOM</Name>
+         <MemberReference>m721eos5</MemberReference>
+         <MemberReference>m721eos5</MemberReference>
+         <IterableReference>m721kwx3</IterableReference>
+      </Iteration>
+   </Iterations>
+</Questionnaire>

--- a/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/in.xml
+++ b/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/in.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Questionnaire xmlns="http://xml.insee.fr/schema/applis/pogues" id="m6uw1hiz"
+  genericName="QUESTIONNAIRE" agency="fr.insee" final="false" flowLogic="FILTER"
+  formulasLanguage="VTL"
+  lastUpdatedDate="Fri Feb 07 2025 16:29:40 GMT+0100 (heure normale d’Europe centrale)"
+  owner="ENO-INTEGRATION-TESTS">
+  <Name>ENO_SUGGESTER_ARBITRARY</Name>
+  <Label>Eno - Suggester with arbitrary</Label>
+  <TargetMode>CAPI</TargetMode>
+  <TargetMode>CATI</TargetMode>
+  <TargetMode>CAWI</TargetMode>
+  <TargetMode>PAPI</TargetMode>
+  <Child id="m6uwl291" depth="1" genericName="MODULE"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+    <Name>S1</Name>
+    <Label>&quot;Sequence&quot;</Label>
+    <TargetMode>CAPI</TargetMode>
+    <TargetMode>CATI</TargetMode>
+    <TargetMode>CAWI</TargetMode>
+    <TargetMode>PAPI</TargetMode>
+    <Child id="m6uw3z0d" questionType="SINGLE_CHOICE"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+      <Name>COUNTRY</Name>
+      <Label>&quot;Suggester question (country)&quot;</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Response id="m6uw9cka" mandatory="false">
+        <CodeListReference>L_PAYS-1-2-0</CodeListReference>
+        <Datatype typeName="TEXT" visualizationHint="SUGGESTER" allowArbitraryResponse="false"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+          <MaxLength>1</MaxLength>
+          <Pattern/>
+        </Datatype>
+        <CollectedVariableReference>m6uxkrge</CollectedVariableReference>
+      </Response>
+    </Child>
+    <Child id="m6uwmbzo" questionType="SINGLE_CHOICE"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="QuestionType">
+      <Name>ACTIVITY</Name>
+      <Label>&quot;Suggester question (activity) with arbitrary response&quot;</Label>
+      <TargetMode>CAPI</TargetMode>
+      <TargetMode>CATI</TargetMode>
+      <TargetMode>CAWI</TargetMode>
+      <TargetMode>PAPI</TargetMode>
+      <Response id="m6uw7qbe" mandatory="false">
+        <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+        <Datatype typeName="TEXT" visualizationHint="SUGGESTER" allowArbitraryResponse="true"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TextDatatypeType">
+          <MaxLength>1</MaxLength>
+          <Pattern/>
+        </Datatype>
+        <CollectedVariableReference>m6uxo8wf</CollectedVariableReference>
+      </Response>
+      <ArbitraryResponse id="m6uxal31" mandatory="false">
+        <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:type="TextDatatypeType">
+          <MaxLength>249</MaxLength>
+        </Datatype>
+        <CollectedVariableReference>m6uxax4o</CollectedVariableReference>
+      </ArbitraryResponse>
+    </Child>
+  </Child>
+  <Child id="m6uxuwt1" depth="1" genericName="MODULE"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+    <Name>END</Name>
+    <Label>&quot;End&quot;</Label>
+    <TargetMode>CAPI</TargetMode>
+    <TargetMode>CATI</TargetMode>
+    <TargetMode>CAWI</TargetMode>
+    <TargetMode>PAPI</TargetMode>
+  </Child>
+  <Child id="idendquest" depth="1" genericName="MODULE"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="SequenceType">
+    <Name>QUESTIONNAIRE_END</Name>
+    <Label>QUESTIONNAIRE_END</Label>
+    <TargetMode>CAPI</TargetMode>
+    <TargetMode>CATI</TargetMode>
+    <TargetMode>CAWI</TargetMode>
+    <TargetMode>PAPI</TargetMode>
+  </Child>
+  <DataCollection id="s2106-dc" uri="http://ddi:fr.insee:DataCollection.s2106-dc"/>
+  <ComponentGroup id="m6uwp0c8">
+    <Name>PAGE_1</Name>
+    <Label>Components for page 1</Label>
+    <MemberReference>m6uwl291</MemberReference>
+    <MemberReference>m6uw3z0d</MemberReference>
+    <MemberReference>m6uwmbzo</MemberReference>
+    <MemberReference>idendquest</MemberReference>
+    <MemberReference>m6uxuwt1</MemberReference>
+  </ComponentGroup>
+  <CodeLists>
+    <CodeList id="L_PAYS-1-2-0" Urn="urn:ddi:fr.insee:l_pays-1-2-0:1">
+      <Name>L_PAYS-1-2-0</Name>
+      <Label>Pays</Label>
+      <SuggesterParameters>
+        <fields>
+          <name>label</name>
+          <rules>[\w]+</rules>
+          <language>French</language>
+          <min>3</min>
+          <stemmer>false</stemmer>
+        </fields>
+        <queryParser>
+          <type>tokenized</type>
+          <params>
+            <language>French</language>
+            <min>3</min>
+            <pattern>[\w.]+</pattern>
+            <stemmer>false</stemmer>
+          </params>
+        </queryParser>
+        <version>1</version>
+      </SuggesterParameters>
+    </CodeList>
+    <CodeList id="L_ACTIVITES-2-0-0" Urn="urn:ddi:fr.insee:l_activites-2-0-0:1">
+      <Name>L_ACTIVITES-2-0-0</Name>
+      <Label>Activités</Label>
+      <SuggesterParameters>
+        <fields>
+          <name>label</name>
+          <rules>[\w]+</rules>
+          <language>French</language>
+          <min>3</min>
+          <stemmer>false</stemmer>
+          <synonyms>
+            <source>EHPAD</source>
+            <target>EPHAD</target>
+            <target>HEPAD</target>
+            <target>EPAD</target>
+            <target>EPAHD</target>
+            <target>EPADH</target>
+          </synonyms>
+          <synonyms>
+            <source>URSSAF</source>
+            <target>URSAF</target>
+            <target>URSAFF</target>
+          </synonyms>
+          <synonyms>
+            <source>ascenseurs</source>
+            <target>ASCENCEUR</target>
+            <target>ASSENCEUR</target>
+            <target>ACSENCEUR</target>
+          </synonyms>
+          <synonyms>
+            <source>joaillerie</source>
+            <target>JOAILLIER</target>
+          </synonyms>
+          <synonyms>
+            <source>alimentaire</source>
+            <target>ALIMANTAIRE</target>
+          </synonyms>
+          <synonyms>
+            <source>briqueterie</source>
+            <target>BRIQUETTERIE</target>
+          </synonyms>
+          <synonyms>
+            <source>prestations</source>
+            <target>PRESTATAIRE</target>
+          </synonyms>
+          <synonyms>
+            <source>alimentaires</source>
+            <target>ALIMANTAIRES</target>
+          </synonyms>
+          <synonyms>
+            <source>echafaudages</source>
+            <target>ECHAFFAUDAGE</target>
+            <target>ECHAFFAUDEUR</target>
+          </synonyms>
+          <synonyms>
+            <source>plaquisterie</source>
+            <target>PLACO</target>
+            <target>PLACOPLATRE</target>
+          </synonyms>
+          <synonyms>
+            <source>pneumatiques</source>
+            <target>PNEUS</target>
+          </synonyms>
+          <synonyms>
+            <source>agroalimentaire</source>
+            <target>AGGROALIMANTAIRE</target>
+            <target>AGROALIMANTAIRE</target>
+          </synonyms>
+          <synonyms>
+            <source>agroalimentaires</source>
+            <target>AGGROALIMANTAIRES</target>
+            <target>AGROALIMENTAIRES</target>
+          </synonyms>
+        </fields>
+        <stopWords>a</stopWords>
+        <stopWords>au</stopWords>
+        <stopWords>dans</stopWords>
+        <stopWords>de</stopWords>
+        <stopWords>des</stopWords>
+        <stopWords>du</stopWords>
+        <stopWords>en</stopWords>
+        <stopWords>et</stopWords>
+        <stopWords>la</stopWords>
+        <stopWords>le</stopWords>
+        <stopWords>ou</stopWords>
+        <stopWords>sur</stopWords>
+        <stopWords>d</stopWords>
+        <stopWords>l</stopWords>
+        <stopWords>aux</stopWords>
+        <stopWords>dans</stopWords>
+        <stopWords>un</stopWords>
+        <stopWords>une</stopWords>
+        <stopWords>pour</stopWords>
+        <stopWords>avec</stopWords>
+        <stopWords>chez</stopWords>
+        <stopWords>par</stopWords>
+        <stopWords>les</stopWords>
+        <queryParser>
+          <type>tokenized</type>
+          <params>
+            <language>French</language>
+            <min>3</min>
+            <pattern>[\w.]+</pattern>
+            <stemmer>false</stemmer>
+          </params>
+        </queryParser>
+        <version>1</version>
+      </SuggesterParameters>
+    </CodeList>
+  </CodeLists>
+  <Variables>
+    <Variable id="m6uxkrge" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:type="CollectedVariableType">
+      <CodeListReference>L_PAYS-1-2-0</CodeListReference>
+      <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:type="TextDatatypeType">
+        <MaxLength>1</MaxLength>
+        <Pattern/>
+      </Datatype>
+      <Name>COUNTRY</Name>
+      <Label>COUNTRY label</Label>
+    </Variable>
+    <Variable id="m6uxo8wf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:type="CollectedVariableType">
+      <CodeListReference>L_ACTIVITES-2-0-0</CodeListReference>
+      <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:type="TextDatatypeType">
+        <MaxLength>1</MaxLength>
+        <Pattern/>
+      </Datatype>
+      <Name>ACTIVITY</Name>
+      <Label>ACTIVITY label</Label>
+    </Variable>
+    <Variable id="m6uxax4o" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:type="CollectedVariableType">
+      <Datatype typeName="TEXT" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:type="TextDatatypeType">
+        <MaxLength>249</MaxLength>
+      </Datatype>
+      <Name>ACTIVITY_ARBITRARY</Name>
+      <Label>ACTIVITY_ARBITRARY label</Label>
+    </Variable>
+  </Variables>
+</Questionnaire>

--- a/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/out-loop.xml
+++ b/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/out-loop.xml
@@ -1,0 +1,1279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+             xmlns:a="ddi:archive:3_3"
+             xmlns:d="ddi:datacollection:3_3"
+             xmlns:g="ddi:group:3_3"
+             xmlns:l="ddi:logicalproduct:3_3"
+             xmlns:r="ddi:reusable:3_3"
+             xmlns:s="ddi:studyunit:3_3"
+             xmlns:xhtml="http://www.w3.org/1999/xhtml"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+             isMaintainable="true"><!--Eno version : 2.12.3-SNAPSHOT. Generation date : 12/02/2025 - 17:21:14-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-m721awnn</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Suggester with arbitrary inside Loop</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-m721awnn</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-m721awnn</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary inside Loop</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwl291</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721c9xk</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721ydpl</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Loop</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxuwt1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwl291</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721c9xk</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">HABITANT</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Habitant"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721eos5</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">BONJOURPRE</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Bonjour " || PRENOM</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722vlnr-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxuwt1</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">END</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"End"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723ou03-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Loop>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721ydpl</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">BOUCLE_PRENOM</r:String>
+            </d:ConstructName>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721ydpl-SEQ</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Loop>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721ydpl-SEQ</r:ID>
+            <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721eos5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721kwx3-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">LISTEDESHA</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721l8n5-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">ACTIVITY_LOOP</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m722vlnr-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">AGE</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722vlnr</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m723ou03-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">Q_END</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723ou03</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">COUNTRY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (country)"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_PAYS-1-2-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_PAYS-1-2-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (activity) with arbitrary response"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID/>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721l8n5</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">ACTIVITY_LOOP</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5-QOP-m7214v7q</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">ACTIVITY_LOOP</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721l8n5-RDOP-m7214v7q</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721l8n5-QOP-m7214v7q</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"LOOP Suggester question (activity) with arbitrary response"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721l8n5-RDOP-m7214v7q</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID/>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m722vlnr</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">AGE</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722vlnr-QOP-m722uy45</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">AGE</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m722vlnr-RDOP-m722uy45</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m722vlnr-QOP-m722uy45</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Quel âge as-tu ?"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m722vlnr-RDOP-m722uy45</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m723ou03</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">Q_END</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723ou03-QOP-m723hzer</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">Q_END</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m723ou03-RDOP-m723hzer</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m723ou03-QOP-m723hzer</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Q_END"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m723ou03-RDOP-m723hzer</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+         <d:QuestionGrid>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721kwx3</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionGridName>
+               <r:String xml:lang="fr-FR">LISTEDESHA</r:String>
+            </d:QuestionGridName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3-QOP-m7233p81</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">PRENOM</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721kwx3-RDOP-m7233p81</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721kwx3-QOP-m7233p81</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Liste des habitants"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:GridDimension displayCode="false" displayLabel="false" rank="1">
+               <d:Roster baseCodeValue="1"
+                         codeIterationValue="1"
+                         minimumRequired="1"
+                         maximumAllowed="2"/>
+            </d:GridDimension>
+            <d:GridDimension displayCode="false" displayLabel="false" rank="2">
+               <d:CodeDomain>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>m721kwx3-secondDimension-fakeCL-1</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </d:CodeDomain>
+            </d:GridDimension>
+            <d:StructuredMixedGridResponseDomain>
+               <d:GridResponseDomainInMixed>
+                  <d:TextDomain maxLength="249">
+                     <r:OutParameter isArray="false">
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>m721kwx3-RDOP-m7233p81</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TextRepresentation maxLength="249"/>
+                     </r:OutParameter>
+                  </d:TextDomain>
+                  <d:GridAttachment>
+                     <d:CellCoordinatesAsDefined>
+                        <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
+                        <d:SelectDimension rank="2" rangeMinimum="1" rangeMaximum="1"/>
+                     </d:CellCoordinatesAsDefined>
+                  </d:GridAttachment>
+               </d:GridResponseDomainInMixed>
+            </d:StructuredMixedGridResponseDomain>
+         </d:QuestionGrid>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-m721kwx3-secondDimension-fakeCL-1</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">FAKE-CODELIST-m721kwx3-secondDimension-fakeCL-1</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>CA-m721kwx3-secondDimension-fakeCL-1-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Prénom ?"</r:Content>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENO_SUGGESTER_ARBITRARY-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENO_SUGGESTER_ARBITRARY</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_PAYS-1-2-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                  </fields>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_PAYS-1-2-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Pays</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_pays-1-2-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_ACTIVITES-2-0-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                     <synonyms>
+                        <source>EHPAD</source>
+                        <target>EPHAD</target>
+                        <target>HEPAD</target>
+                        <target>EPAD</target>
+                        <target>EPAHD</target>
+                        <target>EPADH</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>URSSAF</source>
+                        <target>URSAF</target>
+                        <target>URSAFF</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>ascenseurs</source>
+                        <target>ASCENCEUR</target>
+                        <target>ASSENCEUR</target>
+                        <target>ACSENCEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>joaillerie</source>
+                        <target>JOAILLIER</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaire</source>
+                        <target>ALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>briqueterie</source>
+                        <target>BRIQUETTERIE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>prestations</source>
+                        <target>PRESTATAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaires</source>
+                        <target>ALIMANTAIRES</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>echafaudages</source>
+                        <target>ECHAFFAUDAGE</target>
+                        <target>ECHAFFAUDEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>plaquisterie</source>
+                        <target>PLACO</target>
+                        <target>PLACOPLATRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>pneumatiques</source>
+                        <target>PNEUS</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaire</source>
+                        <target>AGGROALIMANTAIRE</target>
+                        <target>AGROALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaires</source>
+                        <target>AGGROALIMANTAIRES</target>
+                        <target>AGROALIMENTAIRES</target>
+                     </synonyms>
+                  </fields>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">a</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">au</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">de</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">des</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">du</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">en</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">et</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">la</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">le</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">ou</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">sur</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">d</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">l</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">aux</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">un</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">une</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">pour</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">avec</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">chez</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">par</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">les</stopWords>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_ACTIVITES-2-0-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Activités</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_activites-2-0-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721kwx3-secondDimension-fakeCL-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">FAKE-CODELIST-m721kwx3-secondDimension-fakeCL-1</r:Content>
+            </r:Label>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3-secondDimension-fakeCL-1-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>CA-m721kwx3-secondDimension-fakeCL-1-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxkrge</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">COUNTRY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_PAYS-1-2-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxo8wf</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxax4o</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY_ARBITRARY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY_ARBITRARY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m723w1qs</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m72170v3</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">PRENOM</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Prénom ?</r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3-QOP-m7233p81</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721avl2</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY_LOOP</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY_LOOP label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5-QOP-m7214v7q</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721dstu</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY_LOOP_ARBITRARY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY_LOOP_ARBITRARY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5-QOP-m723qv7z</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721l8n5</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m722wgb3</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">AGE</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">AGE label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722vlnr-QOP-m722uy45</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722vlnr</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m723babu</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">Q_END</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Q_END label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723ou03-QOP-m723hzer</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723ou03</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m721kwx3-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721kwx3</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
+               </r:BasedOnReference>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m721ydpl</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Loop</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Loop</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>LISTEDESHA</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m72170v3</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721avl2</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721dstu</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m722wgb3</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-m721awnn-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-m721awnn</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxkrge</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxo8wf</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxax4o</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m723babu</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <l:VariableGroupReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m721kwx3-vg</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+            </l:VariableGroupReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+               l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-m721awnn</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-m721awnn</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-m721awnn</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-m721awnn</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-m721awnn</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-m721awnn</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                          xmlns:cm="ddi:comparative:3_3"
+                          xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                          xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-m721awnn</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary inside Loop questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-m721awnn</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>

--- a/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/out.xml
+++ b/src/test/resources/pogues-xml-to-ddi/suggester-arbitrary/out.xml
@@ -1,0 +1,680 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+             xmlns:a="ddi:archive:3_3"
+             xmlns:d="ddi:datacollection:3_3"
+             xmlns:g="ddi:group:3_3"
+             xmlns:l="ddi:logicalproduct:3_3"
+             xmlns:r="ddi:reusable:3_3"
+             xmlns:s="ddi:studyunit:3_3"
+             xmlns:xhtml="http://www.w3.org/1999/xhtml"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+             isMaintainable="true"><!--Eno version : 2.12.3-SNAPSHOT.3. Generation date : 10/02/2025 - 18:46:25-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-m6uw1hiz</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Suggester with arbitrary</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-m6uw1hiz</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwl291</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxuwt1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwl291</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxuwt1</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">END</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"End"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">COUNTRY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (country)"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_PAYS-1-2-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_PAYS-1-2-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (activity) with arbitrary response"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID/>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENO_SUGGESTER_ARBITRARY-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENO_SUGGESTER_ARBITRARY</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_PAYS-1-2-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                  </fields>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_PAYS-1-2-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Pays</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_pays-1-2-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_ACTIVITES-2-0-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                     <synonyms>
+                        <source>EHPAD</source>
+                        <target>EPHAD</target>
+                        <target>HEPAD</target>
+                        <target>EPAD</target>
+                        <target>EPAHD</target>
+                        <target>EPADH</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>URSSAF</source>
+                        <target>URSAF</target>
+                        <target>URSAFF</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>ascenseurs</source>
+                        <target>ASCENCEUR</target>
+                        <target>ASSENCEUR</target>
+                        <target>ACSENCEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>joaillerie</source>
+                        <target>JOAILLIER</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaire</source>
+                        <target>ALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>briqueterie</source>
+                        <target>BRIQUETTERIE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>prestations</source>
+                        <target>PRESTATAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaires</source>
+                        <target>ALIMANTAIRES</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>echafaudages</source>
+                        <target>ECHAFFAUDAGE</target>
+                        <target>ECHAFFAUDEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>plaquisterie</source>
+                        <target>PLACO</target>
+                        <target>PLACOPLATRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>pneumatiques</source>
+                        <target>PNEUS</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaire</source>
+                        <target>AGGROALIMANTAIRE</target>
+                        <target>AGROALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaires</source>
+                        <target>AGGROALIMANTAIRES</target>
+                        <target>AGROALIMENTAIRES</target>
+                     </synonyms>
+                  </fields>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">a</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">au</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">de</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">des</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">du</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">en</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">et</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">la</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">le</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">ou</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">sur</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">d</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">l</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">aux</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">un</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">une</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">pour</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">avec</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">chez</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">par</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">les</stopWords>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_ACTIVITES-2-0-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Activités</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_activites-2-0-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxkrge</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">COUNTRY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_PAYS-1-2-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxo8wf</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxax4o</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY_ARBITRARY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY_ARBITRARY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uxal31</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-m6uw1hiz-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-m6uw1hiz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxkrge</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxo8wf</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxax4o</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+                            l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-m6uw1hiz</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                          xmlns:cm="ddi:comparative:3_3"
+                          xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                          xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-m6uw1hiz</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-m6uw1hiz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>


### PR DESCRIPTION
## Summary

La réponse "champ libre" pour les questions à choix unique en auto-complétion (réponse _aribitrary_ pour les _suggesters_) n'est pas modélisée en DDI.

Cependant il faut que la variable associée à la réponse _arbitrary_ soit créée dans le DDI, et mise dans le bon `VariableGroup`.

## Done

Dans `inputs/pogues-xml`

- ajustements XPath pour que la présence de la variable arbitrary (qui est associée à une `ArbitraryResponse` et pas une `Response` comme les autres collectées) ne fasse pas planter la transfo (erreurs du style _An empty sequence is not allowed as the first argument of is-not-collected_)
- ajout de `ArbitraryResponse` à côté de `Response` dans certains templates

_**To do**_ : ajouter ce qu'il faut pour que la variable arbitrary soit référencée dans un `VariableGroup` dans DDI