### PR TITLE
refactor: default params papi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>fr.insee.eno</groupId>
 	<artifactId>eno-core</artifactId>
-	<version>2.12.3</version>
+	<version>2.12.4</version>
 	<packaging>jar</packaging>
 
 	<name>Eno – Questionnaire generator</name>

--- a/src/main/resources/params/default/parameters.xml
+++ b/src/main/resources/params/default/parameters.xml
@@ -41,11 +41,11 @@
             <Roster>
                 <Row>
                     <MinimumEmpty>1</MinimumEmpty>
-                    <DefaultSize>10</DefaultSize>
+                    <DefaultSize>5</DefaultSize>
                 </Row>
             </Roster>
             <Loop>
-                <DefaultOccurrence>5</DefaultOccurrence>
+                <DefaultOccurrence>2</DefaultOccurrence>
                 <MinimumEmptyOccurrence>1</MinimumEmptyOccurrence>
             </Loop>
             <TextArea>
@@ -59,7 +59,7 @@
                 </Row>
             </Table>
             <Capture>
-                <Numeric>optical</Numeric>
+                <Numeric>manual</Numeric>
             </Capture>
             <PageBreakBetween/>
             <AccompanyingMail/>

--- a/src/test/java/fr/insee/eno/test/TestDDI2FO.java
+++ b/src/test/java/fr/insee/eno/test/TestDDI2FO.java
@@ -14,14 +14,14 @@ import java.io.*;
 
 import static fr.insee.eno.Constants.createTempEnoFile;
 
-public class TestDDI2FO {
+class TestDDI2FO {
 		
-	private DDI2FOGenerator ddi2fo = new DDI2FOGenerator();
+	private final DDI2FOGenerator ddi2fo = new DDI2FOGenerator();
 
-	private XMLDiff xmlDiff = new XMLDiff();
+	private final XMLDiff xmlDiff = new XMLDiff();
 
 	@Test
-	public void simpleDiffTest() {
+	void simpleDiffTest() {
 		try {
 			String basePath = "src/test/resources/ddi-to-fo";
 			File in = new File(String.format("%s/in.xml", basePath));
@@ -82,7 +82,7 @@ public class TestDDI2FO {
 	}
 
 	private String getDiffMessage(Diff diff, String path) {
-		return String.format("Transformed output for %s should match expected XML document:\n %s", path,
+		return  String.format("Transformed output for %s should match expected XML document:\n %s", path,
 				diff.toString());
 	}
 }

--- a/src/test/resources/ddi-to-fo/out.fo
+++ b/src/test/resources/ddi-to-fo/out.fo
@@ -38,13 +38,14 @@
             marges de 5mm autour, blanches.
             Le body est interne à ces marges et mesure donc 200 par 287.
             A l'intérieur du body se trouve les zones before/after (en haut en bas) et start/end (à gauche/a droite)
-            qui peuvent faire 1cm de large. Ces zones vont recueillir les numéros de page, encoches des bords, 
+            qui peuvent faire 1cm de large. Ces zones vont recueillir les numéros de page, encoches des bords,
             et code barres.
             L'emplacement d'une zone fixe la position du coin haut gauche de la zone, et sa taille.
             La position peut être définie par rapport au hautou bas de la zone concernée et gauche ou droite.
-                     
+
             Dans les zones before/after/start/end, les mesures se font par rapport au 0,0 de la zone concernée.
-            --><fo:simple-page-master master-name="page-even-default"
+            -->
+      <fo:simple-page-master master-name="page-even-default"
                              page-height="297mm"
                              page-width="210mm"
                              reference-orientation="0"
@@ -159,7 +160,7 @@
                              font-family="Liberation Sans"
                              font-size="10pt">
             <fo:block margin="20mm">
-                    Cette page peut être surchargée par une page standardisée, comportant l'identification de l'enquêté, 
+                    Cette page peut être surchargée par une page standardisée, comportant l'identification de l'enquêté,
                     l'adresse de retour du questionnaire, un encadré légal CNIS, un espace libre de commentaire etc...
                                    </fo:block>
          </fo:block-container>
@@ -203,7 +204,10 @@
       <fo:flow flow-name="xsl-region-body"
                border-collapse="collapse"
                font-size="10pt">
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -212,34 +216,31 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">I - Introduction</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">I - Introduction</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">
+                   text-align="justify">
             <fo:block>We're going to test your knowledge about the simpsons series.</fo:block>
             <fo:block/>
             <fo:block>
                <fo:inline font-weight="bold">Welcome in the simspons world!</fo:inline>
             </fo:block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">
+                   text-align="justify">
             <fo:block>➡ 1. Before starting, do you have any comments about the Simpsons</fo:block>
             <fo:block> family?</fo:block>
          </fo:block>
@@ -248,15 +249,15 @@
                <fo:block> </fo:block>
             </fo:block-container>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 2. Are you ready?</fo:block>
+                   text-align="justify">➡ 2. Are you ready?</fo:block>
          <fo:block id="READY" page-break-inside="avoid">
             <fo:list-block>
                <fo:list-item>
@@ -275,13 +276,13 @@
                </fo:list-item>
             </fo:list-block>
          </fo:block>
-         <fo:block space-before="2pt"
+         <fo:block page-break-inside="avoid"
+                   keep-with-previous="always"
+                   space-before="2pt"
                    space-after="2pt"
                    start-indent="5%"
                    end-indent="0%"
-                   background-color="#f0f0f0"
-                   page-break-inside="avoid"
-                   keep-with-previous="always">
+                   background-color="#f0f0f0">
             <fo:inline-container start-indent="0%"
                                  end-indent="0%"
                                  width="9%"
@@ -302,26 +303,26 @@
                          text-align="justify">If you are not ready, please go to the end of the questionnaire</fo:block>
             </fo:inline-container>
          </fo:block>
-         <fo:block background-color="#CCCCCC"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#CCCCCC"
                    color="black"
                    font-weight="bold"
                    margin-bottom="9pt"
                    font-size="12pt"
                    text-align="left"
                    space-before="6mm"
-                   space-before.conditionality="discard"
-                   page-break-inside="avoid"
+                   space-before.conditionality="discard">General knowledge of the series</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">General knowledge of the series</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 3. Who is the producer?</fo:block>
+                   text-align="justify">➡ 3. Who is the producer?</fo:block>
          <fo:block id="PRODUCER" page-break-inside="avoid">
             <fo:block>
                <fo:block-container height="8mm"
@@ -332,84 +333,101 @@
                </fo:block-container>
             </fo:block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 4. What is the current season number?</fo:block>
+                   text-align="justify">➡ 4. What is the current season number?</fo:block>
          <fo:block id="SEASON_NUMBER" page-break-inside="avoid">
             <fo:block>
-               <fo:block color="black"
+               <fo:block padding-bottom="0mm"
+                         padding-top="0mm"
+                         color="black"
                          font-weight="normal"
                          font-size="10pt"
                          padding="1mm"
-                         text-align="justify"
-                         padding-bottom="0mm"
-                         padding-top="0mm">
-                  <fo:external-graphic src="mask_number.png"/>
-                  <fo:external-graphic src="mask_number.png"/>
+                         text-align="justify">
+                  <fo:inline-container width="8mm">
+                     <fo:block-container height="8mm"
+                                         width="8mm"
+                                         border-color="black"
+                                         border-style="solid">
+                        <fo:block>
+									 
+								</fo:block>
+                     </fo:block-container>
+                  </fo:inline-container>
                   <fo:inline/>
                </fo:block>
             </fo:block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">➡ 5. When was the first episode of the Simpsons?</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">➡ 5. When was the first episode of the Simpsons?</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">For your information, the date of the last broadcast was on ${LAST_BROADCAST} </fo:block>
+                   text-align="justify">For your information, the date of the last broadcast was on ${LAST_BROADCAST} </fo:block>
          <fo:block id="DATEFIRST" page-break-inside="avoid">
             <fo:block color="black"
                       font-weight="normal"
                       font-size="10pt"
                       padding="1mm"
                       text-align="justify">
-               <fo:external-graphic src="date-o-fr-YYYYMMDD.png"/>
+               <fo:external-graphic src="date-m-fr-YYYYMMDD.png"/>
             </fo:block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 6. In your opinion, how much is the part of audience share in US for the 2016 season?</fo:block>
+                   text-align="justify">➡ 6. In your opinion, how much is the part of audience share in US for the 2016 season?</fo:block>
          <fo:block id="AUDIENCE_SHARE" page-break-inside="avoid">
             <fo:block>
-               <fo:block color="black"
+               <fo:block padding-bottom="0mm"
+                         padding-top="0mm"
+                         color="black"
                          font-weight="normal"
                          font-size="10pt"
                          padding="1mm"
-                         text-align="justify"
-                         padding-bottom="0mm"
-                         padding-top="0mm">
-                  <fo:external-graphic src="mask_number.png"/>
-                  <fo:external-graphic src="mask_number.png"/>
-                  <fo:inline> , </fo:inline>
-                  <fo:external-graphic src="mask_number.png"/>
+                         text-align="justify">
+                  <fo:inline-container width="16mm">
+                     <fo:block-container height="8mm"
+                                         width="16mm"
+                                         border-color="black"
+                                         border-style="solid">
+                        <fo:block>
+									 
+								</fo:block>
+                     </fo:block-container>
+                  </fo:inline-container>
                   <fo:inline/>
                </fo:block>
             </fo:block>
          </fo:block>
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -418,37 +436,34 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">II - Simpsons' city</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">II - Simpsons' city</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">This module asks about your general knowledge of the Simpsons city</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">This module asks about your general knowledge of the Simpsons city</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">➡ 1. In which city do the Simpsons reside?</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">➡ 1. In which city do the Simpsons reside?</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">One possible answer</fo:block>
+                   text-align="justify">One possible answer</fo:block>
          <fo:block id="CITY" page-break-inside="avoid">
             <fo:list-block>
                <fo:list-item>
@@ -495,24 +510,24 @@
                </fo:list-item>
             </fo:list-block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">➡ 2. Who is the Simpsons city mayor?</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">➡ 2. Who is the Simpsons city mayor?</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">Only one possible answer</fo:block>
+                   text-align="justify">Only one possible answer</fo:block>
          <fo:block id="MAYOR" page-break-inside="avoid">
             <fo:list-block>
                <fo:list-item>
@@ -573,15 +588,15 @@
                </fo:list-item>
             </fo:list-block>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 3. In which state do The Simpsons reside?</fo:block>
+                   text-align="justify">➡ 3. In which state do The Simpsons reside?</fo:block>
          <fo:block id="STATE" page-break-inside="avoid">
             <fo:block-container height="8mm"
                                 border-color="black"
@@ -590,7 +605,10 @@
                <fo:block> </fo:block>
             </fo:block-container>
          </fo:block>
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -599,28 +617,25 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">III - Characters</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">III - Characters</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">➡ 1. What are the pet names that the Simpsons family had?</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">➡ 1. What are the pet names that the Simpsons family had?</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">
+                   text-align="justify">
             <fo:inline font-style="italic">Several possible answers</fo:inline>
          </fo:block>
          <fo:block id="PET" page-break-inside="avoid">
@@ -689,26 +704,26 @@
                </fo:list-item>
             </fo:list-block>
          </fo:block>
-         <fo:block font-size="10pt"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    space-before="20pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">
+                   text-align="justify">
             <fo:inline font-weight="bold">Now we are going to know if you think that Jay is a gluton.</fo:inline>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 2. Does Jay like the following ice cream flavours?</fo:block>
+                   text-align="justify">➡ 2. Does Jay like the following ice cream flavours?</fo:block>
          <fo:block page-break-inside="avoid" id="ICE_FLAVOUR">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -721,13 +736,13 @@
                       space-after="5mm">
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -766,13 +781,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -811,13 +826,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -856,13 +871,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -903,15 +918,15 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 3. Which character works in the nuclear power plant?</fo:block>
+                   text-align="justify">➡ 3. Which character works in the nuclear power plant?</fo:block>
          <fo:block page-break-inside="avoid" id="NUCLEAR_CHARACTER">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -924,13 +939,13 @@
                       space-after="5mm">
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -954,13 +969,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -984,13 +999,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1014,13 +1029,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1046,15 +1061,15 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block color="black"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 4. In which city each character was born?</fo:block>
+                   text-align="justify">➡ 4. In which city each character was born?</fo:block>
          <fo:block page-break-inside="avoid" id="BIRTH_CHARACTER">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -1067,13 +1082,13 @@
                       space-after="5mm">
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1139,13 +1154,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1211,13 +1226,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1283,13 +1298,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1355,13 +1370,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
                                     padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1"
                                     border="0mm"
                                     padding="0mm">
                         <fo:block color="black"
@@ -1429,7 +1444,10 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -1438,30 +1456,27 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">IV - General questions</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">IV - General questions</fo:block>
-         <fo:block background-color="#CCCCCC"
+                   keep-together.within-column="always"
+                   background-color="#CCCCCC"
                    color="black"
                    font-weight="bold"
                    margin-bottom="9pt"
                    font-size="12pt"
                    text-align="left"
                    space-before="6mm"
-                   space-before.conditionality="discard"
-                   page-break-inside="avoid"
+                   space-before.conditionality="discard">Kwik-E-Mart</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">Kwik-E-Mart</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 1. Please, specify the percentage of Jay's expenses in the Kwik-E-Mart for each product?</fo:block>
+                   text-align="justify">➡ 1. Please, specify the percentage of Jay's expenses in the Kwik-E-Mart for each product?</fo:block>
          <fo:block page-break-inside="avoid" id="PERCENTAGE_EXPENSES">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -1477,25 +1492,25 @@
                                 font-weight="normal"
                                 font-size="10pt"
                                 text-align="center">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="2"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="2">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"/>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1505,26 +1520,26 @@
                </fo:table-header>
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="2"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="2"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"
                                   margin-left="1mm">Frozen products</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1537,17 +1552,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1555,13 +1572,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1574,17 +1591,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1592,26 +1611,26 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="3"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="3"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"
                                   margin-left="1mm">Meat</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1624,17 +1643,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1642,13 +1663,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1661,17 +1682,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1679,13 +1702,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1698,17 +1721,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1716,26 +1741,26 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"
                                   margin-left="1mm">Compote</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1748,17 +1773,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1766,13 +1793,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="2"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="2">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1785,17 +1812,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline> , </fo:inline>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="15mm">
+                                    <fo:block-container height="8mm" width="15mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline>%</fo:inline>
                               </fo:block>
                            </fo:block>
@@ -1805,26 +1834,26 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block background-color="#CCCCCC"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#CCCCCC"
                    color="black"
                    font-weight="bold"
                    margin-bottom="9pt"
                    font-size="12pt"
                    text-align="left"
                    space-before="6mm"
-                   space-before.conditionality="discard"
-                   page-break-inside="avoid"
+                   space-before.conditionality="discard">Clowning</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">Clowning</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 2. Who did these clownings and tell us what you remember?</fo:block>
+                   text-align="justify">➡ 2. Who did these clownings and tell us what you remember?</fo:block>
          <fo:block page-break-inside="avoid" id="CLOWNING">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -1840,37 +1869,37 @@
                                 font-weight="normal"
                                 font-size="10pt"
                                 text-align="center">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"/>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Clowning</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1880,13 +1909,13 @@
                </fo:table-header>
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1919,13 +1948,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1958,13 +1987,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -1997,13 +2026,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2038,35 +2067,35 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block background-color="#CCCCCC"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#CCCCCC"
                    color="black"
                    font-weight="bold"
                    margin-bottom="9pt"
                    font-size="12pt"
                    text-align="left"
                    space-before="6mm"
-                   space-before.conditionality="discard"
-                   page-break-inside="avoid"
+                   space-before.conditionality="discard">Transport</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">Transport</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
+                   text-align="justify">➡ 3. Which of the following means of transport were used by the hero and in which country?</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">➡ 3. Which of the following means of transport were used by the hero and in which country?</fo:block>
-         <fo:block font-size="10pt"
+                   keep-together.within-column="always"
+                   font-size="10pt"
                    font-weight="normal"
                    font-style="italic"
                    margin-bottom="3pt"
                    margin-left="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">Several answers possible: check off all the relevant boxes</fo:block>
+                   text-align="justify">Several answers possible: check off all the relevant boxes</fo:block>
          <fo:block page-break-inside="avoid" id="TRAVEL">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -2082,85 +2111,85 @@
                                 font-weight="normal"
                                 font-size="10pt"
                                 text-align="center">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm"/>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Brazil</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Canada</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Japan</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">France</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Other country*</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2170,13 +2199,13 @@
                </fo:table-header>
                <fo:table-body>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2323,13 +2352,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2476,13 +2505,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2629,13 +2658,13 @@
                      </fo:table-cell>
                   </fo:table-row>
                   <fo:table-row border-color="black">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="left"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2784,7 +2813,10 @@
                </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -2793,19 +2825,16 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">V - Favourite characters</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">V - Favourite characters</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 1. Please, complete the following grid with your favourite characters</fo:block>
+                   text-align="justify">➡ 1. Please, complete the following grid with your favourite characters</fo:block>
          <fo:block page-break-inside="avoid" id="FAVOURITE_CHARACTERS">
             <fo:table inline-progression-dimension="auto"
                       table-layout="fixed"
@@ -2821,25 +2850,25 @@
                                 font-weight="normal"
                                 font-size="10pt"
                                 text-align="center">
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
                                   padding="1mm">Name</fo:block>
                      </fo:table-cell>
-                     <fo:table-cell border-color="black"
+                     <fo:table-cell number-rows-spanned="1"
+                                    number-columns-spanned="1"
+                                    border-color="black"
                                     border-style="solid"
                                     text-align="center"
                                     padding-left="1mm"
-                                    padding-right="1mm"
-                                    number-rows-spanned="1"
-                                    number-columns-spanned="1">
+                                    padding-right="1mm">
                         <fo:block color="black"
                                   font-weight="normal"
                                   font-size="10pt"
@@ -2847,7 +2876,10 @@
                      </fo:table-cell>
                   </fo:table-row>
                </fo:table-header>
-               <fo:table-body>#foreach( ${FAVOURITE_CHARACTERS} in ${FAVOURITE_CHARACTERS-Container} ) #set( $FAVOURITE_CHARACTERS.LoopPosition = $velocityCount)<fo:table-row border-color="black">
+               <fo:table-body>
+#foreach( ${FAVOURITE_CHARACTERS} in ${FAVOURITE_CHARACTERS-Container} )
+#set( $FAVOURITE_CHARACTERS.LoopPosition = $velocityCount)
+<fo:table-row border-color="black">
                      <fo:table-cell text-align="left"
                                     border-color="black"
                                     border-style="solid"
@@ -2864,15 +2896,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -2896,15 +2932,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -2928,15 +2968,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -2960,15 +3004,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -2992,15 +3040,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3024,15 +3076,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3056,15 +3112,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3088,15 +3148,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3120,15 +3184,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3152,21 +3220,26 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
-                  </fo:table-row>#end 
+                  </fo:table-row>
+#end
 #set( $initializeInt = 0)
 #set( $FAVOURITE_CHARACTERS-TotalOccurrenceInt = $initializeInt.parseInt(${FAVOURITE_CHARACTERS-TotalOccurrenceCount}))
 <fo:table-row border-color="black">
@@ -3186,15 +3259,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3218,15 +3295,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3250,15 +3331,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3282,15 +3367,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3314,15 +3403,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3346,15 +3439,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3378,15 +3475,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3410,15 +3511,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3442,15 +3547,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3474,22 +3583,26 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
                   </fo:table-row>
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 8) 
+#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 3)
 <fo:table-row border-color="black">
                      <fo:table-cell text-align="left"
                                     border-color="black"
@@ -3507,15 +3620,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3539,15 +3656,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3571,15 +3692,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3603,15 +3728,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3635,15 +3764,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3667,15 +3800,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3699,15 +3836,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3731,15 +3872,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3763,15 +3908,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3795,24 +3944,27 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
                   </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 7) 
+#end
+#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 2)
 <fo:table-row border-color="black">
                      <fo:table-cell text-align="left"
                                     border-color="black"
@@ -3830,15 +3982,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3862,15 +4018,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3894,15 +4054,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3926,15 +4090,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3958,15 +4126,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -3990,15 +4162,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4022,15 +4198,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4054,15 +4234,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4086,15 +4270,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4118,24 +4306,27 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
                   </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 6) 
+#end
+#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 1)
 <fo:table-row border-color="black">
                      <fo:table-cell text-align="left"
                                     border-color="black"
@@ -4153,15 +4344,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4185,15 +4380,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4217,15 +4416,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4249,15 +4452,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4281,15 +4488,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4313,15 +4524,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4345,15 +4560,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4377,15 +4596,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4409,15 +4632,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4441,24 +4668,27 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
                   </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 5) 
+#end
+#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 0)
 <fo:table-row border-color="black">
                      <fo:table-cell text-align="left"
                                     border-color="black"
@@ -4476,15 +4706,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4508,15 +4742,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4540,15 +4778,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4572,15 +4814,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4604,15 +4850,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4636,15 +4886,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4668,15 +4922,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4700,15 +4958,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4732,15 +4994,19 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
@@ -4764,1641 +5030,33 @@
                                     padding="1mm">
                         <fo:block>
                            <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
+                              <fo:block padding-bottom="0mm"
+                                        padding-top="0mm"
+                                        color="black"
                                         font-weight="normal"
                                         font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
+                                        padding="1mm">
+                                 <fo:inline-container width="9mm">
+                                    <fo:block-container height="8mm" width="9mm">
+                                       <fo:block>
+									 
+								</fo:block>
+                                    </fo:block-container>
+                                 </fo:inline-container>
                                  <fo:inline/>
                               </fo:block>
                            </fo:block>
                         </fo:block>
                      </fo:table-cell>
                   </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 4) 
-<fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 3) 
-<fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 2) 
-<fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 1) 
-<fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-#end 
-
-#if ($FAVOURITE_CHARACTERS-TotalOccurrenceInt le 0) 
-<fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-                  <fo:table-row border-color="black">
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block-container height="40mm">
-                              <fo:block> </fo:block>
-                           </fo:block-container>
-                        </fo:block>
-                     </fo:table-cell>
-                     <fo:table-cell text-align="left"
-                                    border-color="black"
-                                    border-style="solid"
-                                    padding="1mm">
-                        <fo:block>
-                           <fo:block text-align="right" padding-top="0mm" padding-bottom="0mm">
-                              <fo:block color="black"
-                                        font-weight="normal"
-                                        font-size="10pt"
-                                        padding="1mm"
-                                        padding-bottom="0mm"
-                                        padding-top="0mm">
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:external-graphic src="mask_number.png"/>
-                                 <fo:inline/>
-                              </fo:block>
-                           </fo:block>
-                        </fo:block>
-                     </fo:table-cell>
-                  </fo:table-row>
-#end 
+#end
 </fo:table-body>
             </fo:table>
          </fo:block>
-         <fo:block background-color="#666666"
+         <fo:block page-break-inside="avoid"
+                   keep-with-next="always"
+                   keep-together.within-column="always"
+                   background-color="#666666"
                    color="white"
                    font-weight="bold"
                    margin-bottom="9pt"
@@ -6407,19 +5065,16 @@
                    border-style="solid"
                    space-before="10mm"
                    space-before.conditionality="discard"
-                   text-align="left"
-                   page-break-inside="avoid"
+                   text-align="left">VI - Comment</fo:block>
+         <fo:block page-break-inside="avoid"
                    keep-with-next="always"
-                   keep-together.within-column="always">VI - Comment</fo:block>
-         <fo:block color="black"
+                   keep-together.within-column="always"
+                   color="black"
                    font-weight="bold"
                    font-size="10pt"
                    margin-top="9pt"
                    margin-bottom="3pt"
-                   text-align="justify"
-                   page-break-inside="avoid"
-                   keep-with-next="always"
-                   keep-together.within-column="always">➡ 1. Do you have any comment about the survey?</fo:block>
+                   text-align="justify">➡ 1. Do you have any comment about the survey?</fo:block>
          <fo:block id="SURVEY_COMMENT" page-break-inside="avoid">
             <fo:block-container height="40mm" border-color="black" border-style="solid">
                <fo:block> </fo:block>


### PR DESCRIPTION
Changement du paramétrage pour les pdf générés : 

- Moins de boucles par défaut.
- Moins de lignes dans les tableaux dynamiques par défaut.
- Saisie manuelle au lieu de la lecture optique.
