### PR TITLE
fix(pogues): conversion error for vtl size tables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.33.2"
+    version = "3.33.3"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesMultipleChoiceQuestionConverter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/converter/PoguesMultipleChoiceQuestionConverter.java
@@ -35,18 +35,14 @@ class PoguesMultipleChoiceQuestionConverter {
     }
 
     private static EnoObject convertTable(QuestionType poguesQuestion) {
-        if (isStaticTable(poguesQuestion))
-            return new TableQuestion();
-        if (isDynamicTable(poguesQuestion))
-            return new DynamicTableQuestion();
-        throw new ConversionException("Unable to convert Pogues table '" + poguesQuestion.getId() + "'.");
-    }
-    private static boolean isStaticTable(QuestionType poguesQuestion) {
-        // A Pogues table is a static table if all of its "dimensions" are non-dynamic.
-        return poguesQuestion.getResponseStructure().getDimension().getFirst().getDynamic().equals("NON_DYNAMIC");
-    }
-    private static boolean isDynamicTable(QuestionType poguesQuestion) {
-        return poguesQuestion.getResponseStructure().getDimension().getFirst().getDynamic().equals("DYNAMIC_LENGTH");
+        String dynamic = poguesQuestion.getResponseStructure().getDimension().getFirst().getDynamic();
+        return switch (dynamic) {
+            case "NON_DYNAMIC" -> new TableQuestion();
+            case "DYNAMIC_LENGTH", "FIXED_LENGTH" -> new DynamicTableQuestion();
+            default -> throw new ConversionException(
+                    "Unable to convert Pogues table '" + poguesQuestion.getId() + "'.");
+        };
+        // Note: "FIXED_LENGTH" is for a dynamic table, whose size is defined by a VTL expression.
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicTableQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicTableQuestionTest.java
@@ -4,35 +4,62 @@ import fr.insee.eno.core.mappers.PoguesMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.question.DynamicTableQuestion;
 import fr.insee.pogues.model.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DynamicTableQuestionTest {
 
-    @Test
-    void poguesMapping() {
-        QuestionType poguesTable = new QuestionType();
+    private Questionnaire poguesQuestionnaire;
+    private QuestionType poguesTable;
+    private EnoQuestionnaire enoQuestionnaire;
+
+    @BeforeEach
+    void createPoguesQuestionnaireWithDynamicTable() {
+        poguesTable = new QuestionType();
         poguesTable.setQuestionType(QuestionTypeEnum.TABLE);
         poguesTable.setName("DYNAMIC_TABLE_NAME");
         poguesTable.getLabel().add("Dynamic table question.");
         ResponseStructureType responseStructure = new ResponseStructureType();
         DimensionType dimension = new DimensionType();
-        dimension.setDynamic("DYNAMIC_LENGTH");
         responseStructure.getDimension().add(dimension);
         poguesTable.setResponseStructure(responseStructure);
 
-        Questionnaire poguesQuestionnaire = new Questionnaire();
+        poguesQuestionnaire = new Questionnaire();
         SequenceType poguesSequence = new SequenceType();
         poguesSequence.setGenericName(GenericNameEnum.MODULE);
         poguesSequence.getChild().add(poguesTable);
         poguesQuestionnaire.getChild().add(poguesSequence);
+    }
 
-        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+    @Test
+    void poguesMapping() {
+        DimensionType dimension = poguesTable.getResponseStructure().getDimension().getFirst();
+        dimension.setDynamic("DYNAMIC_LENGTH");
+
+        enoQuestionnaire = new EnoQuestionnaire();
 
         new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
 
+        assertNotNull(enoQuestionnaire);
+    }
+
+    @Test
+    void poguesMapping_fixedLength() {
+        DimensionType dimension = poguesTable.getResponseStructure().getDimension().getFirst();
+        dimension.setDynamic("FIXED_LENGTH");
+
+        enoQuestionnaire = new EnoQuestionnaire();
+
+        new PoguesMapper().mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+
+        assertNotNull(enoQuestionnaire);
+    }
+
+    @AfterEach
+    void commonTests() {
         DynamicTableQuestion enoTable = assertInstanceOf(DynamicTableQuestion.class,
                 enoQuestionnaire.getMultipleResponseQuestions().getFirst());
         assertEquals("DYNAMIC_TABLE_NAME", enoTable.getName());


### PR DESCRIPTION
Exception levée pendant le mapping Pogues en présence de tableaux dynamiques de taille définie en VTL.

NB : ça ferait pas de mal de refacto la prop qui définit le "type" des "dynamic" des tableaux Pogues en enum plutôt que du string...