### PR TITLE
Feat: adding parameter question wrapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.36.2"
+    version = "3.37.0-SNAPSHOT"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
@@ -44,7 +44,7 @@ public class LunaticParameters {
         this.setFilterResult(isWeb || isProcess);
         this.setMissingVariables(isInterview || isProcess);
         this.setLunaticPaginationMode(paginationValue(context, modeParameter));
-        this.setQuestionWrapping(false);
+        this.setQuestionWrapping(true);
     }
 
     private LunaticPaginationMode paginationValue(EnoParameters.Context context, EnoParameters.ModeParameter modeParameter) {

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
@@ -1,5 +1,6 @@
 package fr.insee.eno.core.parameter;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +17,10 @@ public class LunaticParameters {
     private boolean filterResult;
     private boolean filterDescription;
     private LunaticPaginationMode lunaticPaginationMode;
+
+    /** Parameter to include or exclude the question component (temporary modification) */
+    @JsonProperty("questionWrapping")
+    private boolean questionWrapping;
 
     private LunaticParameters() {}
 
@@ -39,6 +44,7 @@ public class LunaticParameters {
         this.setFilterResult(isWeb || isProcess);
         this.setMissingVariables(isInterview || isProcess);
         this.setLunaticPaginationMode(paginationValue(context, modeParameter));
+        this.setQuestionWrapping(false);
     }
 
     private LunaticPaginationMode paginationValue(EnoParameters.Context context, EnoParameters.ModeParameter modeParameter) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -59,7 +59,7 @@ public class LunaticProcessing {
                 .thenIf(enoParameters.getModeParameter().equals(EnoParameters.ModeParameter.CAWI), new LunaticSequenceDescription())
                 .then(new LunaticInputNumberDescription(enoParameters.getLanguage()))
                 .then(new LunaticDurationDescription())
-                .then(new LunaticQuestionComponent())
+                .thenIf(lunaticParameters.isQuestionWrapping(), new LunaticQuestionComponent())
                 .then(new LunaticRoundaboutLoops(enoQuestionnaire));
     }
 

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -9,6 +9,7 @@ import fr.insee.eno.ws.exception.*;
 import fr.insee.eno.ws.legacy.parameters.CaptureEnum;
 import fr.insee.eno.ws.service.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +50,8 @@ public class GenerationStandardController {
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,
             @PathVariable Context context,
             @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter,
-            @RequestParam(defaultValue = "false") boolean questionWrapping)
+            @Parameter(description = "Temporary parameter for question wrapping, may be removed in future versions.")
+            @RequestParam(defaultValue = "true") boolean questionWrapping)
             throws ModeParameterException, DDIToLunaticException, EnoControllerException, IOException {
         //
         if (EnoParameters.ModeParameter.PAPI.equals(modeParameter))
@@ -78,7 +80,8 @@ public class GenerationStandardController {
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,
             @PathVariable Context context,
             @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter,
-            @RequestParam(defaultValue = "false") boolean questionWrapping)
+            @Parameter(description = "Temporary parameter for question wrapping, may be removed in future versions.")
+            @RequestParam(defaultValue = "true") boolean questionWrapping)
             throws ModeParameterException, DDIToLunaticException, EnoControllerException, IOException {
         //
         if (EnoParameters.ModeParameter.PAPI.equals(modeParameter))

--- a/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
+++ b/eno-ws/src/main/java/fr/insee/eno/ws/controller/GenerationStandardController.java
@@ -48,13 +48,15 @@ public class GenerationStandardController {
             @RequestPart(value="in") MultipartFile poguesFile,
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,
             @PathVariable Context context,
-            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter)
+            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter,
+            @RequestParam(defaultValue = "false") boolean questionWrapping)
             throws ModeParameterException, DDIToLunaticException, EnoControllerException, IOException {
         //
         if (EnoParameters.ModeParameter.PAPI.equals(modeParameter))
             throw new ModeParameterException("Lunatic format is not compatible with the mode 'PAPER'.");
         //
         EnoParameters enoParameters = EnoParameters.of(context, modeParameter, Format.LUNATIC);
+        enoParameters.getLunaticParameters().setQuestionWrapping(questionWrapping);
         //
         LunaticPostProcessing lunaticPostProcessing = specificTreatmentsService.generateFrom(specificTreatment);
         //
@@ -75,13 +77,15 @@ public class GenerationStandardController {
             @RequestPart(value="in") MultipartFile ddiFile,
             @RequestPart(value="specificTreatment", required = false) MultipartFile specificTreatment,
             @PathVariable Context context,
-            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter)
+            @PathVariable(name = "mode") EnoParameters.ModeParameter modeParameter,
+            @RequestParam(defaultValue = "false") boolean questionWrapping)
             throws ModeParameterException, DDIToLunaticException, EnoControllerException, IOException {
         //
         if (EnoParameters.ModeParameter.PAPI.equals(modeParameter))
             throw new ModeParameterException("Lunatic format is not compatible with the mode 'PAPER'.");
         //
         EnoParameters enoParameters = EnoParameters.of(context, modeParameter, Format.LUNATIC);
+        enoParameters.getLunaticParameters().setQuestionWrapping(questionWrapping);
         //
         LunaticPostProcessing lunaticPostProcessing = specificTreatmentsService.generateFrom(specificTreatment);
         //


### PR DESCRIPTION
Ajout d'un paramètre **questionWrapping** avec les valeurs : 

- **true [default value]** : génère un lunatic model avec le composant question.
- **false :** génère un lunatic model sans le composant question.

👍 Pour deux endpoints des standard parameters (**/questionnaire/{context}/lunatic-json/{mode}** et /**questionnaire/pogues-2-lunatic/{context}/{mode}**)

💯 _Une description a été ajoutée dans le Swagger à côté du paramètre pour indiquer qu'il est temporaire._
