### PR TITLE
fix: detail responses bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.33.2-SNAPSHOT"
+    version = "3.33.2-SNAPSHOT.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/in/PoguesInProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/in/PoguesInProcessing.java
@@ -4,7 +4,6 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.processing.ProcessingPipeline;
 import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertCodeLists;
 import fr.insee.eno.core.processing.in.steps.ddi.DDIInsertMultipleChoiceLabels;
-import fr.insee.eno.core.processing.in.steps.pogues.PoguesCodeResponseDetails;
 import fr.insee.eno.core.processing.in.steps.pogues.PoguesNestedCodeLists;
 
 public class PoguesInProcessing {
@@ -18,7 +17,7 @@ public class PoguesInProcessing {
                 .then(new PoguesNestedCodeLists())
                 .then(new DDIInsertCodeLists())
                 .then(new DDIInsertMultipleChoiceLabels())
-                .then(new PoguesCodeResponseDetails())
+                //.then(new PoguesCodeResponseDetails()) // Disabled since it isn't implemented yet
         ;
     }
 


### PR DESCRIPTION
Processing step de Pogues pour les detail responses appellée à tort.

\+ truc tricky : les detail responses en DDI sont décrites comme des réponses ordinaires => nécessité d'ajouter une exception dans `InMapper` pour autoriser le fait d'avoir des listes de taille différente entre Pogues et DDI pour les `codeResponses` des QCM "tableau"
