### PR TITLE
fix: pogues plus ddi mapping

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/PoguesDDIToEno.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/PoguesDDIToEno.java
@@ -8,6 +8,7 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.processing.common.EnoProcessing;
 import fr.insee.eno.core.processing.in.DDIInProcessing;
+import fr.insee.eno.core.processing.in.PoguesInProcessing;
 import fr.insee.eno.core.serialize.DDIDeserializer;
 import fr.insee.eno.core.serialize.PoguesDeserializer;
 import fr.insee.pogues.model.Questionnaire;
@@ -52,6 +53,7 @@ public class PoguesDDIToEno implements InToEno {
     public EnoQuestionnaire transform(EnoParameters enoParameters) {
         EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
         new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+        new PoguesInProcessing().applyProcessing(enoQuestionnaire);
         new DDIMapper().mapDDI(ddiQuestionnaire, enoQuestionnaire);
         new DDIInProcessing().applyProcessing(enoQuestionnaire);
         new EnoProcessing(enoParameters).applyProcessing(enoQuestionnaire);

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesMultipleChoiceQuestionConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesMultipleChoiceQuestionConverter.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.converter;
 
+import fr.insee.eno.core.exceptions.technical.ConversionException;
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.model.question.ComplexMultipleChoiceQuestion;
@@ -36,13 +37,16 @@ class PoguesMultipleChoiceQuestionConverter {
     private static EnoObject convertTable(QuestionType poguesQuestion) {
         if (isStaticTable(poguesQuestion))
             return new TableQuestion();
-        return new DynamicTableQuestion();
+        if (isDynamicTable(poguesQuestion))
+            return new DynamicTableQuestion();
+        throw new ConversionException("Unable to convert Pogues table '" + poguesQuestion.getId() + "'.");
     }
     private static boolean isStaticTable(QuestionType poguesQuestion) {
         // A Pogues table is a static table if all of its "dimensions" are non-dynamic.
-        return poguesQuestion.getResponseStructure().getDimension().stream()
-                .map(DimensionType::getDynamic)
-                .allMatch("0"::equals);
+        return poguesQuestion.getResponseStructure().getDimension().getFirst().getDynamic().equals("NON_DYNAMIC");
+    }
+    private static boolean isDynamicTable(QuestionType poguesQuestion) {
+        return poguesQuestion.getResponseStructure().getDimension().getFirst().getDynamic().equals("DYNAMIC_LENGTH");
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesSingleResponseQuestionConversion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesSingleResponseQuestionConversion.java
@@ -3,10 +3,7 @@ package fr.insee.eno.core.converter;
 import fr.insee.eno.core.exceptions.technical.MappingException;
 import fr.insee.eno.core.model.EnoObject;
 import fr.insee.eno.core.model.question.*;
-import fr.insee.pogues.model.DatatypeTypeEnum;
-import fr.insee.pogues.model.QuestionType;
-import fr.insee.pogues.model.QuestionTypeEnum;
-import fr.insee.pogues.model.ResponseType;
+import fr.insee.pogues.model.*;
 
 class PoguesSingleResponseQuestionConversion {
 
@@ -18,7 +15,9 @@ class PoguesSingleResponseQuestionConversion {
         if (QuestionTypeEnum.SIMPLE.equals(questionType))
             return convertSimpleQuestion(poguesQuestion);
         if (QuestionTypeEnum.SINGLE_CHOICE.equals(questionType))
-            return new UniqueChoiceQuestion();
+            return convertUniqueChoiceQuestion(poguesQuestion);
+        if (QuestionTypeEnum.PAIRWISE.equals(questionType))
+            return new PairwiseQuestion();
         throw new MappingException("Unexpected single response question of type " + questionType + ".");
     }
 
@@ -32,6 +31,13 @@ class PoguesSingleResponseQuestionConversion {
             case DATE -> new DateQuestion();
             case DURATION -> new DurationQuestion();
         };
+    }
+
+    private static EnoObject convertUniqueChoiceQuestion(QuestionType poguesQuestion) {
+        if (poguesQuestion.getResponse().getFirst().getDatatype().getVisualizationHint()
+                .equals(VisualizationHintEnum.SUGGESTER))
+            return new SuggesterQuestion();
+        return new UniqueChoiceQuestion();
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/LunaticMapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/LunaticMapper.java
@@ -145,7 +145,7 @@ public class LunaticMapper extends Mapper {
                 expression, lunaticObject, enoObject.getClass(), propertyDescriptor.getName());
         assert lunaticCollection != null : "Lunatic collections are expected to be initialized.";
         // Get the model collection
-        Collection<Object> enoCollection = readCollection(propertyDescriptor, enoObject);
+        Collection<Object> enoCollection = readList(propertyDescriptor, enoObject);
         assert enoCollection != null : "Model collections are expected to be initialized.";
         if (! enoCollection.isEmpty()) {
             // Content type of the model collection

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/Mapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/Mapper.java
@@ -10,10 +10,7 @@ import org.springframework.beans.BeanWrapper;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 public class Mapper {
@@ -69,9 +66,10 @@ public class Mapper {
     }
 
     @SuppressWarnings("unchecked")
-    Collection<Object> readCollection(PropertyDescriptor propertyDescriptor, EnoObject enoObject) {
+    List<Object> readList(PropertyDescriptor propertyDescriptor, EnoObject enoObject) {
         try {
-            return (Collection<Object>) propertyDescriptor.getReadMethod().invoke(enoObject);
+            Collection<Object> collection = (Collection<Object>) propertyDescriptor.getReadMethod().invoke(enoObject);
+            return new ArrayList<>(collection);
         } catch (IllegalAccessException | InvocationTargetException e) {
             log.debug("hint: Make sure that collection has been initialized (i.e. is not null) in model class.");
             log.debug("hint: Example: List<SomeEnoObject> = new ArrayList<>();");

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/Mapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/Mapper.java
@@ -68,8 +68,7 @@ public class Mapper {
     @SuppressWarnings("unchecked")
     List<Object> readList(PropertyDescriptor propertyDescriptor, EnoObject enoObject) {
         try {
-            Collection<Object> collection = (Collection<Object>) propertyDescriptor.getReadMethod().invoke(enoObject);
-            return new ArrayList<>(collection);
+            return (List<Object>) propertyDescriptor.getReadMethod().invoke(enoObject);
         } catch (IllegalAccessException | InvocationTargetException e) {
             log.debug("hint: Make sure that collection has been initialized (i.e. is not null) in model class.");
             log.debug("hint: Example: List<SomeEnoObject> = new ArrayList<>();");

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -158,8 +158,18 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
      * They are inserted in objects that rely on a code list through a DDI processing.
      */
     @Pogues("getCodeLists()?.getCodeList()")
-    @DDI("getResourcePackageArray(0).getCodeListSchemeArray(0).getCodeListList()")
+    @DDI("getResourcePackageArray(0).getCodeListSchemeArray(0).getCodeListList()" +
+            ".?[#this.getIDArray(0).getStringValue() != 'INSEE-COMMUN-CL-Booleen']" +
+            ".?[! #this.getIDArray(0).getStringValue().contains('secondDimension-fakeCL')]")
     List<CodeList> codeLists = new ArrayList<>();
+
+    /** In addition to the code lists defined in Pogues, there are 'fake' code lists added by Eno xml in the
+     * Pogues to DDI transformation to represent the second dimension of tables.
+     */
+    @DDI("getResourcePackageArray(0).getCodeListSchemeArray(0).getCodeListList()" +
+            ".?[#this.getIDArray(0).getStringValue() != 'INSEE-COMMUN-CL-Booleen']" +
+            ".?[#this.getIDArray(0).getStringValue().contains('secondDimension-fakeCL')]")
+    List<CodeList> fakeCodeLists = new ArrayList<>();
 
     public static List<SequenceType> mapPoguesSequences(Questionnaire poguesQuestionnaire) {
         List<SequenceType> poguesSequences = poguesQuestionnaire.getChild().stream()

--- a/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/EnoQuestionnaire.java
@@ -211,7 +211,8 @@ public class EnoQuestionnaire extends EnoIdentifiableObject {
     }
     public static boolean isSingleResponseQuestion(QuestionType poguesQuestion) {
         return QuestionTypeEnum.SIMPLE.equals(poguesQuestion.getQuestionType())
-                || QuestionTypeEnum.SINGLE_CHOICE.equals(poguesQuestion.getQuestionType());
+                || QuestionTypeEnum.SINGLE_CHOICE.equals(poguesQuestion.getQuestionType())
+                || QuestionTypeEnum.PAIRWISE.equals(poguesQuestion.getQuestionType());
     }
 
     public static List<QuestionType> mapPoguesMultipleResponseQuestions(Questionnaire poguesQuestionnaire) {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
@@ -12,8 +12,8 @@ import fr.insee.pogues.model.ExpressionType;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import static fr.insee.eno.core.annotations.Contexts.Context;
 
@@ -47,6 +47,6 @@ public class CalculatedExpression extends EnoObject {
     /** In DDI, the expression contains variable references instead of variables names.
      * This list contains the references of these variables. */
     @DDI("getInParameterList()")
-    private Set<BindingReference> bindingReferences = new HashSet<>();
+    private List<BindingReference> bindingReferences = new ArrayList<>();
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/model/navigation/ComponentFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/navigation/ComponentFilter.java
@@ -10,9 +10,8 @@ import fr.insee.lunatic.model.flat.LabelTypeEnum;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /** Class that is very similar to the calculatedExpression class, designed to map the "conditionFilter"
  * property in Lunatic components.
@@ -37,10 +36,10 @@ public class ComponentFilter extends EnoObject {
     String type = LabelTypeEnum.VTL.value();
 
     @Getter
-    private final Set<BindingReference> bindingReferences = new HashSet<>();
+    private final List<BindingReference> bindingReferences = new ArrayList<>();
 
     @Getter
-    private final Set<BindingReference> resolvedBindingReferences = new HashSet<>();
+    private final List<BindingReference> resolvedBindingReferences = new ArrayList<>();
 
     /** Contrary to CalculatedExpression class, Lunatic binding dependencies are mapped in the condition filter
      * object. */

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoResolveBindingReferences.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/common/steps/EnoResolveBindingReferences.java
@@ -10,7 +10,10 @@ import fr.insee.eno.core.model.variable.CalculatedVariable;
 import fr.insee.eno.core.model.variable.Variable;
 import fr.insee.eno.core.processing.ProcessingStep;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /** Processing on the Eno-model calculated expressions concerning calculated variables.
  * When a calculated expression has a reference to a calculated variable, we want to retrieve the variables references
@@ -96,7 +99,7 @@ public class EnoResolveBindingReferences implements ProcessingStep<EnoQuestionna
      * @param bindingReferences References to be added in the expression binding references.
      * @param expression Expression being updated.
      */
-    private void insertReferences(Set<BindingReference> bindingReferences, CalculatedExpression expression) {
+    private void insertReferences(List<BindingReference> bindingReferences, CalculatedExpression expression) {
         for (BindingReference bindingReference : bindingReferences) {
             Variable variable = findVariable(bindingReference);
             if (Variable.CollectionType.CALCULATED.equals(variable.getCollectionType())) {
@@ -112,14 +115,14 @@ public class EnoResolveBindingReferences implements ProcessingStep<EnoQuestionna
         enoComponents.stream()
                 .map(EnoComponent::getComponentFilter)
                 .forEach(componentFilter -> {
-                    Set<BindingReference> references = resolveBindingReferences(componentFilter.getBindingReferences());
+                    List<BindingReference> references = resolveBindingReferences(componentFilter.getBindingReferences());
                     componentFilter.getResolvedBindingReferences().addAll(references);
                 } );
     }
 
     /** Update the binding references of the "min" and "max" expressions of the given loop. */
     private void updateStandaloneLoopReferences(StandaloneLoop standaloneLoop) {
-        Set<BindingReference> references = resolveBindingReferences(standaloneLoop.getMinIteration().getBindingReferences());
+        List<BindingReference> references = resolveBindingReferences(standaloneLoop.getMinIteration().getBindingReferences());
         standaloneLoop.getMinIteration().setBindingReferences(references);
 
         references = resolveBindingReferences(standaloneLoop.getMaxIteration().getBindingReferences());
@@ -131,9 +134,9 @@ public class EnoResolveBindingReferences implements ProcessingStep<EnoQuestionna
      * this method adds the references contained in these calculated variables.
      * @param bindingReferences Binding references to be updated.
      */
-    private Set<BindingReference> resolveBindingReferences(Set<BindingReference> bindingReferences) {
+    private List<BindingReference> resolveBindingReferences(List<BindingReference> bindingReferences) {
         // shallow copy
-        Set<BindingReference> resolvedBindingReferences = new HashSet<>(bindingReferences);
+        List<BindingReference> resolvedBindingReferences = new ArrayList<>(bindingReferences);
         //
         for (BindingReference bindingReference : bindingReferences) {
             Variable variable = findVariable(bindingReference);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/PoguesInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/PoguesInProcessing.java
@@ -4,8 +4,6 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.processing.ProcessingPipeline;
 import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertCodeLists;
 import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertMultipleChoiceLabels;
-import fr.insee.eno.core.processing.in.steps.pogues.PoguesCheckExpressionLanguage;
-import fr.insee.eno.core.processing.in.steps.pogues.PoguesCheckFilterMode;
 import fr.insee.eno.core.processing.in.steps.pogues.PoguesCodeResponseDetails;
 import fr.insee.eno.core.processing.in.steps.pogues.PoguesNestedCodeLists;
 
@@ -15,8 +13,8 @@ public class PoguesInProcessing {
         ProcessingPipeline<EnoQuestionnaire> processingPipeline = new ProcessingPipeline<>();
         // Note: some steps share the same logic between Pogues and DDI, DDI steps are re-used in that case
         processingPipeline.start(enoQuestionnaire)
-                .then(new PoguesCheckFilterMode())
-                .then(new PoguesCheckExpressionLanguage())
+                //.then(new PoguesCheckFilterMode())
+                //.then(new PoguesCheckExpressionLanguage()) // Disabled while Pogues DDI is used
                 .then(new PoguesNestedCodeLists())
                 .then(new DDIInsertCodeLists())
                 .then(new DDIInsertMultipleChoiceLabels())

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveSequencesStructure.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveSequencesStructure.java
@@ -25,6 +25,8 @@ public class DDIResolveSequencesStructure implements ProcessingStep<EnoQuestionn
     @Override
     public void apply(EnoQuestionnaire enoQuestionnaire) {
         this.enoQuestionnaire = enoQuestionnaire;
+        enoQuestionnaire.getSequences().forEach(sequence -> sequence.getSequenceStructure().clear());
+        enoQuestionnaire.getSubsequences().forEach(subsequence -> subsequence.getSequenceStructure().clear());
         for (Sequence sequence : enoQuestionnaire.getSequences()) {
             resolveSequenceStructure(sequence);
         }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressions.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressions.java
@@ -10,7 +10,10 @@ import fr.insee.eno.core.model.variable.CalculatedVariable;
 import fr.insee.eno.core.model.variable.Variable;
 import fr.insee.eno.core.processing.ProcessingStep;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 public class DDIResolveVariableReferencesInExpressions implements ProcessingStep<EnoQuestionnaire> {
 
@@ -72,7 +75,7 @@ public class DDIResolveVariableReferencesInExpressions implements ProcessingStep
      * @param bindingReferences A set of binding references.
      * @return A list of the binding references, ordered by id.
      */
-    private static List<BindingReference> orderById(Set<BindingReference> bindingReferences) {
+    private static List<BindingReference> orderById(List<BindingReference> bindingReferences) {
         List<BindingReference> res = new ArrayList<>(bindingReferences);
         res.sort(Comparator.comparing(BindingReference::getId));
         return res;

--- a/eno-core/src/test/java/fr/insee/eno/core/DDIToEnoTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/DDIToEnoTest.java
@@ -76,7 +76,8 @@ class DDIToEnoTest {
         }
         @Test
         void codeLists() {
-            assertEquals(16, enoQuestionnaire.getCodeLists().size()); // Code lists should be refactored at questionnaire level
+            assertEquals(10, enoQuestionnaire.getCodeLists().size());
+            assertEquals(5, enoQuestionnaire.getFakeCodeLists().size());
         }
         @Test
         void sequencesCount() {

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicTableQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicTableQuestionTest.java
@@ -19,7 +19,7 @@ class DynamicTableQuestionTest {
         poguesTable.getLabel().add("Dynamic table question.");
         ResponseStructureType responseStructure = new ResponseStructureType();
         DimensionType dimension = new DimensionType();
-        dimension.setDynamic("1-5");
+        dimension.setDynamic("DYNAMIC_LENGTH");
         responseStructure.getDimension().add(dimension);
         poguesTable.setResponseStructure(responseStructure);
 

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/TableQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/TableQuestionTest.java
@@ -19,6 +19,9 @@ class TableQuestionTest {
         poguesTable.getLabel().add("Static table question.");
         ResponseStructureType responseStructure = new ResponseStructureType();
         poguesTable.setResponseStructure(responseStructure);
+        DimensionType dimensionType = new DimensionType();
+        dimensionType.setDynamic("NON_DYNAMIC");
+        poguesTable.getResponseStructure().getDimension().add(dimensionType);
 
         Questionnaire poguesQuestionnaire = new Questionnaire();
         SequenceType poguesSequence = new SequenceType();

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertCodeListsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIInsertCodeListsTest.java
@@ -1,0 +1,39 @@
+package fr.insee.eno.core.processing.in.steps.ddi;
+
+import fr.insee.eno.core.exceptions.business.DDIParsingException;
+import fr.insee.eno.core.mappers.DDIMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.ComplexMultipleChoiceQuestion;
+import fr.insee.eno.core.serialize.DDIDeserializer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DDIInsertCodeListsTest {
+
+    @Test
+    void multipleChoiceQuestions() throws DDIParsingException {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        new DDIMapper().mapDDI(
+                DDIDeserializer.deserialize(this.getClass().getClassLoader().getResourceAsStream(
+                        "integration/ddi/ddi-mcq.xml")),
+                enoQuestionnaire);
+
+        // When
+        new DDIInsertCodeLists().apply(enoQuestionnaire);
+
+        // Then
+        // This questionnaire has 1 'simple' multiples choice question, then 4 'complex' multiple choice questions.
+        // For each of these, let's test that the code list is present,
+        // and its id should be the same as the one referenced during mapping.
+        for (int i = 1; i < 5; i ++) {
+            ComplexMultipleChoiceQuestion mcq = (ComplexMultipleChoiceQuestion) enoQuestionnaire
+                    .getMultipleResponseQuestions().get(i);
+            assertEquals(mcq.getLeftColumnCodeListReference(), mcq.getLeftColumn().getId());
+        }
+    }
+
+    // TODO: tests for table question cases.
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/in/steps/ddi/DDIResolveVariableReferencesInExpressionsTest.java
@@ -7,8 +7,8 @@ import fr.insee.eno.core.model.navigation.Filter;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -49,7 +49,7 @@ class DDIResolveVariableReferencesInExpressionsTest {
             Filter filter = new Filter();
             CalculatedExpression calculatedExpression= new CalculatedExpression();
             calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-10 = 1");
-            Set<BindingReference> bindingReferences = new LinkedHashSet<>();
+            List<BindingReference> bindingReferences = new ArrayList<>();
             bindingReferences.add(new BindingReference("foo-ref-1", "FOO_A"));
             bindingReferences.add(new BindingReference("foo-ref-10", "FOO_K"));
             calculatedExpression.setBindingReferences(bindingReferences);
@@ -59,7 +59,7 @@ class DDIResolveVariableReferencesInExpressionsTest {
             new DDIResolveVariableReferencesInExpressions().apply(enoQuestionnaire);
             //
             assertEquals("FOO_A = 1 and FOO_K = 1",
-                    enoQuestionnaire.getFilters().get(0).getExpression().getValue());
+                    enoQuestionnaire.getFilters().getFirst().getExpression().getValue());
         }
 
         /**
@@ -73,7 +73,7 @@ class DDIResolveVariableReferencesInExpressionsTest {
             Filter filter = new Filter();
             CalculatedExpression calculatedExpression= new CalculatedExpression();
             calculatedExpression.setValue("foo-ref-1 = 1 and foo-ref-10 = 1");
-            Set<BindingReference> bindingReferences = new LinkedHashSet<>();
+            List<BindingReference> bindingReferences = new ArrayList<>();
             bindingReferences.add(new BindingReference("foo-ref-10", "FOO_K"));
             bindingReferences.add(new BindingReference("foo-ref-1", "FOO_A"));
             calculatedExpression.setBindingReferences(bindingReferences);

--- a/eno-core/src/test/resources/functional/ddi/ddi-l8x6fhtd.xml
+++ b/eno-core/src/test/resources/functional/ddi/ddi-l8x6fhtd.xml
@@ -10,7 +10,7 @@
              xmlns:xs="http://www.w3.org/2001/XMLSchema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
-             isMaintainable="true"><!--Eno version : 2.4.9. Generation date : 17/08/2023 - 13:11:33-->
+             isMaintainable="true"><!--Eno version : 2.12.3-SNAPSHOT. Generation date : 13/02/2025 - 12:57:17-->
    <r:Agency>fr.insee</r:Agency>
    <r:ID>INSEE-l8x6fhtd</r:ID>
    <r:Version>1</r:Version>
@@ -403,12 +403,6 @@
             <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QC</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
-            </d:ControlConstructReference>
-            <d:ControlConstructReference>
-               <r:Agency>fr.insee</r:Agency>
                <r:ID>l988nifn-QC</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
@@ -609,6 +603,7 @@
             <r:Agency>fr.insee</r:Agency>
             <r:ID>lc0c5724-SEQ</r:ID>
             <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>lcoxacye</r:ID>
@@ -640,6 +635,7 @@
             <r:Agency>fr.insee</r:Agency>
             <r:ID>lc0cefvn-SEQ</r:ID>
             <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>lc0c6j7f</r:ID>
@@ -683,6 +679,7 @@
             <r:Agency>fr.insee</r:Agency>
             <r:ID>lcq19udk-SEQ</r:ID>
             <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>lchfj2o1</r:ID>
@@ -708,6 +705,7 @@
             <r:Agency>fr.insee</r:Agency>
             <r:ID>lcq1cpki-SEQ</r:ID>
             <r:Version>1</r:Version>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">loopContent</d:TypeOfSequence>
             <d:ControlConstructReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>lcq1esye</r:ID>
@@ -769,20 +767,6 @@
                <r:ID>l9nxvj6m</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>QuestionItem</r:TypeOfObject>
-            </r:QuestionReference>
-         </d:QuestionConstruct>
-         <d:QuestionConstruct>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6ntp2p-QC</r:ID>
-            <r:Version>1</r:Version>
-            <d:ConstructName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA</r:String>
-            </d:ConstructName>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
             </r:QuestionReference>
          </d:QuestionConstruct>
          <d:QuestionConstruct>
@@ -1392,291 +1376,6 @@
                </r:OutParameter>
             </d:NumericDomain>
          </d:QuestionItem>
-         <d:QuestionGrid>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6ntp2p</r:ID>
-            <r:Version>1</r:Version>
-            <d:QuestionGridName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA</r:String>
-            </d:QuestionGridName>
-            <r:OutParameter isArray="false">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nedhr</r:ID>
-               <r:Version>1</r:Version>
-               <r:ParameterName>
-                  <r:String xml:lang="fr-FR">QCMIMBRICA1</r:String>
-               </r:ParameterName>
-            </r:OutParameter>
-            <r:OutParameter isArray="false">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6npups</r:ID>
-               <r:Version>1</r:Version>
-               <r:ParameterName>
-                  <r:String xml:lang="fr-FR">QCMIMBRICA2</r:String>
-               </r:ParameterName>
-            </r:OutParameter>
-            <r:OutParameter isArray="false">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nnsfl</r:ID>
-               <r:Version>1</r:Version>
-               <r:ParameterName>
-                  <r:String xml:lang="fr-FR">QCMIMBRICA3</r:String>
-               </r:ParameterName>
-            </r:OutParameter>
-            <r:OutParameter isArray="false">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nygf3</r:ID>
-               <r:Version>1</r:Version>
-               <r:ParameterName>
-                  <r:String xml:lang="fr-FR">QCMIMBRICA4</r:String>
-               </r:ParameterName>
-            </r:OutParameter>
-            <r:OutParameter isArray="false">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nw4kc</r:ID>
-               <r:Version>1</r:Version>
-               <r:ParameterName>
-                  <r:String xml:lang="fr-FR">QCMIMBRICA5</r:String>
-               </r:ParameterName>
-            </r:OutParameter>
-            <r:Binding>
-               <r:SourceParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-RDOP-lk6nedhr</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:SourceParameterReference>
-               <r:TargetParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-QOP-lk6nedhr</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:TargetParameterReference>
-            </r:Binding>
-            <r:Binding>
-               <r:SourceParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-RDOP-lk6npups</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:SourceParameterReference>
-               <r:TargetParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-QOP-lk6npups</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:TargetParameterReference>
-            </r:Binding>
-            <r:Binding>
-               <r:SourceParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-RDOP-lk6nnsfl</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:SourceParameterReference>
-               <r:TargetParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-QOP-lk6nnsfl</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:TargetParameterReference>
-            </r:Binding>
-            <r:Binding>
-               <r:SourceParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-RDOP-lk6nygf3</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:SourceParameterReference>
-               <r:TargetParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-QOP-lk6nygf3</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:TargetParameterReference>
-            </r:Binding>
-            <r:Binding>
-               <r:SourceParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-RDOP-lk6nw4kc</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:SourceParameterReference>
-               <r:TargetParameterReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lk6ntp2p-QOP-lk6nw4kc</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
-               </r:TargetParameterReference>
-            </r:Binding>
-            <d:QuestionText>
-               <d:LiteralText>
-                  <d:Text xml:lang="fr-FR">qcm-imbrication</d:Text>
-               </d:LiteralText>
-            </d:QuestionText>
-            <d:GridDimension displayCode="false" displayLabel="false" rank="1">
-               <d:CodeDomain>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>l9ny0mef</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </d:CodeDomain>
-            </d:GridDimension>
-            <d:StructuredMixedGridResponseDomain>
-               <d:GridResponseDomainInMixed>
-                  <d:CodeDomain>
-                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">drop-down-list</r:GenericOutputFormat>
-                     <r:CodeListReference>
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6nv33d</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:TypeOfObject>CodeList</r:TypeOfObject>
-                     </r:CodeListReference>
-                     <r:OutParameter isArray="false">
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6ntp2p-RDOP-lk6nedhr</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:CodeRepresentation>
-                           <r:CodeListReference>
-                              <r:Agency>fr.insee</r:Agency>
-                              <r:ID>lk6nv33d</r:ID>
-                              <r:Version>1</r:Version>
-                              <r:TypeOfObject>CodeList</r:TypeOfObject>
-                           </r:CodeListReference>
-                        </r:CodeRepresentation>
-                     </r:OutParameter>
-                     <r:ResponseCardinality maximumResponses="1"/>
-                  </d:CodeDomain>
-                  <d:GridAttachment>
-                     <d:CellCoordinatesAsDefined>
-                        <d:SelectDimension rank="1" rangeMinimum="1" rangeMaximum="1"/>
-                     </d:CellCoordinatesAsDefined>
-                  </d:GridAttachment>
-               </d:GridResponseDomainInMixed>
-               <d:GridResponseDomainInMixed>
-                  <d:CodeDomain>
-                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">drop-down-list</r:GenericOutputFormat>
-                     <r:CodeListReference>
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6nv33d</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:TypeOfObject>CodeList</r:TypeOfObject>
-                     </r:CodeListReference>
-                     <r:OutParameter isArray="false">
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6ntp2p-RDOP-lk6npups</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:CodeRepresentation>
-                           <r:CodeListReference>
-                              <r:Agency>fr.insee</r:Agency>
-                              <r:ID>lk6nv33d</r:ID>
-                              <r:Version>1</r:Version>
-                              <r:TypeOfObject>CodeList</r:TypeOfObject>
-                           </r:CodeListReference>
-                        </r:CodeRepresentation>
-                     </r:OutParameter>
-                     <r:ResponseCardinality maximumResponses="1"/>
-                  </d:CodeDomain>
-                  <d:GridAttachment>
-                     <d:CellCoordinatesAsDefined>
-                        <d:SelectDimension rank="1" rangeMinimum="2" rangeMaximum="2"/>
-                     </d:CellCoordinatesAsDefined>
-                  </d:GridAttachment>
-               </d:GridResponseDomainInMixed>
-               <d:GridResponseDomainInMixed>
-                  <d:CodeDomain>
-                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">drop-down-list</r:GenericOutputFormat>
-                     <r:CodeListReference>
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6nv33d</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:TypeOfObject>CodeList</r:TypeOfObject>
-                     </r:CodeListReference>
-                     <r:OutParameter isArray="false">
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6ntp2p-RDOP-lk6nnsfl</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:CodeRepresentation>
-                           <r:CodeListReference>
-                              <r:Agency>fr.insee</r:Agency>
-                              <r:ID>lk6nv33d</r:ID>
-                              <r:Version>1</r:Version>
-                              <r:TypeOfObject>CodeList</r:TypeOfObject>
-                           </r:CodeListReference>
-                        </r:CodeRepresentation>
-                     </r:OutParameter>
-                     <r:ResponseCardinality maximumResponses="1"/>
-                  </d:CodeDomain>
-                  <d:GridAttachment>
-                     <d:CellCoordinatesAsDefined>
-                        <d:SelectDimension rank="1" rangeMinimum="3" rangeMaximum="3"/>
-                     </d:CellCoordinatesAsDefined>
-                  </d:GridAttachment>
-               </d:GridResponseDomainInMixed>
-               <d:GridResponseDomainInMixed>
-                  <d:CodeDomain>
-                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">drop-down-list</r:GenericOutputFormat>
-                     <r:CodeListReference>
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6nv33d</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:TypeOfObject>CodeList</r:TypeOfObject>
-                     </r:CodeListReference>
-                     <r:OutParameter isArray="false">
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6ntp2p-RDOP-lk6nygf3</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:CodeRepresentation>
-                           <r:CodeListReference>
-                              <r:Agency>fr.insee</r:Agency>
-                              <r:ID>lk6nv33d</r:ID>
-                              <r:Version>1</r:Version>
-                              <r:TypeOfObject>CodeList</r:TypeOfObject>
-                           </r:CodeListReference>
-                        </r:CodeRepresentation>
-                     </r:OutParameter>
-                     <r:ResponseCardinality maximumResponses="1"/>
-                  </d:CodeDomain>
-                  <d:GridAttachment>
-                     <d:CellCoordinatesAsDefined>
-                        <d:SelectDimension rank="1" rangeMinimum="4" rangeMaximum="4"/>
-                     </d:CellCoordinatesAsDefined>
-                  </d:GridAttachment>
-               </d:GridResponseDomainInMixed>
-               <d:GridResponseDomainInMixed>
-                  <d:CodeDomain>
-                     <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">drop-down-list</r:GenericOutputFormat>
-                     <r:CodeListReference>
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6nv33d</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:TypeOfObject>CodeList</r:TypeOfObject>
-                     </r:CodeListReference>
-                     <r:OutParameter isArray="false">
-                        <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lk6ntp2p-RDOP-lk6nw4kc</r:ID>
-                        <r:Version>1</r:Version>
-                        <r:CodeRepresentation>
-                           <r:CodeListReference>
-                              <r:Agency>fr.insee</r:Agency>
-                              <r:ID>lk6nv33d</r:ID>
-                              <r:Version>1</r:Version>
-                              <r:TypeOfObject>CodeList</r:TypeOfObject>
-                           </r:CodeListReference>
-                        </r:CodeRepresentation>
-                     </r:OutParameter>
-                     <r:ResponseCardinality maximumResponses="1"/>
-                  </d:CodeDomain>
-                  <d:GridAttachment>
-                     <d:CellCoordinatesAsDefined>
-                        <d:SelectDimension rank="1" rangeMinimum="5" rangeMaximum="5"/>
-                     </d:CellCoordinatesAsDefined>
-                  </d:GridAttachment>
-               </d:GridResponseDomainInMixed>
-            </d:StructuredMixedGridResponseDomain>
-         </d:QuestionGrid>
          <d:QuestionGrid>
             <r:Agency>fr.insee</r:Agency>
             <r:ID>l988nifn</r:ID>
@@ -3313,30 +3012,6 @@
       </l:CategoryScheme>
       <l:CategoryScheme>
          <r:Agency>fr.insee</r:Agency>
-         <r:ID>CategoryScheme-lk6nv33d</r:ID>
-         <r:Version>1</r:Version>
-         <r:Label>
-            <r:Content xml:lang="fr-FR">qcm-reponse</r:Content>
-         </r:Label>
-         <l:Category>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>CA-lk6nv33d-1</r:ID>
-            <r:Version>1</r:Version>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">dsfgsdgd</r:Content>
-            </r:Label>
-         </l:Category>
-         <l:Category>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>CA-lk6nv33d-2</r:ID>
-            <r:Version>1</r:Version>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">dsgdsg</r:Content>
-            </r:Label>
-         </l:Category>
-      </l:CategoryScheme>
-      <l:CategoryScheme>
-         <r:Agency>fr.insee</r:Agency>
          <r:ID>CategoryScheme-l988okev</r:ID>
          <r:Version>1</r:Version>
          <r:Label>
@@ -3708,42 +3383,6 @@
                   </r:CategoryReference>
                   <r:Value>m23</r:Value>
                </l:Code>
-            </l:Code>
-         </l:CodeList>
-         <l:CodeList>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6nv33d</r:ID>
-            <r:Version>1</r:Version>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">qcm-reponse</r:Content>
-            </r:Label>
-            <l:HierarchyType>Regular</l:HierarchyType>
-            <l:Level levelNumber="1">
-               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
-            </l:Level>
-            <l:Code levelNumber="1" isDiscrete="true">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6nv33d-1</r:ID>
-               <r:Version>1</r:Version>
-               <r:CategoryReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>CA-lk6nv33d-1</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>Category</r:TypeOfObject>
-               </r:CategoryReference>
-               <r:Value>sdsgdsg</r:Value>
-            </l:Code>
-            <l:Code levelNumber="1" isDiscrete="true">
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6nv33d-2</r:ID>
-               <r:Version>1</r:Version>
-               <r:CategoryReference>
-                  <r:Agency>fr.insee</r:Agency>
-                  <r:ID>CA-lk6nv33d-2</r:ID>
-                  <r:Version>1</r:Version>
-                  <r:TypeOfObject>Category</r:TypeOfObject>
-               </r:CategoryReference>
-               <r:Value>sdgdsfg</r:Value>
             </l:Code>
          </l:CodeList>
          <l:CodeList>
@@ -4329,171 +3968,6 @@
                   <r:CodeListReference>
                      <r:Agency>fr.insee</r:Agency>
                      <r:ID>l9ny0mef</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </r:CodeRepresentation>
-            </l:VariableRepresentation>
-         </l:Variable>
-         <l:Variable>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6noqcc</r:ID>
-            <r:Version>1</r:Version>
-            <l:VariableName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA1</r:String>
-            </l:VariableName>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">m1 - "Modalité simple 1"</r:Content>
-            </r:Label>
-            <r:SourceParameterReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nedhr</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>OutParameter</r:TypeOfObject>
-            </r:SourceParameterReference>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </r:QuestionReference>
-            <l:VariableRepresentation>
-               <r:CodeRepresentation>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>lk6nv33d</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </r:CodeRepresentation>
-            </l:VariableRepresentation>
-         </l:Variable>
-         <l:Variable>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6ns1az</r:ID>
-            <r:Version>1</r:Version>
-            <l:VariableName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA2</r:String>
-            </l:VariableName>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">m21 - "Imbrication 1"</r:Content>
-            </r:Label>
-            <r:SourceParameterReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6npups</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>OutParameter</r:TypeOfObject>
-            </r:SourceParameterReference>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </r:QuestionReference>
-            <l:VariableRepresentation>
-               <r:CodeRepresentation>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>lk6nv33d</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </r:CodeRepresentation>
-            </l:VariableRepresentation>
-         </l:Variable>
-         <l:Variable>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6npp1j</r:ID>
-            <r:Version>1</r:Version>
-            <l:VariableName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA3</r:String>
-            </l:VariableName>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">m221 - "Sous-imbrication 1"</r:Content>
-            </r:Label>
-            <r:SourceParameterReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nnsfl</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>OutParameter</r:TypeOfObject>
-            </r:SourceParameterReference>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </r:QuestionReference>
-            <l:VariableRepresentation>
-               <r:CodeRepresentation>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>lk6nv33d</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </r:CodeRepresentation>
-            </l:VariableRepresentation>
-         </l:Variable>
-         <l:Variable>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6nn05m</r:ID>
-            <r:Version>1</r:Version>
-            <l:VariableName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA4</r:String>
-            </l:VariableName>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">m222 - "Sous-imbrication 2"</r:Content>
-            </r:Label>
-            <r:SourceParameterReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nygf3</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>OutParameter</r:TypeOfObject>
-            </r:SourceParameterReference>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </r:QuestionReference>
-            <l:VariableRepresentation>
-               <r:CodeRepresentation>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>lk6nv33d</r:ID>
-                     <r:Version>1</r:Version>
-                     <r:TypeOfObject>CodeList</r:TypeOfObject>
-                  </r:CodeListReference>
-               </r:CodeRepresentation>
-            </l:VariableRepresentation>
-         </l:Variable>
-         <l:Variable>
-            <r:Agency>fr.insee</r:Agency>
-            <r:ID>lk6nwhhj</r:ID>
-            <r:Version>1</r:Version>
-            <l:VariableName>
-               <r:String xml:lang="fr-FR">QCMIMBRICA5</r:String>
-            </l:VariableName>
-            <r:Label>
-               <r:Content xml:lang="fr-FR">m23 - "Imbrication 3"</r:Content>
-            </r:Label>
-            <r:SourceParameterReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p-QOP-lk6nw4kc</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>OutParameter</r:TypeOfObject>
-            </r:SourceParameterReference>
-            <r:QuestionReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ntp2p</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>QuestionGrid</r:TypeOfObject>
-            </r:QuestionReference>
-            <l:VariableRepresentation>
-               <r:CodeRepresentation>
-                  <r:CodeListReference>
-                     <r:Agency>fr.insee</r:Agency>
-                     <r:ID>lk6nv33d</r:ID>
                      <r:Version>1</r:Version>
                      <r:TypeOfObject>CodeList</r:TypeOfObject>
                   </r:CodeListReference>
@@ -5856,36 +5330,6 @@
             <r:VariableReference>
                <r:Agency>fr.insee</r:Agency>
                <r:ID>l9ny6ifi</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>Variable</r:TypeOfObject>
-            </r:VariableReference>
-            <r:VariableReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6noqcc</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>Variable</r:TypeOfObject>
-            </r:VariableReference>
-            <r:VariableReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6ns1az</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>Variable</r:TypeOfObject>
-            </r:VariableReference>
-            <r:VariableReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6npp1j</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>Variable</r:TypeOfObject>
-            </r:VariableReference>
-            <r:VariableReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6nn05m</r:ID>
-               <r:Version>1</r:Version>
-               <r:TypeOfObject>Variable</r:TypeOfObject>
-            </r:VariableReference>
-            <r:VariableReference>
-               <r:Agency>fr.insee</r:Agency>
-               <r:ID>lk6nwhhj</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>Variable</r:TypeOfObject>
             </r:VariableReference>

--- a/eno-core/src/test/resources/functional/pogues/pogues-kzy5kbtl.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-kzy5kbtl.json
@@ -1046,8 +1046,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz5b6im3"
               },
               {
@@ -1157,8 +1157,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz5b6im3"
               },
               {
@@ -1258,8 +1258,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kzy4qkq6"
               },
               {
@@ -1447,8 +1447,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "4-4"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": "4",
+                "MinLines": "4",
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",
@@ -1518,8 +1520,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-10"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": "10",
+                "MinLines": "1",
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",
@@ -1606,8 +1610,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-10"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": "10",
+                "MinLines": "1",
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",
@@ -1820,8 +1826,10 @@
                 ],
                 "Dimension": [
                   {
-                    "dimensionType": "PRIMARY",
-                    "dynamic": "1-3"
+                    "dynamic": "DYNAMIC_LENGTH",
+                    "MaxLines": "3",
+                    "MinLines": "1",
+                    "dimensionType": "PRIMARY"
                   },
                   {
                     "dimensionType": "MEASURE",
@@ -2003,8 +2011,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "kzy4qkq6"
                   },
                   {
@@ -2320,8 +2328,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "kzy4qkq6"
                   },
                   {

--- a/eno-core/src/test/resources/functional/pogues/pogues-l20g2ba7.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-l20g2ba7.json
@@ -3354,8 +3354,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "jfjevykh"
                   },
                   {
@@ -3473,8 +3473,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "jfkxgkqx"
                   },
                   {
@@ -3600,8 +3600,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "jfjevykh"
                   },
                   {
@@ -3779,8 +3779,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "l8u7vv82"
               },
               {
@@ -3905,8 +3905,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "jfkxgkqx"
               },
               {
@@ -4079,8 +4079,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "jfkxgkqx"
               },
               {
@@ -4450,8 +4450,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "jfjevykh"
               },
               {
@@ -4955,8 +4955,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "jfkxc40e"
               },
               {
@@ -5071,8 +5071,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": "5",
+                "MinLines": "1",
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/functional/pogues/pogues-l5v3spn0.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-l5v3spn0.json
@@ -667,8 +667,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": "5",
+                "MinLines": "1",
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/functional/pogues/pogues-l8x6fhtd.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-l8x6fhtd.json
@@ -1092,8 +1092,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "l988okev"
               },
               {
@@ -1244,8 +1244,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "l9nygs1y"
               },
               {
@@ -1410,8 +1410,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "l988nznm"
               },
               {

--- a/eno-core/src/test/resources/functional/pogues/pogues-li49zxju.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-li49zxju.json
@@ -9657,8 +9657,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbglwey5"
               },
               {
@@ -10516,8 +10516,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz2mu4s7"
               },
               {
@@ -10904,8 +10904,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz2otmvz"
               },
               {
@@ -12396,8 +12396,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbglwey5"
               },
               {
@@ -13458,8 +13458,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz2mu4s7"
               },
               {
@@ -13890,8 +13890,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz2otmvz"
               },
               {
@@ -16610,8 +16610,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "kz4bpb1d"
               },
               {
@@ -17474,8 +17474,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbgid6s3"
               },
               {
@@ -17580,8 +17580,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbgi97ke"
               },
               {
@@ -17745,8 +17745,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbkjkhix"
               },
               {
@@ -17945,8 +17945,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lbkkg2tb"
               },
               {

--- a/eno-core/src/test/resources/functional/pogues/pogues-ljr4jm9a.json
+++ b/eno-core/src/test/resources/functional/pogues/pogues-ljr4jm9a.json
@@ -7208,8 +7208,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "l1214jho"
                   },
                   {
@@ -7445,8 +7445,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "l13e77ow"
                   },
                   {
@@ -7731,8 +7731,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "l13oddrm"
                   },
                   {
@@ -11913,8 +11913,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "libyau6k"
                   },
                   {
@@ -12316,8 +12316,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "libz1uqg"
                   },
                   {
@@ -12483,8 +12483,8 @@
                 ],
                 "Dimension": [
                   {
+                    "dynamic": "NON_DYNAMIC",
                     "dimensionType": "PRIMARY",
-                    "dynamic": "0",
                     "CodeListReference": "libyy6jr"
                   },
                   {
@@ -13397,8 +13397,8 @@
             ],
             "Dimension": [
               {
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
                 "CodeListReference": "lic0700g"
               },
               {

--- a/eno-core/src/test/resources/integration/ddi/ddi-suggester-arbitrary.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-suggester-arbitrary.xml
@@ -1,0 +1,680 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DDIInstance xmlns="ddi:instance:3_3"
+             xmlns:a="ddi:archive:3_3"
+             xmlns:d="ddi:datacollection:3_3"
+             xmlns:g="ddi:group:3_3"
+             xmlns:l="ddi:logicalproduct:3_3"
+             xmlns:r="ddi:reusable:3_3"
+             xmlns:s="ddi:studyunit:3_3"
+             xmlns:xhtml="http://www.w3.org/1999/xhtml"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
+             isMaintainable="true"><!--Eno version : 2.12.3-SNAPSHOT.3. Generation date : 10/02/2025 - 18:46:25-->
+   <r:Agency>fr.insee</r:Agency>
+   <r:ID>INSEE-m6uw1hiz</r:ID>
+   <r:Version>1</r:Version>
+   <r:Citation>
+      <r:Title>
+         <r:String>Eno - Suggester with arbitrary</r:String>
+      </r:Title>
+   </r:Citation>
+   <g:ResourcePackage isMaintainable="true" versionDate="2018-01-25+01:00">
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>RessourcePackage-m6uw1hiz</r:ID>
+      <r:Version>1</r:Version>
+      <d:InterviewerInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>InterviewerInstructionScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+      </d:InterviewerInstructionScheme>
+      <d:ControlConstructScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ControlConstructScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>Sequence-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">template</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwl291</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxuwt1</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Sequence</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwl291</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">S1</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"Sequence"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+            <d:ControlConstructReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QC</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionConstruct</r:TypeOfObject>
+            </d:ControlConstructReference>
+         </d:Sequence>
+         <d:Sequence>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxuwt1</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">END</r:String>
+            </d:ConstructName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">"End"</r:Content>
+            </r:Label>
+            <d:TypeOfSequence controlledVocabularyID="INSEE-TOS-CL-1">module</d:TypeOfSequence>
+         </d:Sequence>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+         <d:QuestionConstruct>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo-QC</r:ID>
+            <r:Version>1</r:Version>
+            <d:ConstructName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:ConstructName>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+         </d:QuestionConstruct>
+      </d:ControlConstructScheme>
+      <d:QuestionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>QuestionScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uw3z0d</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">COUNTRY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (country)"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_PAYS-1-2-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uw3z0d-RDOP-m6uw9cka</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_PAYS-1-2-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+         </d:QuestionItem>
+         <d:QuestionItem>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uwmbzo</r:ID>
+            <r:Version>1</r:Version>
+            <d:QuestionItemName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </d:QuestionItemName>
+            <r:OutParameter isArray="false">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:ParameterName>
+                  <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+               </r:ParameterName>
+            </r:OutParameter>
+            <r:Binding>
+               <r:SourceParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:SourceParameterReference>
+               <r:TargetParameterReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>OutParameter</r:TypeOfObject>
+               </r:TargetParameterReference>
+            </r:Binding>
+            <d:QuestionText>
+               <d:LiteralText>
+                  <d:Text xml:lang="fr-FR">"Suggester question (activity) with arbitrary response"</d:Text>
+               </d:LiteralText>
+            </d:QuestionText>
+            <d:CodeDomain>
+               <r:GenericOutputFormat controlledVocabularyID="INSEE-GOF-CV">suggester</r:GenericOutputFormat>
+               <r:CodeListReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>CodeList</r:TypeOfObject>
+               </r:CodeListReference>
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>m6uwmbzo-RDOP-m6uw7qbe</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:CodeRepresentation>
+                     <r:CodeListReference>
+                        <r:Agency>fr.insee</r:Agency>
+                        <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                        <r:Version>1</r:Version>
+                        <r:TypeOfObject>CodeList</r:TypeOfObject>
+                     </r:CodeListReference>
+                  </r:CodeRepresentation>
+               </r:OutParameter>
+               <r:ResponseCardinality maximumResponses="1"/>
+            </d:CodeDomain>
+            <d:TextDomain maxLength="249">
+               <r:OutParameter isArray="false">
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID/>
+                  <r:Version>1</r:Version>
+                  <r:TextRepresentation maxLength="249"/>
+               </r:OutParameter>
+            </d:TextDomain>
+         </d:QuestionItem>
+      </d:QuestionScheme>
+      <l:CategoryScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>CategoryScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">A définir</r:Content>
+         </r:Label>
+         <l:Category>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+            <r:Version>1</r:Version>
+            <r:Label>
+               <r:Content xml:lang="fr-FR"/>
+            </r:Label>
+         </l:Category>
+      </l:CategoryScheme>
+      <l:CodeListScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>ENO_SUGGESTER_ARBITRARY-CLS</r:ID>
+         <r:Version>1</r:Version>
+         <l:CodeListSchemeName>
+            <r:String xml:lang="en-IE">ENO_SUGGESTER_ARBITRARY</r:String>
+         </l:CodeListSchemeName>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_PAYS-1-2-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                  </fields>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_PAYS-1-2-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Pays</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_pays-1-2-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>L_ACTIVITES-2-0-0</r:ID>
+            <r:Version>1</r:Version>
+            <r:UserAttributePair>
+               <r:AttributeKey>SuggesterConfiguration</r:AttributeKey>
+               <r:AttributeValue><![CDATA[<fields xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <name>label</name>
+                     <rules>[\w]+</rules>
+                     <language>French</language>
+                     <min>3</min>
+                     <stemmer>false</stemmer>
+                     <synonyms>
+                        <source>EHPAD</source>
+                        <target>EPHAD</target>
+                        <target>HEPAD</target>
+                        <target>EPAD</target>
+                        <target>EPAHD</target>
+                        <target>EPADH</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>URSSAF</source>
+                        <target>URSAF</target>
+                        <target>URSAFF</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>ascenseurs</source>
+                        <target>ASCENCEUR</target>
+                        <target>ASSENCEUR</target>
+                        <target>ACSENCEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>joaillerie</source>
+                        <target>JOAILLIER</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaire</source>
+                        <target>ALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>briqueterie</source>
+                        <target>BRIQUETTERIE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>prestations</source>
+                        <target>PRESTATAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>alimentaires</source>
+                        <target>ALIMANTAIRES</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>echafaudages</source>
+                        <target>ECHAFFAUDAGE</target>
+                        <target>ECHAFFAUDEUR</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>plaquisterie</source>
+                        <target>PLACO</target>
+                        <target>PLACOPLATRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>pneumatiques</source>
+                        <target>PNEUS</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaire</source>
+                        <target>AGGROALIMANTAIRE</target>
+                        <target>AGROALIMANTAIRE</target>
+                     </synonyms>
+                     <synonyms>
+                        <source>agroalimentaires</source>
+                        <target>AGGROALIMANTAIRES</target>
+                        <target>AGROALIMENTAIRES</target>
+                     </synonyms>
+                  </fields>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">a</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">au</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">de</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">des</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">du</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">en</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">et</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">la</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">le</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">ou</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">sur</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">d</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">l</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">aux</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">dans</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">un</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">une</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">pour</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">avec</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">chez</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">par</stopWords>
+                  <stopWords xmlns="http://xml.insee.fr/schema/applis/lunatic-h">les</stopWords>
+                  <queryParser xmlns="http://xml.insee.fr/schema/applis/lunatic-h">
+                     <type>tokenized</type>
+                     <params>
+                        <language>French</language>
+                        <min>3</min>
+                        <pattern>[\w.]+</pattern>
+                        <stemmer>false</stemmer>
+                     </params>
+                  </queryParser>
+                  <version xmlns="http://xml.insee.fr/schema/applis/lunatic-h">1</version>]]></r:AttributeValue>
+            </r:UserAttributePair>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">L_ACTIVITES-2-0-0</r:String>
+            </l:CodeListName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">Activités</r:Content>
+            </r:Label>
+            <r:CodeListReference isExternal="true">
+               <r:URN>urn:ddi:fr.insee:l_activites-2-0-0:1</r:URN>
+               <r:TypeOfObject>CodeList</r:TypeOfObject>
+            </r:CodeListReference>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+         </l:CodeList>
+         <l:CodeList>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-COMMUN-CL-Booleen</r:ID>
+            <r:Version>1</r:Version>
+            <l:CodeListName>
+               <r:String xml:lang="fr-FR">Booleen</r:String>
+            </l:CodeListName>
+            <l:HierarchyType>Regular</l:HierarchyType>
+            <l:Level levelNumber="1">
+               <l:CategoryRelationship>Ordinal</l:CategoryRelationship>
+            </l:Level>
+            <l:Code levelNumber="1" isDiscrete="true">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>INSEE-COMMUN-CL-Booleen-1</r:ID>
+               <r:Version>1</r:Version>
+               <r:CategoryReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>INSEE-COMMUN-CA-Booleen-1</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Category</r:TypeOfObject>
+               </r:CategoryReference>
+               <r:Value>1</r:Value>
+            </l:Code>
+         </l:CodeList>
+      </l:CodeListScheme>
+      <l:VariableScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>VariableScheme-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="fr-FR">Variable Scheme for the survey</r:Content>
+         </r:Label>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxkrge</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">COUNTRY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">COUNTRY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d-QOP-m6uw9cka</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uw3z0d</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_PAYS-1-2-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxo8wf</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uw7qbe</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:CodeRepresentation>
+                  <r:CodeListReference>
+                     <r:Agency>fr.insee</r:Agency>
+                     <r:ID>L_ACTIVITES-2-0-0</r:ID>
+                     <r:Version>1</r:Version>
+                     <r:TypeOfObject>CodeList</r:TypeOfObject>
+                  </r:CodeListReference>
+               </r:CodeRepresentation>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:Variable>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>m6uxax4o</r:ID>
+            <r:Version>1</r:Version>
+            <l:VariableName>
+               <r:String xml:lang="fr-FR">ACTIVITY_ARBITRARY</r:String>
+            </l:VariableName>
+            <r:Label>
+               <r:Content xml:lang="fr-FR">ACTIVITY_ARBITRARY label </r:Content>
+            </r:Label>
+            <r:SourceParameterReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo-QOP-m6uxal31</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>OutParameter</r:TypeOfObject>
+            </r:SourceParameterReference>
+            <r:QuestionReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uwmbzo</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>QuestionItem</r:TypeOfObject>
+            </r:QuestionReference>
+            <l:VariableRepresentation>
+               <r:TextRepresentation maxLength="249"/>
+            </l:VariableRepresentation>
+         </l:Variable>
+         <l:VariableGroup>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>INSEE-Instrument-m6uw1hiz-vg</r:ID>
+            <r:Version>1</r:Version>
+            <r:BasedOnObject>
+               <r:BasedOnReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Instrument-m6uw1hiz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Instrument</r:TypeOfObject>
+               </r:BasedOnReference>
+            </r:BasedOnObject>
+            <l:TypeOfVariableGroup>Questionnaire</l:TypeOfVariableGroup>
+            <l:VariableGroupName>
+               <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+            </l:VariableGroupName>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxkrge</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxo8wf</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+            <r:VariableReference>
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>m6uxax4o</r:ID>
+               <r:Version>1</r:Version>
+               <r:TypeOfObject>Variable</r:TypeOfObject>
+            </r:VariableReference>
+         </l:VariableGroup>
+      </l:VariableScheme>
+      <d:ProcessingInstructionScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-PIS-1</r:ID>
+         <r:Version>1</r:Version>
+         <d:ProcessingInstructionSchemeName>
+            <r:String xml:lang="en-IE">SIMPSONS</r:String>
+         </d:ProcessingInstructionSchemeName>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Processing instructions of the Simpsons questionnaire</r:Content>
+         </r:Label>
+      </d:ProcessingInstructionScheme>
+      <r:ManagedRepresentationScheme>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>INSEE-SIMPSONS-MRS</r:ID>
+         <r:Version>1</r:Version>
+         <r:Label>
+            <r:Content xml:lang="en-IE">Liste de formats numériques et dates de
+                            l'enquête</r:Content>
+            <r:Content xml:lang="en-IE">Numeric and DateTime list for the survey</r:Content>
+         </r:Label>
+      </r:ManagedRepresentationScheme>
+   </g:ResourcePackage>
+   <s:StudyUnit>
+      <r:Agency>fr.insee</r:Agency>
+      <r:ID>StudyUnit-m6uw1hiz</r:ID>
+      <r:Version>1</r:Version>
+      <r:ExPostEvaluation/>
+      <d:DataCollection>
+         <r:Agency>fr.insee</r:Agency>
+         <r:ID>DataCollection-m6uw1hiz</r:ID>
+         <r:Version>1</r:Version>
+         <r:QuestionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>QuestionScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>QuestionScheme</r:TypeOfObject>
+         </r:QuestionSchemeReference>
+         <r:ControlConstructSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>ControlConstructScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>ControlConstructScheme</r:TypeOfObject>
+         </r:ControlConstructSchemeReference>
+         <r:InterviewerInstructionSchemeReference>
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InterviewerInstructionScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <r:TypeOfObject>InterviewerInstructionScheme</r:TypeOfObject>
+         </r:InterviewerInstructionSchemeReference>
+         <d:InstrumentScheme xml:lang="fr-FR">
+            <r:Agency>fr.insee</r:Agency>
+            <r:ID>InstrumentScheme-m6uw1hiz</r:ID>
+            <r:Version>1</r:Version>
+            <d:Instrument xmlns:c="ddi:conceptualcomponent:3_3"
+                          xmlns:cm="ddi:comparative:3_3"
+                          xmlns:pogues="http://xml.insee.fr/schema/applis/pogues"
+                          xmlns:pr="ddi:ddiprofile:3_3">
+               <r:Agency>fr.insee</r:Agency>
+               <r:ID>Instrument-m6uw1hiz</r:ID>
+               <r:Version>1</r:Version>
+               <d:InstrumentName>
+                  <r:String>ENO_SUGGESTER_ARBITRARY</r:String>
+               </d:InstrumentName>
+               <r:Label>
+                  <r:Content xml:lang="fr-FR">Eno - Suggester with arbitrary questionnaire</r:Content>
+               </r:Label>
+               <d:TypeOfInstrument>A définir</d:TypeOfInstrument>
+               <d:ControlConstructReference>
+                  <r:Agency>fr.insee</r:Agency>
+                  <r:ID>Sequence-m6uw1hiz</r:ID>
+                  <r:Version>1</r:Version>
+                  <r:TypeOfObject>Sequence</r:TypeOfObject>
+               </d:ControlConstructReference>
+            </d:Instrument>
+         </d:InstrumentScheme>
+      </d:DataCollection>
+   </s:StudyUnit>
+</DDIInstance>

--- a/eno-core/src/test/resources/integration/pogues/pogues-suggester-arbitrary.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-suggester-arbitrary.json
@@ -1,0 +1,369 @@
+{
+  "id": "m6uw1hiz",
+  "Name": "ENO_SUGGESTER_ARBITRARY",
+  "Child": [
+    {
+      "id": "m6uwl291",
+      "Name": "S1",
+      "type": "SequenceType",
+      "Child": [
+        {
+          "id": "m6uw3z0d",
+          "Name": "COUNTRY",
+          "type": "QuestionType",
+          "Label": [
+            "\"Suggester question (country)\""
+          ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "m6uw9cka",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 1,
+                "visualizationHint": "SUGGESTER",
+                "allowArbitraryResponse": false
+              },
+              "mandatory": false,
+              "CodeListReference": "L_PAYS-1-2-0",
+              "CollectedVariableReference": "m6uxkrge"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [],
+          "questionType": "SINGLE_CHOICE",
+          "ClarificationQuestion": []
+        },
+        {
+          "id": "m6uwmbzo",
+          "Name": "ACTIVITY",
+          "type": "QuestionType",
+          "Label": [
+            "\"Suggester question (activity) with arbitrary response\""
+          ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "m6uw7qbe",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 1,
+                "visualizationHint": "SUGGESTER",
+                "allowArbitraryResponse": true
+              },
+              "mandatory": false,
+              "CodeListReference": "L_ACTIVITES-2-0-0",
+              "CollectedVariableReference": "m6uxo8wf"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [],
+          "questionType": "SINGLE_CHOICE",
+          "ArbitraryResponse": {
+            "id": "m6uxal31",
+            "Datatype": {
+              "type": "TextDatatypeType",
+              "typeName": "TEXT",
+              "MaxLength": 249
+            },
+            "mandatory": false,
+            "CollectedVariableReference": "m6uxax4o"
+          },
+          "ClarificationQuestion": []
+        }
+      ],
+      "Label": [
+        "\"Sequence\""
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "m6uxuwt1",
+      "Name": "END",
+      "type": "SequenceType",
+      "Child": [],
+      "Label": [
+        "\"End\""
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "idendquest",
+      "Name": "QUESTIONNAIRE_END",
+      "type": "SequenceType",
+      "Child": [],
+      "Label": [
+        "QUESTIONNAIRE_END"
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    }
+  ],
+  "Label": [
+    "Eno - Suggester with arbitrary"
+  ],
+  "final": false,
+  "owner": "ENO-INTEGRATION-TESTS",
+  "agency": "fr.insee",
+  "CodeLists": {
+    "CodeList": [
+      {
+        "id": "L_PAYS-1-2-0",
+        "Urn": "urn:ddi:fr.insee:l_pays-1-2-0:1",
+        "Name": "L_PAYS-1-2-0",
+        "Label": "Pays",
+        "SuggesterParameters": {
+          "fields": [
+            {
+              "min": 3,
+              "name": "label",
+              "rules": [
+                "[\\w]+"
+              ],
+              "stemmer": false,
+              "language": "French"
+            }
+          ],
+          "version": 1,
+          "queryParser": {
+            "type": "tokenized",
+            "params": {
+              "min": 3,
+              "pattern": "[\\w.]+",
+              "stemmer": false,
+              "language": "French"
+            }
+          }
+        }
+      },
+      {
+        "id": "L_ACTIVITES-2-0-0",
+        "Urn": "urn:ddi:fr.insee:l_activites-2-0-0:1",
+        "Name": "L_ACTIVITES-2-0-0",
+        "Label": "Activités",
+        "SuggesterParameters": {
+          "fields": [
+            {
+              "min": 3,
+              "name": "label",
+              "rules": [
+                "[\\w]+"
+              ],
+              "stemmer": false,
+              "language": "French",
+              "synonyms": {
+                "EHPAD": [
+                  "EPHAD",
+                  "HEPAD",
+                  "EPAD",
+                  "EPAHD",
+                  "EPADH"
+                ],
+                "URSSAF": [
+                  "URSAF",
+                  "URSAFF"
+                ],
+                "ascenseurs": [
+                  "ASCENCEUR",
+                  "ASSENCEUR",
+                  "ACSENCEUR"
+                ],
+                "joaillerie": [
+                  "JOAILLIER"
+                ],
+                "alimentaire": [
+                  "ALIMANTAIRE"
+                ],
+                "briqueterie": [
+                  "BRIQUETTERIE"
+                ],
+                "prestations": [
+                  "PRESTATAIRE"
+                ],
+                "alimentaires": [
+                  "ALIMANTAIRES"
+                ],
+                "echafaudages": [
+                  "ECHAFFAUDAGE",
+                  "ECHAFFAUDEUR"
+                ],
+                "plaquisterie": [
+                  "PLACO",
+                  "PLACOPLATRE"
+                ],
+                "pneumatiques": [
+                  "PNEUS"
+                ],
+                "agroalimentaire": [
+                  "AGGROALIMANTAIRE",
+                  "AGROALIMANTAIRE"
+                ],
+                "agroalimentaires": [
+                  "AGGROALIMANTAIRES",
+                  "AGROALIMENTAIRES"
+                ]
+              }
+            }
+          ],
+          "version": 1,
+          "stopWords": [
+            "a",
+            "au",
+            "dans",
+            "de",
+            "des",
+            "du",
+            "en",
+            "et",
+            "la",
+            "le",
+            "ou",
+            "sur",
+            "d",
+            "l",
+            "aux",
+            "dans",
+            "un",
+            "une",
+            "pour",
+            "avec",
+            "chez",
+            "par",
+            "les"
+          ],
+          "queryParser": {
+            "type": "tokenized",
+            "params": {
+              "min": 3,
+              "pattern": "[\\w.]+",
+              "stemmer": false,
+              "language": "French"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Variables": {
+    "Variable": [
+      {
+        "id": "m6uxkrge",
+        "Name": "COUNTRY",
+        "type": "CollectedVariableType",
+        "Label": "COUNTRY label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 1
+        },
+        "CodeListReference": "L_PAYS-1-2-0"
+      },
+      {
+        "id": "m6uxo8wf",
+        "Name": "ACTIVITY",
+        "type": "CollectedVariableType",
+        "Label": "ACTIVITY label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 1
+        },
+        "CodeListReference": "L_ACTIVITES-2-0-0"
+      },
+      {
+        "id": "m6uxax4o",
+        "Name": "ACTIVITY_ARBITRARY",
+        "type": "CollectedVariableType",
+        "Label": "ACTIVITY_ARBITRARY label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "typeName": "TEXT",
+          "MaxLength": 249
+        }
+      }
+    ]
+  },
+  "flowLogic": "FILTER",
+  "TargetMode": [
+    "CAPI",
+    "CATI",
+    "CAWI",
+    "PAPI"
+  ],
+  "FlowControl": [],
+  "genericName": "QUESTIONNAIRE",
+  "ComponentGroup": [
+    {
+      "id": "m6uwp0c8",
+      "Name": "PAGE_1",
+      "Label": [
+        "Components for page 1"
+      ],
+      "MemberReference": [
+        "m6uwl291",
+        "m6uw3z0d",
+        "m6uwmbzo",
+        "idendquest",
+        "m6uxuwt1"
+      ]
+    }
+  ],
+  "DataCollection": [
+    {
+      "id": "s2106-dc",
+      "uri": "http://ddi:fr.insee:DataCollection.s2106-dc"
+    }
+  ],
+  "lastUpdatedDate": "Fri Feb 07 2025 16:29:40 GMT+0100 (heure normale d’Europe centrale)",
+  "formulasLanguage": "VTL",
+  "childQuestionnaireRef": []
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,8 +8,8 @@ pluginManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("lunatic-model", "3.15.3")
-            version("pogues-model", "1.5.0")
+            version("lunatic-model", "3.16.0")
+            version("pogues-model", "1.6.0-SNAPSHOT")
             library("lunatic-model", "fr.insee.lunatic", "lunatic-model").versionRef("lunatic-model")
             library("pogues-model", "fr.insee.pogues", "pogues-model").versionRef("pogues-model")
         }


### PR DESCRIPTION
Problématique / contexte : 

1. Pogues mapping
1. DDI mapping
1. Lunatic mapping

-> On veut pouvoir lire certaines infos présentes dans l'input Pogues et pas en DDI, mais quand même lire le DDI car le mapping Pogues est incomplet.

Avant cette PR, les objets DDI écrasaient ceux de Pogues, donc on perdait les infos spécifiques à Pogues 😿 

Refactor/fixes pour garder les objets qui viennent de Pogues, en sécurisant le processus pour que le mapping préalable Pogues ne "déforme" pas le mapping DDI.
