### PR TITLE
Fix: remove dollar signs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.34.4-SNAPSHOT"
+    version = "3.36.1-SNAPSHOT"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
@@ -28,7 +28,7 @@ public class DynamicLabel extends EnoObject implements EnoLabel {
     /** Label content.
      * @see Label for details.
      */
-    @Pogues("#this")
+    @Pogues("T(fr.insee.eno.core.model.calculated.CalculatedExpression).removeSurroundingDollarSigns(#this)")
     @DDI("getTextContentArray(0).getText().getStringValue()")
     @Lunatic("setValue(#param)")
     String value;

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
@@ -30,7 +30,7 @@ public class Label extends EnoObject implements EnoLabel {
     /** Text content of the label, which can be either static or dynamic.
      * In DDI, if the label contains variables, their names are replaced by references.
      * There is a processing class to resolve the references and put back variable names instead. */
-    @Pogues("#this")
+    @Pogues("T(fr.insee.eno.core.model.calculated.CalculatedExpression).removeSurroundingDollarSigns(#this)")
     @DDI("getContentArray(0).getStringValue()")
     @Lunatic("setValue(#param)")
     String value;

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/NumericQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/NumericQuestionTest.java
@@ -65,7 +65,7 @@ class NumericQuestionTest {
 
         assertNull(numericQuestion1.getUnit());
         if (inFormat == Format.POGUES) assertEquals("€", numericQuestion2.getUnit().getValue());
-        if (inFormat == Format.POGUES) assertEquals("$WHICH_UNIT$", numericQuestion3.getUnit().getValue());
+        if (inFormat == Format.POGUES) assertEquals("WHICH_UNIT", numericQuestion3.getUnit().getValue());
 
         assertEquals("NUMBER_NO_UNIT", numericQuestion1.getResponse().getVariableName());
         assertEquals("NUMBER_FIXED_UNIT", numericQuestion2.getResponse().getVariableName());

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static fr.insee.eno.core.model.calculated.CalculatedExpression.removeSurroundingDollarSigns;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CalculatedExpressionTest {
@@ -70,6 +71,21 @@ class CalculatedExpressionTest {
                 mappingException.getCause());
         assertTrue(exception.getMessage().startsWith("Name 'FOO' used in expression:"));
         assertTrue(exception.getMessage().contains(expression));
+    }
+
+    @Test
+    void removeSurroundingDollarSignsTest1(){
+        String expression = "\"\\\"I - \\\" || \\\"$Adresse$\\\"\",";
+        String expressionWithout = removeSurroundingDollarSigns(expression);
+        assertEquals("\"\\\"I - \\\" || \\\"Adresse\\\"\",", expressionWithout);
+    }
+
+    @Test
+    void removeSurroundingDollarSignsTest2(){
+        String expression = "cast(nvl($EXT_NOM_FAMILLE$,\"toto\"), string) || \" \" cast(nvl($CALC_CONCAC_Q5_Q6$, string)";
+        String expressionWithout = removeSurroundingDollarSigns(expression);
+        assertEquals("cast(nvl(EXT_NOM_FAMILLE,\"toto\"), string) || \" \" cast(nvl(CALC_CONCAC_Q5_Q6, string)"
+                , expressionWithout);
     }
 
 }


### PR DESCRIPTION
Suite à la recette sur **"[Eno Java][Pogues] lecture des variables - Première partie"** : 

- Retrait des "$" dans les _labels dynamiques_.
- Modification d'un test suite à cet ajustement.

