### PR TITLE
v3-next: 3.36.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.36.0"
+    version = "3.36.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/calculated/CalculatedExpression.java
@@ -13,6 +13,7 @@ import fr.insee.lunatic.model.flat.LabelTypeEnum;
 import fr.insee.pogues.model.ExpressionType;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -27,6 +28,7 @@ import static fr.insee.eno.core.annotations.Contexts.Context;
  * calculated variables, controls, filters. */
 @Getter
 @Setter
+@Slf4j
 @Context(format = Format.POGUES, type = ExpressionType.class)
 @Context(format = Format.DDI, type = CommandType.class)
 @Context(format = Format.LUNATIC, type = LabelType.class)
@@ -83,11 +85,14 @@ public class CalculatedExpression extends EnoObject {
     }
 
     private static void validatePoguesReference(String expression, String variableName, PoguesIndex poguesIndex) {
-        if (! poguesIndex.containsVariable(variableName))
-            throw new IllegalPoguesElementException(String.format(
+        if (! poguesIndex.containsVariable(variableName)) {
+            String message = String.format(
                     "Name '%s' used in expression:%n%s%n" +
                             "does not match any variable.",
-                    variableName, expression));
+                    variableName, expression);
+            log.warn(message);
+            // should be an exception, yet Pogues composition feature creates cases where this is allowed
+        }
     }
 
     /** The removeSurroundingDollarSigns method removes the "$" symbols surrounding the reference to

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/DynamicLabel.java
@@ -28,7 +28,7 @@ public class DynamicLabel extends EnoObject implements EnoLabel {
     /** Label content.
      * @see Label for details.
      */
-    @Pogues("#this")
+    @Pogues("T(fr.insee.eno.core.model.calculated.CalculatedExpression).removeSurroundingDollarSigns(#this)")
     @DDI("getTextContentArray(0).getText().getStringValue()")
     @Lunatic("setValue(#param)")
     String value;

--- a/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/label/Label.java
@@ -30,7 +30,7 @@ public class Label extends EnoObject implements EnoLabel {
     /** Text content of the label, which can be either static or dynamic.
      * In DDI, if the label contains variables, their names are replaced by references.
      * There is a processing class to resolve the references and put back variable names instead. */
-    @Pogues("#this")
+    @Pogues("T(fr.insee.eno.core.model.calculated.CalculatedExpression).removeSurroundingDollarSigns(#this)")
     @DDI("getContentArray(0).getStringValue()")
     @Lunatic("setValue(#param)")
     String value;

--- a/eno-core/src/main/java/fr/insee/eno/core/serialize/PoguesDeserializer.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/serialize/PoguesDeserializer.java
@@ -49,8 +49,7 @@ public class PoguesDeserializer {
         JSONDeserializer poguesDeserializer = new JSONDeserializer();
         log.info("Deserializing Pogues json questionnaire from URL {}.", poguesFileUrl);
         try {
-            Questionnaire poguesQuestionnaire = poguesDeserializer.deserialize(
-                    Path.of(poguesFileUrl.toURI()).toString());
+            Questionnaire poguesQuestionnaire = poguesDeserializer.deserialize(poguesFileUrl.openStream());
             log.info("Successfully deserialized Pogues questionnaire from URL {}.", poguesFileUrl);
             return poguesQuestionnaire;
         } catch (JAXBException e) {

--- a/eno-core/src/test/java/fr/insee/eno/core/PoguesDDIToEnoTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/PoguesDDIToEnoTest.java
@@ -22,6 +22,7 @@ import fr.insee.eno.core.serialize.DDIDeserializer;
 import fr.insee.eno.core.serialize.PoguesDeserializer;
 import fr.insee.pogues.model.Questionnaire;
 import org.json.JSONException;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -76,6 +77,7 @@ class PoguesDDIToEnoTest {
             "lmyjrqbb",
             "lqnje8yr"
     })
+    @Disabled("Exception for unknown variables temporary replaced by a warning")
     void invalidPoguesQuestionnaires_shouldThrow(String id) throws PoguesDeserializationException {
         //
         Questionnaire poguesQuestionnaire = PoguesDeserializer.deserialize(classLoader.getResourceAsStream(

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/NumericQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/NumericQuestionTest.java
@@ -65,7 +65,7 @@ class NumericQuestionTest {
 
         assertNull(numericQuestion1.getUnit());
         if (inFormat == Format.POGUES) assertEquals("€", numericQuestion2.getUnit().getValue());
-        if (inFormat == Format.POGUES) assertEquals("$WHICH_UNIT$", numericQuestion3.getUnit().getValue());
+        if (inFormat == Format.POGUES) assertEquals("WHICH_UNIT", numericQuestion3.getUnit().getValue());
 
         assertEquals("NUMBER_NO_UNIT", numericQuestion1.getResponse().getVariableName());
         assertEquals("NUMBER_FIXED_UNIT", numericQuestion2.getResponse().getVariableName());

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static fr.insee.eno.core.model.calculated.CalculatedExpression.removeSurroundingDollarSigns;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CalculatedExpressionTest {
@@ -70,6 +71,21 @@ class CalculatedExpressionTest {
                 mappingException.getCause());
         assertTrue(exception.getMessage().startsWith("Name 'FOO' used in expression:"));
         assertTrue(exception.getMessage().contains(expression));
+    }
+
+    @Test // dynamic label-like expression
+    void removeSurroundingDollarSignsTest1() {
+        String expression = "\"II - \" || $FIRST_NAME$";
+        String expressionWithout = removeSurroundingDollarSigns(expression);
+        assertEquals("\"II - \" || FIRST_NAME", expressionWithout);
+    }
+
+    @Test // calculated expression-like expression
+    void removeSurroundingDollarSignsTest2() {
+        String expression = "cast(nvl($LAST_NAME$, \"X\"), string) || \" \" || cast(nvl($CALC_VAR$, \"\"), string)";
+        String expressionWithout = removeSurroundingDollarSigns(expression);
+        assertEquals("cast(nvl(LAST_NAME, \"X\"), string) || \" \" || cast(nvl(CALC_VAR, \"\"), string)",
+                expressionWithout);
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/CalculatedExpressionTest.java
@@ -9,6 +9,7 @@ import fr.insee.pogues.model.CalculatedVariableType;
 import fr.insee.pogues.model.CollectedVariableType;
 import fr.insee.pogues.model.ExpressionType;
 import fr.insee.pogues.model.Questionnaire;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -49,6 +50,7 @@ class CalculatedExpressionTest {
     }
 
     @Test
+    @Disabled("Exception temporary replaced by a warning")
     void unknownVariableCase() {
 
         // Given

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicLabelTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/DynamicLabelTest.java
@@ -1,0 +1,36 @@
+package fr.insee.eno.core.mapping.in.pogues;
+
+import fr.insee.eno.core.mappers.PoguesMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.label.DynamicLabel;
+import fr.insee.pogues.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DynamicLabelTest {
+
+    @Test
+    void labelInDeclaration_withDollarSign() {
+        // Given
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        SequenceType poguesSequence = new SequenceType();
+        poguesSequence.setGenericName(GenericNameEnum.MODULE);
+        DeclarationType poguesDeclaration = new DeclarationType();
+        poguesDeclaration.setPosition(DeclarationPositionEnum.BEFORE_QUESTION_TEXT);
+        String labelValue = "\"Your revenue last year was \" || $EXT_REVENUE$";
+        poguesDeclaration.setText(labelValue);
+        poguesSequence.getDeclaration().add(poguesDeclaration);
+        poguesQuestionnaire.getChild().add(poguesSequence);
+
+        // When
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        PoguesMapper poguesMapper = new PoguesMapper();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+
+        // Then
+        DynamicLabel enoLabel = enoQuestionnaire.getSequences().getFirst().getDeclarations().getFirst().getLabel();
+        assertEquals("\"Your revenue last year was \" || EXT_REVENUE", enoLabel.getValue());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/LabelTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/in/pogues/LabelTest.java
@@ -1,0 +1,41 @@
+package fr.insee.eno.core.mapping.in.pogues;
+
+import fr.insee.eno.core.mappers.PoguesMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.label.Label;
+import fr.insee.pogues.model.GenericNameEnum;
+import fr.insee.pogues.model.Questionnaire;
+import fr.insee.pogues.model.SequenceType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reminder: all label objects are actually "dynamic labels"
+ * (i.e. labels that can be dynamically interpreted using VTL variables)
+ * There is several label objects due to DDI modeling.
+ * @see DynamicLabelTest
+ */
+class LabelTest {
+
+    @Test
+    void sequenceLabel_dollarSigns() {
+        // Given
+        Questionnaire poguesQuestionnaire = new Questionnaire();
+        SequenceType poguesSequence = new SequenceType();
+        poguesSequence.setGenericName(GenericNameEnum.MODULE);
+        String labelValue = "\"Questions for \" || $FIRST_NAME$ || \" \" || $LAST_NAME$";
+        poguesSequence.getLabel().add(labelValue);
+        poguesQuestionnaire.getChild().add(poguesSequence);
+
+        // When
+        EnoQuestionnaire enoQuestionnaire = new EnoQuestionnaire();
+        PoguesMapper poguesMapper = new PoguesMapper();
+        poguesMapper.mapPoguesQuestionnaire(poguesQuestionnaire, enoQuestionnaire);
+
+        // Then
+        Label enoLabel = enoQuestionnaire.getSequences().getFirst().getLabel();
+        assertEquals("\"Questions for \" || FIRST_NAME || \" \" || LAST_NAME", enoLabel.getValue());
+    }
+
+}

--- a/eno-ws/src/main/java/fr/insee/eno/ws/EnoWsApplication.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/EnoWsApplication.java
@@ -28,7 +28,7 @@ public class EnoWsApplication {
 
 	@Bean
 	public UriComponentsBuilder uriBuilderWithBaseUrl(@Value("${eno.legacy.ws.url}") String baseUrl) {
-		return UriComponentsBuilder.fromHttpUrl(baseUrl);
+		return UriComponentsBuilder.fromUriString(baseUrl);
 	}
 
 	@Bean


### PR DESCRIPTION
- Correction sur les `$` dans les libellés VTL avec le questionnaire Pogues en input (PR en cours)

Autres :

- Refacto sur le PoguesDeserializer pour ne pas utilisée une méthode dépréciée.
