### PR TITLE
hotfix: no data cell variables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.33.3"
+    version = "3.33.4"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/mappers/InMapper.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/mappers/InMapper.java
@@ -238,7 +238,7 @@ public abstract class InMapper extends Mapper {
     }
 
     /** List of properties that are allowed to have a different size between Pogues and DDI mapping. */
-    private static final List<String> LIST_PROPERTIES_EXCEPTIONS = List.of("codeResponses");
+    private static final List<String> LIST_PROPERTIES_EXCEPTIONS = List.of("codeResponses", "variables");
 
     /** Returns the condition that determines if the mapper should iterate on existing objects of the Eno collection
      * or create new ones.

--- a/eno-core/src/test/java/fr/insee/eno/core/PoguesDDIToEnoTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/PoguesDDIToEnoTest.java
@@ -8,6 +8,8 @@ import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.model.code.CodeItem;
 import fr.insee.eno.core.model.question.NumericQuestion;
 import fr.insee.eno.core.model.question.SimpleMultipleChoiceQuestion;
+import fr.insee.eno.core.model.question.SuggesterQuestion;
+import fr.insee.eno.core.model.question.UniqueChoiceQuestion;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.parameter.EnoParameters.Context;
 import fr.insee.eno.core.parameter.EnoParameters.ModeParameter;
@@ -63,6 +65,71 @@ class PoguesDDIToEnoTest {
         JSONAssert.assertEquals(serialized1, serialized2, JSONCompareMode.STRICT);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "controls",
+            "controls-line",
+            "dates-2",
+            "declarations",
+            "dimensions",
+            "durations-2",
+            "dynamic-table",
+            "dynamic-table-2",
+            "dynamic-table-size",
+            "dynamic-unit",
+            "filters-calculated",
+            "filters-extended",
+            "filters-nested",
+            "filters-simple",
+            "labels",
+            "loop-except",
+            "loops-extended-sequence",
+            "loops-extended-subsequence",
+            "loops-sequence",
+            "loops-subsequence",
+            "mcq",
+            "no-data-cell",
+            //"other-specify",
+            "pairwise",
+            "resizing",
+            "roundabout",
+            "roundabout-controls",
+            "roundabout-except",
+            "roundabout-subsequence",
+            "simple",
+            "subsequences",
+            "suggester",
+            "suggester-arbitrary",
+            "suggester-options",
+            "suggester-options-table",
+            "table-custom-header",
+            "tooltips",
+            "variables"
+    })
+    void nonRegressionTest2(String classifier) throws ParsingException, JsonProcessingException, JSONException {
+
+        // Given Pogues & DDI inputs and Eno parameters
+        // (for questionnaires that does not contain features described in Pogues and not in DDI)
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        DDIInstanceDocument ddiQuestionnaire = DDIDeserializer.deserialize(classLoader.getResourceAsStream(
+                "integration/ddi/ddi-" + classifier + ".xml"));
+        Questionnaire poguesQuestionnaire = PoguesDeserializer.deserialize(classLoader.getResourceAsStream(
+                "integration/pogues/pogues-" + classifier + ".json"));
+        EnoParameters enoParameters = EnoParameters.of(Context.DEFAULT, ModeParameter.PROCESS, Format.LUNATIC);
+
+        // When mapping from DDI and from Pogues + DDI
+        EnoQuestionnaire fromDDI = DDIToEno.fromObject(ddiQuestionnaire)
+                .transform(enoParameters);
+        EnoQuestionnaire fromPoguesDDI = PoguesDDIToEno.fromObjects(poguesQuestionnaire, ddiQuestionnaire)
+                .transform(enoParameters);
+        removePoguesSpecificProperties(fromPoguesDDI);
+
+        // Then the resulting Eno questionnaire should be identical
+        String serialized1 = new ObjectMapper().writeValueAsString(fromDDI);
+        String serialized2 = new ObjectMapper().writeValueAsString(fromPoguesDDI);
+        JSONAssert.assertEquals(serialized1, serialized2, JSONCompareMode.STRICT);
+    }
+
     /**
      * Removes the properties that are specific to Pogues to ease the testing of
      * "Pogues + DDI" vs. "DDI only".
@@ -80,9 +147,20 @@ class PoguesDDIToEnoTest {
                 .forEach(numericQuestion -> numericQuestion.setIsUnitDynamic(null));
         enoQuestionnaire.getMultipleResponseQuestions().stream()
                 .filter(SimpleMultipleChoiceQuestion.class::isInstance).map(SimpleMultipleChoiceQuestion.class::cast)
-                .forEach(question -> question.getCodeResponses()
-                        .forEach(codeResponse -> codeResponse.getResponse().setVariableReference(null)));
+                .forEach(question -> {
+                    question.getCodeResponses()
+                            .forEach(codeResponse -> codeResponse.getResponse().setVariableReference(null));
+                    question.getDetailResponses()
+                            .forEach(detailResponse -> detailResponse.setPoguesId(null));
+                });
+        enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(UniqueChoiceQuestion.class::isInstance).map(UniqueChoiceQuestion.class::cast)
+                .forEach(question -> question.getDetailResponses()
+                        .forEach(detailResponse -> detailResponse.setPoguesId(null)));
         enoQuestionnaire.getCodeLists().forEach(codeList -> codeList.getCodeItems().forEach(this::removeCodeItemParentValues));
+        enoQuestionnaire.getSingleResponseQuestions().stream()
+                .filter(SuggesterQuestion.class::isInstance).map(SuggesterQuestion.class::cast)
+                .forEach(suggesterQuestion -> suggesterQuestion.setArbitraryResponse(null));
     }
     private void removeCodeItemParentValues(CodeItem codeItem) {
         codeItem.setParentValue(null);

--- a/eno-core/src/test/resources/integration/ddi/ddi-other-specify.xml
+++ b/eno-core/src/test/resources/integration/ddi/ddi-other-specify.xml
@@ -10,7 +10,7 @@
              xmlns:xs="http://www.w3.org/2001/XMLSchema"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="ddi:instance:3_3 https://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd"
-             isMaintainable="true"><!--Eno version : 2.8.0. Generation date : 10/04/2024 - 9:02:48-->
+             isMaintainable="true"><!--Eno version : 2.12.3. Generation date : 21/02/2025 - 15:56:36-->
    <r:Agency>fr.insee</r:Agency>
    <r:ID>INSEE-lutk9kue</r:ID>
    <r:Version>1</r:Version>
@@ -139,7 +139,7 @@
             </d:QuestionItemName>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+               <r:ID>lutkqj7u-QOP-lutl1gyc</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_RADIO</r:String>
@@ -147,7 +147,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+               <r:ID>m7eyrd9b-QOP-m7eyepyo</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_codeC_RADIO</r:String>
@@ -155,7 +155,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+               <r:ID>m7eyqgnu-QOP-m7eysikc</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_codeD_RADIO</r:String>
@@ -164,13 +164,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+                  <r:ID>lutkqj7u-RDOP-lutl1gyc</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+                  <r:ID>lutkqj7u-QOP-lutl1gyc</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -178,13 +178,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+                  <r:ID>m7eyrd9b-RDOP-m7eyepyo</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+                  <r:ID>m7eyrd9b-QOP-m7eyepyo</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -192,13 +192,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+                  <r:ID>m7eyqgnu-RDOP-m7eysikc</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+                  <r:ID>m7eyqgnu-QOP-m7eysikc</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -220,7 +220,7 @@
                      </r:CodeListReference>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkqj7u-RDOP-lutlcmdc</r:ID>
+                        <r:ID>lutkqj7u-RDOP-lutl1gyc</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeListReference>
@@ -241,7 +241,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutl4boi-RDOP-lutldzwz</r:ID>
+                        <r:ID>m7eyrd9b-RDOP-m7eyepyo</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="20"/>
                      </r:OutParameter>
@@ -265,7 +265,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutl72ne-RDOP-lutl513r</r:ID>
+                        <r:ID>m7eyqgnu-RDOP-m7eysikc</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="30"/>
                      </r:OutParameter>
@@ -293,7 +293,7 @@
             </d:QuestionItemName>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+               <r:ID>lutkmu5x-QOP-lutlkq28</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_CHECKBOX</r:String>
@@ -301,7 +301,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+               <r:ID>m7eynlus-QOP-m7eyns86</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_codeC_CHECKBOX</r:String>
@@ -309,7 +309,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+               <r:ID>m7eyesaq-QOP-m7eyhq9h</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">UCQ_codeD_CHECKBOX</r:String>
@@ -318,13 +318,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkmu5x-RDOP-lutl3eds</r:ID>
+                  <r:ID>lutkmu5x-RDOP-lutlkq28</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+                  <r:ID>lutkmu5x-QOP-lutlkq28</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -332,13 +332,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlbp0u-RDOP-lutlhhgn</r:ID>
+                  <r:ID>m7eynlus-RDOP-m7eyns86</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+                  <r:ID>m7eynlus-QOP-m7eyns86</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -346,13 +346,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlld7b-RDOP-lutldnjm</r:ID>
+                  <r:ID>m7eyesaq-RDOP-m7eyhq9h</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+                  <r:ID>m7eyesaq-QOP-m7eyhq9h</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -374,7 +374,7 @@
                      </r:CodeListReference>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkmu5x-RDOP-lutl3eds</r:ID>
+                        <r:ID>lutkmu5x-RDOP-lutlkq28</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeListReference>
@@ -395,7 +395,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutlbp0u-RDOP-lutlhhgn</r:ID>
+                        <r:ID>m7eynlus-RDOP-m7eyns86</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="20"/>
                      </r:OutParameter>
@@ -419,7 +419,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutlld7b-RDOP-lutldnjm</r:ID>
+                        <r:ID>m7eyesaq-RDOP-m7eyhq9h</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="30"/>
                      </r:OutParameter>
@@ -447,7 +447,7 @@
             </d:QuestionGridName>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+               <r:ID>lutkxex2-QOP-lutll481</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ1</r:String>
@@ -455,7 +455,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+               <r:ID>lutkxex2-QOP-lutlkzqn</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ2</r:String>
@@ -463,7 +463,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+               <r:ID>lutkxex2-QOP-lutlf2kj</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ3</r:String>
@@ -471,7 +471,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+               <r:ID>lutkxex2-QOP-lutlg1iw</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ4</r:String>
@@ -479,7 +479,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+               <r:ID>m7eyw831-QOP-m7eywh0w</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ_codeC</r:String>
@@ -487,7 +487,7 @@
             </r:OutParameter>
             <r:OutParameter isArray="false">
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+               <r:ID>m7eypvnj-QOP-m7eywfek</r:ID>
                <r:Version>1</r:Version>
                <r:ParameterName>
                   <r:String xml:lang="fr-FR">MCQ_codeD</r:String>
@@ -496,13 +496,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+                  <r:ID>lutkxex2-RDOP-lutll481</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+                  <r:ID>lutkxex2-QOP-lutll481</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -510,13 +510,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+                  <r:ID>lutkxex2-RDOP-lutlkzqn</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+                  <r:ID>lutkxex2-QOP-lutlkzqn</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -524,13 +524,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+                  <r:ID>lutkxex2-RDOP-lutlf2kj</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+                  <r:ID>lutkxex2-QOP-lutlf2kj</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -538,13 +538,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+                  <r:ID>lutkxex2-RDOP-lutlg1iw</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+                  <r:ID>lutkxex2-QOP-lutlg1iw</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -552,13 +552,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+                  <r:ID>m7eyw831-RDOP-m7eywh0w</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+                  <r:ID>m7eyw831-QOP-m7eywh0w</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -566,13 +566,13 @@
             <r:Binding>
                <r:SourceParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+                  <r:ID>m7eypvnj-RDOP-m7eywfek</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:SourceParameterReference>
                <r:TargetParameterReference>
                   <r:Agency>fr.insee</r:Agency>
-                  <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+                  <r:ID>m7eypvnj-QOP-m7eywfek</r:ID>
                   <r:Version>1</r:Version>
                   <r:TypeOfObject>OutParameter</r:TypeOfObject>
                </r:TargetParameterReference>
@@ -597,7 +597,7 @@
                   <d:NominalDomain>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkxex2-RDOP-lutlb389</r:ID>
+                        <r:ID>lutkxex2-RDOP-lutll481</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeSubsetInformation>
@@ -625,7 +625,7 @@
                   <d:NominalDomain>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkxex2-RDOP-lutligr6</r:ID>
+                        <r:ID>lutkxex2-RDOP-lutlkzqn</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeSubsetInformation>
@@ -653,7 +653,7 @@
                   <d:NominalDomain>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkxex2-RDOP-lutllcqj</r:ID>
+                        <r:ID>lutkxex2-RDOP-lutlf2kj</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeSubsetInformation>
@@ -681,7 +681,7 @@
                   <d:NominalDomain>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutkxex2-RDOP-lutle98i</r:ID>
+                        <r:ID>lutkxex2-RDOP-lutlg1iw</r:ID>
                         <r:Version>1</r:Version>
                         <r:CodeRepresentation>
                            <r:CodeSubsetInformation>
@@ -712,7 +712,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutlgqmy-RDOP-lutl6p92</r:ID>
+                        <r:ID>m7eyw831-RDOP-m7eywh0w</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="20"/>
                      </r:OutParameter>
@@ -736,7 +736,7 @@
                      </r:Label>
                      <r:OutParameter isArray="false">
                         <r:Agency>fr.insee</r:Agency>
-                        <r:ID>lutljcf1-RDOP-lutl8s82</r:ID>
+                        <r:ID>m7eypvnj-RDOP-m7eywfek</r:ID>
                         <r:Version>1</r:Version>
                         <r:TextRepresentation maxLength="30"/>
                      </r:OutParameter>
@@ -923,7 +923,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkqj7u-QOP-lutlcmdc</r:ID>
+               <r:ID>lutkqj7u-QOP-lutl1gyc</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -956,7 +956,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutl4boi-QOP-lutldzwz</r:ID>
+               <r:ID>m7eyrd9b-QOP-m7eyepyo</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -982,7 +982,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutl72ne-QOP-lutl513r</r:ID>
+               <r:ID>m7eyqgnu-QOP-m7eysikc</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1008,7 +1008,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkmu5x-QOP-lutl3eds</r:ID>
+               <r:ID>lutkmu5x-QOP-lutlkq28</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1041,7 +1041,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlbp0u-QOP-lutlhhgn</r:ID>
+               <r:ID>m7eynlus-QOP-m7eyns86</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1067,7 +1067,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlld7b-QOP-lutldnjm</r:ID>
+               <r:ID>m7eyesaq-QOP-m7eyhq9h</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1093,7 +1093,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutlb389</r:ID>
+               <r:ID>lutkxex2-QOP-lutll481</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1130,7 +1130,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutligr6</r:ID>
+               <r:ID>lutkxex2-QOP-lutlkzqn</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1167,7 +1167,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutllcqj</r:ID>
+               <r:ID>lutkxex2-QOP-lutlf2kj</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1204,7 +1204,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutkxex2-QOP-lutle98i</r:ID>
+               <r:ID>lutkxex2-QOP-lutlg1iw</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1241,7 +1241,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutlgqmy-QOP-lutl6p92</r:ID>
+               <r:ID>m7eyw831-QOP-m7eywh0w</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>
@@ -1267,7 +1267,7 @@
             </r:Label>
             <r:SourceParameterReference>
                <r:Agency>fr.insee</r:Agency>
-               <r:ID>lutljcf1-QOP-lutl8s82</r:ID>
+               <r:ID>m7eypvnj-QOP-m7eywfek</r:ID>
                <r:Version>1</r:Version>
                <r:TypeOfObject>OutParameter</r:TypeOfObject>
             </r:SourceParameterReference>

--- a/eno-core/src/test/resources/integration/pogues/pogues-controls-line.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-controls-line.json
@@ -113,8 +113,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/integration/pogues/pogues-dimensions.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-dimensions.json
@@ -536,8 +536,10 @@
                 ],
                 "Dimension": [
                   {
-                    "dimensionType": "PRIMARY",
-                    "dynamic": "1-5"
+                    "dynamic": "DYNAMIC_LENGTH",
+                    "MaxLines": 5,
+                    "MinLines": 1,
+                    "dimensionType": "PRIMARY"
                   },
                   {
                     "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/integration/pogues/pogues-dynamic-table-2.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-dynamic-table-2.json
@@ -162,8 +162,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/integration/pogues/pogues-dynamic-table.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-dynamic-table.json
@@ -187,8 +187,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/integration/pogues/pogues-no-data-cell.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-no-data-cell.json
@@ -164,7 +164,7 @@
             ],
             "Dimension": [
               {
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
                 "CodeListReference": "lx1j7nb1"
               },
@@ -281,7 +281,9 @@
             ],
             "Dimension": [
               {
-                "dynamic": "4-4",
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 4,
+                "MinLines": 4,
                 "dimensionType": "PRIMARY"
               },
               {
@@ -402,7 +404,9 @@
             ],
             "Dimension": [
               {
-                "dynamic": "1-5",
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
                 "dimensionType": "PRIMARY"
               },
               {

--- a/eno-core/src/test/resources/integration/pogues/pogues-other-specify.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-other-specify.json
@@ -1,330 +1,36 @@
 {
-  "owner": "ENO-INTEGRATION-TESTS",
-  "FlowControl": [],
-  "ComponentGroup": [
-    {
-      "MemberReference": [
-        "idendquest",
-        "lutkf97g",
-        "lutkqj7u",
-        "lutkmu5x",
-        "lutkxex2"
-      ],
-      "Label": [
-        "Components for page 1"
-      ],
-      "id": "lutle9w5",
-      "Name": "PAGE_1"
-    }
-  ],
-  "agency": "fr.insee",
-  "genericName": "QUESTIONNAIRE",
-  "Label": [
-    "Eno - Other please specify"
-  ],
-  "childQuestionnaireRef": [],
-  "Name": "ENO_OTHER",
-  "Variables": {
-    "Variable": [
-      {
-        "Label": "UCQ_RADIO label",
-        "id": "lutkscmh",
-        "type": "CollectedVariableType",
-        "CodeListReference": "lutkfklf",
-        "Name": "UCQ_RADIO",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": 1
-        }
-      },
-      {
-        "Label": "UCQ_codeC radio detail",
-        "id": "lutl57n5",
-        "type": "CollectedVariableType",
-        "CodeListReference": "lutkfklf",
-        "Name": "UCQ_codeC_RADIO",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "20"
-        }
-      },
-      {
-        "Label": "UCQ_codeD radio detail",
-        "id": "lutkv69x",
-        "type": "CollectedVariableType",
-        "Name": "UCQ_codeD_RADIO",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "30"
-        }
-      },
-      {
-        "Label": "UCQ_CHECKBOX label",
-        "id": "lutkwsd5",
-        "type": "CollectedVariableType",
-        "CodeListReference": "lutkfklf",
-        "Name": "UCQ_CHECKBOX",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": 1
-        }
-      },
-      {
-        "Label": "UCQ_codeC checkbox detail",
-        "id": "lutksrhg",
-        "type": "CollectedVariableType",
-        "Name": "UCQ_codeC_CHECKBOX",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "20"
-        }
-      },
-      {
-        "Label": "UCQ_codeD checkbox detail",
-        "id": "lutl4rut",
-        "type": "CollectedVariableType",
-        "Name": "UCQ_codeD_CHECKBOX",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "30"
-        }
-      },
-      {
-        "Label": "codeA - \"Option A\"",
-        "id": "lutlk4q5",
-        "type": "CollectedVariableType",
-        "Name": "MCQ1",
-        "Datatype": {
-          "typeName": "BOOLEAN",
-          "type": "BooleanDatatypeType"
-        }
-      },
-      {
-        "Label": "codeB - \"Option B\"",
-        "id": "lutli99v",
-        "type": "CollectedVariableType",
-        "Name": "MCQ2",
-        "Datatype": {
-          "typeName": "BOOLEAN",
-          "type": "BooleanDatatypeType"
-        }
-      },
-      {
-        "Label": "codeC - \"Option C (with detail)\"",
-        "id": "lutlbath",
-        "type": "CollectedVariableType",
-        "Name": "MCQ3",
-        "Datatype": {
-          "typeName": "BOOLEAN",
-          "type": "BooleanDatatypeType"
-        }
-      },
-      {
-        "Label": "codeD - \"Option D (with detail)\"",
-        "id": "lutl7oi1",
-        "type": "CollectedVariableType",
-        "Name": "MCQ4",
-        "Datatype": {
-          "typeName": "BOOLEAN",
-          "type": "BooleanDatatypeType"
-        }
-      },
-      {
-        "Label": "MCQ_codeC detail",
-        "id": "lutl5z5d",
-        "type": "CollectedVariableType",
-        "Name": "MCQ_codeC",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "20"
-        }
-      },
-      {
-        "Label": "MCQ_codeD detail",
-        "id": "lutlhxbn",
-        "type": "CollectedVariableType",
-        "Name": "MCQ_codeD",
-        "Datatype": {
-          "Pattern": "",
-          "typeName": "TEXT",
-          "type": "TextDatatypeType",
-          "MaxLength": "30"
-        }
-      }
-    ]
-  },
-  "lastUpdatedDate": "Wed Apr 10 2024 11:02:36 GMT+0200 (heure d’été d’Europe centrale)",
-  "DataCollection": [
-    {
-      "id": "esa-dc-2018",
-      "uri": "http://ddi:fr.insee:DataCollection.esa-dc-2018",
-      "Name": "Enquête sectorielle annuelle 2018"
-    }
-  ],
-  "final": false,
-  "flowLogic": "FILTER",
   "id": "lutk9kue",
-  "TargetMode": [
-    "CAPI",
-    "CATI",
-    "CAWI",
-    "PAPI"
-  ],
-  "CodeLists": {
-    "CodeList": [
-      {
-        "Label": "CODE_LIST_WITH_DETAIL",
-        "id": "lutkfklf",
-        "Code": [
-          {
-            "Parent": "",
-            "Label": "\"Option A\"",
-            "Value": "codeA"
-          },
-          {
-            "Parent": "",
-            "Label": "\"Option B\"",
-            "Value": "codeB"
-          },
-          {
-            "Parent": "",
-            "Label": "\"Option C (with detail)\"",
-            "Value": "codeC"
-          },
-          {
-            "Parent": "",
-            "Label": "\"Option D (with detail)\"",
-            "Value": "codeD"
-          }
-        ],
-        "Name": ""
-      }
-    ]
-  },
-  "formulasLanguage": "VTL",
+  "Name": "ENO_OTHER",
   "Child": [
     {
-      "Control": [],
-      "depth": 1,
-      "FlowControl": [],
-      "genericName": "MODULE",
-      "Label": [
-        "\"Sequence\""
-      ],
       "id": "lutkf97g",
-      "TargetMode": [
-        "CAPI",
-        "CATI",
-        "CAWI",
-        "PAPI"
-      ],
-      "Declaration": [],
+      "Name": "SEQUENCE",
       "type": "SequenceType",
       "Child": [
         {
-          "Response": [
-            {
-              "CollectedVariableReference": "lutkscmh",
-              "id": "lutl1gyc",
-              "mandatory": false,
-              "CodeListReference": "lutkfklf",
-              "Datatype": {
-                "Pattern": "",
-                "typeName": "TEXT",
-                "visualizationHint": "RADIO",
-                "type": "TextDatatypeType",
-                "MaxLength": 1
-              }
-            }
-          ],
-          "Control": [],
-          "depth": 2,
-          "FlowControl": [
-            {
-              "Description": "$UCQ_RADIO$ = 'codeC' : UCQ_codeC_RADIO",
-              "Expression": "$UCQ_RADIO$ = 'codeC'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutlkx3g",
-              "IfTrue": "lutljq3k"
-            },
-            {
-              "Description": "$UCQ_RADIO$ = 'codeD' : UCQ_codeD_RADIO",
-              "Expression": "$UCQ_RADIO$ = 'codeD'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutlcitc",
-              "IfTrue": "lutl6vl0"
-            }
-          ],
+          "id": "lutkqj7u",
+          "Name": "UCQ_RADIO",
+          "type": "QuestionType",
           "Label": [
             "\"Unique choice question (radio buttons)\""
           ],
-          "ClarificationQuestion": [
+          "depth": 2,
+          "Control": [],
+          "Response": [
             {
-              "Response": [
-                {
-                  "CollectedVariableReference": "lutl57n5",
-                  "id": "lutliibb",
-                  "mandatory": false,
-                  "Datatype": {
-                    "Pattern": "",
-                    "typeName": "TEXT",
-                    "type": "TextDatatypeType",
-                    "MaxLength": "20"
-                  }
-                }
-              ],
-              "Label": "\"Please, specify about option C:\"",
-              "id": "lutljq3k",
-              "TargetMode": [
-                "CAPI",
-                "CATI",
-                "CAWI",
-                "PAPI"
-              ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeC"
-            },
-            {
-              "Response": [
-                {
-                  "CollectedVariableReference": "lutkv69x",
-                  "id": "lutl1qhv",
-                  "mandatory": false,
-                  "Datatype": {
-                    "Pattern": "",
-                    "typeName": "TEXT",
-                    "type": "TextDatatypeType",
-                    "MaxLength": "30"
-                  }
-                }
-              ],
-              "Label": "\"Please, specify about option D:\"",
-              "id": "lutl6vl0",
-              "TargetMode": [
-                "CAPI",
-                "CATI",
-                "CAWI",
-                "PAPI"
-              ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeD"
+              "id": "lutl1gyc",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 1,
+                "visualizationHint": "RADIO"
+              },
+              "mandatory": false,
+              "CodeListReference": "lutkfklf",
+              "CollectedVariableReference": "lutkscmh"
             }
           ],
-          "id": "lutkqj7u",
           "TargetMode": [
             "CAPI",
             "CATI",
@@ -332,100 +38,100 @@
             "PAPI"
           ],
           "Declaration": [],
-          "type": "QuestionType",
-          "questionType": "SINGLE_CHOICE",
-          "Name": "UCQ_RADIO"
-        },
-        {
-          "Response": [
-            {
-              "CollectedVariableReference": "lutkwsd5",
-              "id": "lutlkq28",
-              "mandatory": false,
-              "CodeListReference": "lutkfklf",
-              "Datatype": {
-                "Pattern": "",
-                "typeName": "TEXT",
-                "visualizationHint": "CHECKBOX",
-                "type": "TextDatatypeType",
-                "MaxLength": 1
-              }
-            }
-          ],
-          "Control": [],
-          "depth": 2,
           "FlowControl": [
             {
-              "Description": "$UCQ_CHECKBOX$ = 'codeC' : UCQ_codeC_CHECKBOX",
-              "Expression": "$UCQ_CHECKBOX$ = 'codeC'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutl3gi6",
-              "IfTrue": "lutl5tm8"
+              "id": "lutlkx3g",
+              "IfTrue": "lutljq3k",
+              "Expression": "$UCQ_RADIO$ = 'codeC'",
+              "Description": "$UCQ_RADIO$ = 'codeC' : UCQ_codeC_RADIO",
+              "flowControlType": "CLARIFICATION"
             },
             {
-              "Description": "$UCQ_CHECKBOX$ = 'codeD' : UCQ_codeD_CHECKBOX",
-              "Expression": "$UCQ_CHECKBOX$ = 'codeD'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutl8ym1",
-              "IfTrue": "lutl8zv7"
+              "id": "lutlcitc",
+              "IfTrue": "lutl6vl0",
+              "Expression": "$UCQ_RADIO$ = 'codeD'",
+              "Description": "$UCQ_RADIO$ = 'codeD' : UCQ_codeD_RADIO",
+              "flowControlType": "CLARIFICATION"
             }
           ],
+          "questionType": "SINGLE_CHOICE",
+          "ClarificationQuestion": [
+            {
+              "id": "lutljq3k",
+              "Name": "UCQ_codeC",
+              "Label": "\"Please, specify about option C:\"",
+              "Response": [
+                {
+                  "id": "lutliibb",
+                  "Datatype": {
+                    "type": "TextDatatypeType",
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "MaxLength": "20"
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutl57n5"
+                }
+              ],
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE"
+            },
+            {
+              "id": "lutl6vl0",
+              "Name": "UCQ_codeD",
+              "Label": "\"Please, specify about option D:\"",
+              "Response": [
+                {
+                  "id": "lutl1qhv",
+                  "Datatype": {
+                    "type": "TextDatatypeType",
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "MaxLength": "30"
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutkv69x"
+                }
+              ],
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE"
+            }
+          ]
+        },
+        {
+          "id": "lutkmu5x",
+          "Name": "UCQ_CHECKBOX",
+          "type": "QuestionType",
           "Label": [
             "\"Unique choice question (checkbox buttons)\""
           ],
-          "ClarificationQuestion": [
+          "depth": 2,
+          "Control": [],
+          "Response": [
             {
-              "Response": [
-                {
-                  "CollectedVariableReference": "lutksrhg",
-                  "id": "lutlazew",
-                  "mandatory": false,
-                  "Datatype": {
-                    "Pattern": "",
-                    "typeName": "TEXT",
-                    "type": "TextDatatypeType",
-                    "MaxLength": "20"
-                  }
-                }
-              ],
-              "Label": "\"Please, specify about option C:\"",
-              "id": "lutl5tm8",
-              "TargetMode": [
-                "CAPI",
-                "CATI",
-                "CAWI",
-                "PAPI"
-              ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeC"
-            },
-            {
-              "Response": [
-                {
-                  "CollectedVariableReference": "lutl4rut",
-                  "id": "lutl9djy",
-                  "mandatory": false,
-                  "Datatype": {
-                    "Pattern": "",
-                    "typeName": "TEXT",
-                    "type": "TextDatatypeType",
-                    "MaxLength": "30"
-                  }
-                }
-              ],
-              "Label": "\"Please, specify about option D:\"",
-              "id": "lutl8zv7",
-              "TargetMode": [
-                "CAPI",
-                "CATI",
-                "CAWI",
-                "PAPI"
-              ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeD"
+              "id": "lutlkq28",
+              "Datatype": {
+                "type": "TextDatatypeType",
+                "Pattern": "",
+                "typeName": "TEXT",
+                "MaxLength": 1,
+                "visualizationHint": "CHECKBOX"
+              },
+              "mandatory": false,
+              "CodeListReference": "lutkfklf",
+              "CollectedVariableReference": "lutkwsd5"
             }
           ],
-          "id": "lutkmu5x",
           "TargetMode": [
             "CAPI",
             "CATI",
@@ -433,32 +139,144 @@
             "PAPI"
           ],
           "Declaration": [],
-          "type": "QuestionType",
-          "questionType": "SINGLE_CHOICE",
-          "Name": "UCQ_CHECKBOX"
-        },
-        {
           "FlowControl": [
             {
-              "Description": "$MCQ3$ = '1' : MCQ_codeC",
-              "Expression": "$MCQ3$ = '1'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutlmafr",
-              "IfTrue": "lutlm64y"
+              "id": "lutl3gi6",
+              "IfTrue": "lutl5tm8",
+              "Expression": "$UCQ_CHECKBOX$ = 'codeC'",
+              "Description": "$UCQ_CHECKBOX$ = 'codeC' : UCQ_codeC_CHECKBOX",
+              "flowControlType": "CLARIFICATION"
             },
             {
-              "Description": "$MCQ4$ = '1' : MCQ_codeD",
-              "Expression": "$MCQ4$ = '1'",
-              "flowControlType": "CLARIFICATION",
-              "id": "lutlj6si",
-              "IfTrue": "lutl9ech"
+              "id": "lutl8ym1",
+              "IfTrue": "lutl8zv7",
+              "Expression": "$UCQ_CHECKBOX$ = 'codeD'",
+              "Description": "$UCQ_CHECKBOX$ = 'codeD' : UCQ_codeD_CHECKBOX",
+              "flowControlType": "CLARIFICATION"
             }
           ],
+          "questionType": "SINGLE_CHOICE",
+          "ClarificationQuestion": [
+            {
+              "id": "lutl5tm8",
+              "Name": "UCQ_codeC",
+              "Label": "\"Please, specify about option C:\"",
+              "Response": [
+                {
+                  "id": "lutlazew",
+                  "Datatype": {
+                    "type": "TextDatatypeType",
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "MaxLength": "20"
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutksrhg"
+                }
+              ],
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE"
+            },
+            {
+              "id": "lutl8zv7",
+              "Name": "UCQ_codeD",
+              "Label": "\"Please, specify about option D:\"",
+              "Response": [
+                {
+                  "id": "lutl9djy",
+                  "Datatype": {
+                    "type": "TextDatatypeType",
+                    "Pattern": "",
+                    "typeName": "TEXT",
+                    "MaxLength": "30"
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutl4rut"
+                }
+              ],
+              "TargetMode": [
+                "CAPI",
+                "CATI",
+                "CAWI",
+                "PAPI"
+              ],
+              "questionType": "SIMPLE"
+            }
+          ]
+        },
+        {
+          "id": "lutkxex2",
+          "Name": "MCQ",
+          "type": "QuestionType",
           "Label": [
             "\"Multiple choice question\""
           ],
+          "depth": 2,
+          "Control": [],
+          "Response": [
+            {
+              "id": "lutll481",
+              "Datatype": {
+                "type": "BooleanDatatypeType",
+                "typeName": "BOOLEAN"
+              },
+              "CollectedVariableReference": "lutlk4q5"
+            },
+            {
+              "id": "lutlkzqn",
+              "Datatype": {
+                "type": "BooleanDatatypeType",
+                "typeName": "BOOLEAN"
+              },
+              "CollectedVariableReference": "lutli99v"
+            },
+            {
+              "id": "lutlf2kj",
+              "Datatype": {
+                "type": "BooleanDatatypeType",
+                "typeName": "BOOLEAN"
+              },
+              "CollectedVariableReference": "lutlbath"
+            },
+            {
+              "id": "lutlg1iw",
+              "Datatype": {
+                "type": "BooleanDatatypeType",
+                "typeName": "BOOLEAN"
+              },
+              "CollectedVariableReference": "lutl7oi1"
+            }
+          ],
+          "TargetMode": [
+            "CAPI",
+            "CATI",
+            "CAWI",
+            "PAPI"
+          ],
+          "Declaration": [],
+          "FlowControl": [
+            {
+              "id": "lutlmafr",
+              "IfTrue": "lutlm64y",
+              "Expression": "$MCQ3$ = '1'",
+              "Description": "$MCQ3$ = '1' : MCQ_codeC",
+              "flowControlType": "CLARIFICATION"
+            },
+            {
+              "id": "lutlj6si",
+              "IfTrue": "lutl9ech",
+              "Expression": "$MCQ4$ = '1'",
+              "Description": "$MCQ4$ = '1' : MCQ_codeD",
+              "flowControlType": "CLARIFICATION"
+            }
+          ],
+          "questionType": "MULTIPLE_CHOICE",
           "ResponseStructure": {
-            "Attribute": [],
             "Mapping": [
               {
                 "MappingSource": "lutll481",
@@ -477,130 +295,78 @@
                 "MappingTarget": "4"
               }
             ],
+            "Attribute": [],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
                 "dynamic": "0",
+                "dimensionType": "PRIMARY",
                 "CodeListReference": "lutkfklf"
               },
               {
-                "dimensionType": "MEASURE",
-                "dynamic": "0"
+                "dynamic": "0",
+                "dimensionType": "MEASURE"
               }
             ]
           },
-          "type": "QuestionType",
-          "Name": "MCQ",
-          "Response": [
-            {
-              "CollectedVariableReference": "lutlk4q5",
-              "id": "lutll481",
-              "Datatype": {
-                "typeName": "BOOLEAN",
-                "type": "BooleanDatatypeType"
-              }
-            },
-            {
-              "CollectedVariableReference": "lutli99v",
-              "id": "lutlkzqn",
-              "Datatype": {
-                "typeName": "BOOLEAN",
-                "type": "BooleanDatatypeType"
-              }
-            },
-            {
-              "CollectedVariableReference": "lutlbath",
-              "id": "lutlf2kj",
-              "Datatype": {
-                "typeName": "BOOLEAN",
-                "type": "BooleanDatatypeType"
-              }
-            },
-            {
-              "CollectedVariableReference": "lutl7oi1",
-              "id": "lutlg1iw",
-              "Datatype": {
-                "typeName": "BOOLEAN",
-                "type": "BooleanDatatypeType"
-              }
-            }
-          ],
-          "Control": [],
-          "depth": 2,
           "ClarificationQuestion": [
             {
+              "id": "lutlm64y",
+              "Name": "UCQ_codeC",
+              "Label": "\"Please, specify about option C:\"",
               "Response": [
                 {
-                  "CollectedVariableReference": "lutl5z5d",
                   "id": "lutlfn9e",
-                  "mandatory": false,
                   "Datatype": {
+                    "type": "TextDatatypeType",
                     "Pattern": "",
                     "typeName": "TEXT",
-                    "type": "TextDatatypeType",
                     "MaxLength": "20"
-                  }
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutl5z5d"
                 }
               ],
-              "Label": "\"Please, specify about option C:\"",
-              "id": "lutlm64y",
               "TargetMode": [
                 "CAPI",
                 "CATI",
                 "CAWI",
                 "PAPI"
               ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeC"
+              "questionType": "SIMPLE"
             },
             {
+              "id": "lutl9ech",
+              "Name": "UCQ_codeD",
+              "Label": "\"Please, specify about option D:\"",
               "Response": [
                 {
-                  "CollectedVariableReference": "lutlhxbn",
                   "id": "lutl3cfc",
-                  "mandatory": false,
                   "Datatype": {
+                    "type": "TextDatatypeType",
                     "Pattern": "",
                     "typeName": "TEXT",
-                    "type": "TextDatatypeType",
                     "MaxLength": "30"
-                  }
+                  },
+                  "mandatory": false,
+                  "CollectedVariableReference": "lutlhxbn"
                 }
               ],
-              "Label": "\"Please, specify about option D:\"",
-              "id": "lutl9ech",
               "TargetMode": [
                 "CAPI",
                 "CATI",
                 "CAWI",
                 "PAPI"
               ],
-              "questionType": "SIMPLE",
-              "Name": "UCQ_codeD"
+              "questionType": "SIMPLE"
             }
-          ],
-          "id": "lutkxex2",
-          "TargetMode": [
-            "CAPI",
-            "CATI",
-            "CAWI",
-            "PAPI"
-          ],
-          "Declaration": [],
-          "questionType": "MULTIPLE_CHOICE"
+          ]
         }
       ],
-      "Name": "SEQUENCE"
-    },
-    {
-      "Control": [],
-      "depth": 1,
-      "FlowControl": [],
-      "genericName": "MODULE",
       "Label": [
-        "QUESTIONNAIRE_END"
+        "\"Sequence\""
       ],
-      "id": "idendquest",
+      "depth": 1,
+      "Control": [],
       "TargetMode": [
         "CAPI",
         "CATI",
@@ -608,9 +374,243 @@
         "PAPI"
       ],
       "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
+    },
+    {
+      "id": "idendquest",
+      "Name": "QUESTIONNAIRE_END",
       "type": "SequenceType",
       "Child": [],
-      "Name": "QUESTIONNAIRE_END"
+      "Label": [
+        "QUESTIONNAIRE_END"
+      ],
+      "depth": 1,
+      "Control": [],
+      "TargetMode": [
+        "CAPI",
+        "CATI",
+        "CAWI",
+        "PAPI"
+      ],
+      "Declaration": [],
+      "FlowControl": [],
+      "genericName": "MODULE"
     }
-  ]
+  ],
+  "Label": [
+    "Eno - Other please specify"
+  ],
+  "final": false,
+  "owner": "ENO-INTEGRATION-TESTS",
+  "agency": "fr.insee",
+  "CodeLists": {
+    "CodeList": [
+      {
+        "id": "lutkfklf",
+        "Code": [
+          {
+            "Label": "\"Option A\"",
+            "Value": "codeA",
+            "Parent": ""
+          },
+          {
+            "Label": "\"Option B\"",
+            "Value": "codeB",
+            "Parent": ""
+          },
+          {
+            "Label": "\"Option C (with detail)\"",
+            "Value": "codeC",
+            "Parent": ""
+          },
+          {
+            "Label": "\"Option D (with detail)\"",
+            "Value": "codeD",
+            "Parent": ""
+          }
+        ],
+        "Name": "",
+        "Label": "CODE_LIST_WITH_DETAIL"
+      }
+    ]
+  },
+  "Variables": {
+    "Variable": [
+      {
+        "id": "lutkscmh",
+        "Name": "UCQ_RADIO",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_RADIO label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 1
+        },
+        "CodeListReference": "lutkfklf"
+      },
+      {
+        "id": "lutl57n5",
+        "Name": "UCQ_codeC_RADIO",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_codeC radio detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "20"
+        },
+        "CodeListReference": "lutkfklf"
+      },
+      {
+        "id": "lutkv69x",
+        "Name": "UCQ_codeD_RADIO",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_codeD radio detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "30"
+        }
+      },
+      {
+        "id": "lutkwsd5",
+        "Name": "UCQ_CHECKBOX",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_CHECKBOX label",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": 1
+        },
+        "CodeListReference": "lutkfklf"
+      },
+      {
+        "id": "lutksrhg",
+        "Name": "UCQ_codeC_CHECKBOX",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_codeC checkbox detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "20"
+        }
+      },
+      {
+        "id": "lutl4rut",
+        "Name": "UCQ_codeD_CHECKBOX",
+        "type": "CollectedVariableType",
+        "Label": "UCQ_codeD checkbox detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "30"
+        }
+      },
+      {
+        "id": "lutlk4q5",
+        "Name": "MCQ1",
+        "type": "CollectedVariableType",
+        "Label": "codeA - \"Option A\"",
+        "Datatype": {
+          "type": "BooleanDatatypeType",
+          "typeName": "BOOLEAN"
+        }
+      },
+      {
+        "id": "lutli99v",
+        "Name": "MCQ2",
+        "type": "CollectedVariableType",
+        "Label": "codeB - \"Option B\"",
+        "Datatype": {
+          "type": "BooleanDatatypeType",
+          "typeName": "BOOLEAN"
+        }
+      },
+      {
+        "id": "lutlbath",
+        "Name": "MCQ3",
+        "type": "CollectedVariableType",
+        "Label": "codeC - \"Option C (with detail)\"",
+        "Datatype": {
+          "type": "BooleanDatatypeType",
+          "typeName": "BOOLEAN"
+        }
+      },
+      {
+        "id": "lutl7oi1",
+        "Name": "MCQ4",
+        "type": "CollectedVariableType",
+        "Label": "codeD - \"Option D (with detail)\"",
+        "Datatype": {
+          "type": "BooleanDatatypeType",
+          "typeName": "BOOLEAN"
+        }
+      },
+      {
+        "id": "lutl5z5d",
+        "Name": "MCQ_codeC",
+        "type": "CollectedVariableType",
+        "Label": "MCQ_codeC detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "20"
+        }
+      },
+      {
+        "id": "lutlhxbn",
+        "Name": "MCQ_codeD",
+        "type": "CollectedVariableType",
+        "Label": "MCQ_codeD detail",
+        "Datatype": {
+          "type": "TextDatatypeType",
+          "Pattern": "",
+          "typeName": "TEXT",
+          "MaxLength": "30"
+        }
+      }
+    ]
+  },
+  "flowLogic": "FILTER",
+  "TargetMode": [
+    "CAPI",
+    "CATI",
+    "CAWI",
+    "PAPI"
+  ],
+  "FlowControl": [],
+  "genericName": "QUESTIONNAIRE",
+  "ComponentGroup": [
+    {
+      "id": "lutle9w5",
+      "Name": "PAGE_1",
+      "Label": [
+        "Components for page 1"
+      ],
+      "MemberReference": [
+        "idendquest",
+        "lutkf97g",
+        "lutkqj7u",
+        "lutkmu5x",
+        "lutkxex2"
+      ]
+    }
+  ],
+  "DataCollection": [
+    {
+      "id": "esa-dc-2018",
+      "uri": "http://ddi:fr.insee:DataCollection.esa-dc-2018",
+      "Name": "Enquête sectorielle annuelle 2018"
+    }
+  ],
+  "lastUpdatedDate": "Wed Apr 10 2024 11:02:36 GMT+0200 (heure d’été d’Europe centrale)",
+  "formulasLanguage": "VTL",
+  "childQuestionnaireRef": []
 }

--- a/eno-core/src/test/resources/integration/pogues/pogues-suggester-options-table.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-suggester-options-table.json
@@ -81,7 +81,7 @@
             "Attribute": [],
             "Dimension": [
               {
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "dimensionType": "PRIMARY",
                 "CodeListReference": "m2kmcbtl"
               },
@@ -136,7 +136,9 @@
             "Attribute": [],
             "Dimension": [
               {
-                "dynamic": "1-5",
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
                 "dimensionType": "PRIMARY"
               },
               {

--- a/eno-core/src/test/resources/integration/pogues/pogues-suggester.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-suggester.json
@@ -768,7 +768,7 @@
             "Dimension": [
               {
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "CodeListReference": "lruelai2"
               },
               {
@@ -842,8 +842,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-5"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 5,
+                "MinLines": 1,
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",
@@ -918,7 +920,7 @@
             "Dimension": [
               {
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "CodeListReference": "lruelai2"
               },
               {
@@ -993,8 +995,10 @@
             ],
             "Dimension": [
               {
-                "dimensionType": "PRIMARY",
-                "dynamic": "1-2"
+                "dynamic": "DYNAMIC_LENGTH",
+                "MaxLines": 2,
+                "MinLines": 1,
+                "dimensionType": "PRIMARY"
               },
               {
                 "dimensionType": "MEASURE",

--- a/eno-core/src/test/resources/integration/pogues/pogues-tooltips.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-tooltips.json
@@ -288,7 +288,7 @@
             "Dimension": [
               {
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "CodeListReference": "lpgv54ab"
               },
               {
@@ -350,7 +350,7 @@
             "Dimension": [
               {
                 "dimensionType": "PRIMARY",
-                "dynamic": "0",
+                "dynamic": "NON_DYNAMIC",
                 "CodeListReference": "lpgv54ab"
               },
               {

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationCustomController.java
@@ -62,9 +62,7 @@ public class GenerationCustomController {
 				poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
 	}
 
-	/**
-	 * @deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
-	 * */
+	//@deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
 	@Operation(
 			summary = "[Eno Java service] Lunatic questionnaire generation from DDI.",
 			description= "**This endpoint is deprecated: use the `pogues-2-lunatic` endpoint.** " +
@@ -73,7 +71,7 @@ public class GenerationCustomController {
 					"You can get a parameters file by using the endpoint `/parameters/java/{context}/LUNATIC/{mode}`")
 	@PostMapping(value = "ddi-2-lunatic-json",
 			produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Deprecated(since = "3.33.0")
+	//@Deprecated(since = "3.33.0")
 	public ResponseEntity<byte[]> generateLunaticCustomParams(
 			@RequestPart(value="in") MultipartFile ddiFile,
 			@RequestPart(value="params") MultipartFile parametersFile,

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -64,9 +64,7 @@ public class GenerationStandardController {
                 poguesToLunaticService.transform(poguesFile, enoParameters, lunaticPostProcessing));
     }
 
-    /**
-     * @deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
-     * */
+    //@deprecated Some features are not fully described in DDI. The Pogues to Lunatic endpoint should be used instead.
     @Operation(
             summary = "[Eno Java service] Lunatic questionnaire generation from DDI.",
             description = "**This endpoint is deprecated: use the `pogues-2-lunatic` endpoint.** " +
@@ -74,7 +72,7 @@ public class GenerationStandardController {
                     "in function of context and mode. An optional specific treatment `json` file can be added.")
     @PostMapping(value = "{context}/lunatic-json/{mode}",
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Deprecated(since = "3.33.0")
+    //@Deprecated(since = "3.33.0")
     public ResponseEntity<byte[]> generateLunatic(
             @RequestPart(value="in") MultipartFile ddiFile,
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,


### PR DESCRIPTION
- test: add non-regression tests for the Pogues+DDI inputs mapping
- fix: temporary remove the inconsistency list size check for the `variables` property of Eno questionnaire
  - The reason is that table "no data cells" have collected variables in the Pogues questionnaire that get filtered in DDI in the Eno Xml Pogues to DDI transformation. 
  - To do in a next PR: add a Pogues processing that does this filtering and restore the check.
- refactor: remove the "disabled" tag on DDI to Lunatic generation endpoints while users are not familiar with generation of questionnaire from Pogues