### PR TITLE
Feat: reperes saisie dates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.43.0-SNAPSHOT.1"
+    version = "3.43.0-SNAPSHOT.2"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.43.0-SNAPSHOT.3"
+    version = "3.43.0-SNAPSHOT.4"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.43.0-SNAPSHOT.2"
+    version = "3.43.0-SNAPSHOT.3"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.43.0-SNAPSHOT.4"
+    version = "3.43.0"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.41.0"
+    version = "3.43.0-SNAPSHOT"
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.43.0-SNAPSHOT"
+    version = "3.43.0-SNAPSHOT.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/model/question/SingleResponseQuestion.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/model/question/SingleResponseQuestion.java
@@ -40,5 +40,5 @@ public abstract class SingleResponseQuestion extends Question {
     @DDI("getResponseDomain()?.getResponseCardinality()?.getMinimumResponses() != null ? " +
             "getResponseDomain().getResponseCardinality().getMinimumResponses().intValue() > 0 : false")
     @Lunatic("!(#this instanceof T(fr.insee.lunatic.model.flat.PairwiseLinks)) ? setMandatory(#param) : null")
-    boolean mandatory;
+    Boolean mandatory;
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -61,6 +61,7 @@ public class LunaticProcessing {
                 .thenIf(enoParameters.getModeParameter().equals(EnoParameters.ModeParameter.CAWI), new LunaticSequenceDescription())
                 .then(new LunaticInputNumberDescription(enoParameters.getLanguage()))
                 .then(new LunaticDurationDescription())
+                .then(new LunaticDateDescription(enoParameters))
                 .thenIf(lunaticParameters.isQuestionWrapping(), new LunaticQuestionComponent())
                 .then(new LunaticRoundaboutLoops(enoQuestionnaire));
     }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/LunaticProcessing.java
@@ -61,7 +61,7 @@ public class LunaticProcessing {
                 .thenIf(enoParameters.getModeParameter().equals(EnoParameters.ModeParameter.CAWI), new LunaticSequenceDescription())
                 .then(new LunaticInputNumberDescription(enoParameters.getLanguage()))
                 .then(new LunaticDurationDescription())
-                .then(new LunaticDateDescription(enoParameters))
+                .then(new LunaticDateDescription(enoParameters.getLanguage()))
                 .thenIf(lunaticParameters.isQuestionWrapping(), new LunaticQuestionComponent())
                 .then(new LunaticRoundaboutLoops(enoQuestionnaire));
     }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -99,9 +99,9 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
     }
 
     private String dateDescriptionValue(String minFormatted, String maxFormatted) {
-        if (minFormatted == null || minFormatted.isEmpty()) return String.format("Avant %s.",maxFormatted);
-        if (maxFormatted == null || maxFormatted.isEmpty()) return String.format("Après %s.",minFormatted);
-        return String.format("Entre %s et %s.", minFormatted, maxFormatted);
+        if (minFormatted == null || minFormatted.isEmpty()) return String.format("Avant %s",maxFormatted);
+        if (maxFormatted == null || maxFormatted.isEmpty()) return String.format("Après %s",minFormatted);
+        return String.format("Entre %s et %s", minFormatted, maxFormatted);
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -96,7 +96,6 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
         return dateDescriptionValue(minFormatted, maxFormatted);
     }
 
-
     private String dateDescriptionValue(String minFormatted, String maxFormatted) {
         if (minFormatted == null || minFormatted.isEmpty()) return String.format("Avant %s.",maxFormatted);
         if (maxFormatted == null || maxFormatted.isEmpty()) return String.format("Après %s.",minFormatted);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -52,18 +52,18 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
     }
 
     private String generateYearMonthDescription(String min, String max) {
-        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_FORMAT);
+        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_FORMAT);
     }
 
     private String generateYearDescription(String min, String max) {
-        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_FORMAT);
+        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_FORMAT);
     }
 
     private String generateYearMonthDayDescription(String min, String max) {
-        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_DAY_FORMAT);
     }
 
-    private String generateDescriptionSafe(String min, String max, EnoParameters.Language lang, String dateFormat) {
+    private String generateDescription(String min, String max, EnoParameters.Language lang, String dateFormat) {
         if ((min == null || min.isEmpty()) && (max == null || max.isEmpty())) {
             return null;
         }
@@ -93,11 +93,11 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
         String minFormatted = (minResult != null) ? minResult.value() : null;
         String maxFormatted = (maxResult != null) ? maxResult.value() : null;
 
-        return generateDateRangeDescription(minFormatted, maxFormatted);
+        return dateDescriptionValue(minFormatted, maxFormatted);
     }
 
 
-    private String generateDateRangeDescription(String minFormatted, String maxFormatted) {
+    private String dateDescriptionValue(String minFormatted, String maxFormatted) {
         if (minFormatted == null || minFormatted.isEmpty()) return String.format("Avant %s.",maxFormatted);
         if (maxFormatted == null || maxFormatted.isEmpty()) return String.format("Après %s.",minFormatted);
         return String.format("Entre %s et %s.", minFormatted, maxFormatted);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -11,10 +11,10 @@ import java.util.List;
 
 public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
 
-    private final EnoParameters enoParameters;
+    private final EnoParameters.Language language;
 
-    public LunaticDateDescription(EnoParameters enoParameters) {
-        this.enoParameters = enoParameters;
+    public LunaticDateDescription(EnoParameters.Language language) {
+        this.language = language;
     }
 
     @Override
@@ -54,15 +54,15 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
     }
 
     private String generateYearMonthDescription(String min, String max) {
-        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_FORMAT);
+        return generateDescription(min, max, language, DateQuestion.YEAR_MONTH_FORMAT);
     }
 
     private String generateYearDescription(String min, String max) {
-        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_FORMAT);
+        return generateDescription(min, max, language, DateQuestion.YEAR_FORMAT);
     }
 
     private String generateYearMonthDayDescription(String min, String max) {
-        return generateDescription(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        return generateDescription(min, max, language, DateQuestion.YEAR_MONTH_DAY_FORMAT);
     }
 
     private String generateDescription(String min, String max, EnoParameters.Language lang, String dateFormat) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -1,0 +1,106 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.exceptions.business.InvalidValueException;
+import fr.insee.eno.core.i18n.date.DateFormatter;
+import fr.insee.eno.core.model.question.DateQuestion;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.processing.ProcessingStep;
+import fr.insee.lunatic.model.flat.*;
+
+import java.util.List;
+
+public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
+
+    private final EnoParameters enoParameters;
+
+    public LunaticDateDescription(EnoParameters enoParameters) {
+        this.enoParameters = enoParameters;
+    }
+
+    @Override
+    public void apply(Questionnaire lunaticQuestionnaire) {
+        generateDateDescription(lunaticQuestionnaire.getComponents());
+        lunaticQuestionnaire.getComponents().stream()
+                .filter(Loop.class::isInstance).map(Loop.class::cast)
+                .map(Loop::getComponents)
+                .forEach(this::generateDateDescription);
+    }
+
+    private void generateDateDescription(List<ComponentType> components) {
+        components.stream()
+                .filter(Datepicker.class::isInstance).map(Datepicker.class::cast)
+                .forEach(this::generateDateDescription);
+    }
+
+    private void generateDateDescription(Datepicker datepicker) {
+        String min = datepicker.getMin();
+        String max = datepicker.getMax();
+        String format = datepicker.getDateFormat();
+
+        String generatedDescription;
+        switch (format) {
+            case DateQuestion.YEAR_MONTH_DAY_FORMAT -> generatedDescription = generateYearMonthDayDescription(min, max);
+            case DateQuestion.YEAR_MONTH_FORMAT -> generatedDescription = generateYearMonthDescription(min, max);
+            case DateQuestion.YEAR_FORMAT -> generatedDescription = generateYearDescription(min, max);
+            default -> throw new InvalidValueException("Date format '" + format + "' is invalid.");
+        }
+
+        LabelType description = new LabelType();
+        description.setValue(generatedDescription);
+        description.setType(LabelTypeEnum.TXT);
+        datepicker.setDescription(description);
+    }
+
+    private String generateYearMonthDescription(String min, String max) {
+        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_FORMAT);
+    }
+
+    private String generateYearDescription(String min, String max) {
+        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_FORMAT);
+    }
+
+    private String generateYearMonthDayDescription(String min, String max) {
+        return generateDescriptionSafe(min, max, enoParameters.getLanguage(), DateQuestion.YEAR_MONTH_DAY_FORMAT);
+    }
+
+    private String generateDescriptionSafe(String min, String max, EnoParameters.Language lang, String dateFormat) {
+        if ((min == null || min.isEmpty()) && (max == null || max.isEmpty())) {
+            return null;
+        }
+
+        DateFormatter formatter = DateFormatter.Factory.forLanguage(lang);
+        DateFormatter.Result minResult = null;
+        DateFormatter.Result maxResult = null;
+
+        if (min != null && !min.isEmpty()) {
+            minResult = switch (dateFormat) {
+                case DateQuestion.YEAR_MONTH_DAY_FORMAT -> formatter.convertYearMontDayDate(min);
+                case DateQuestion.YEAR_MONTH_FORMAT -> formatter.convertYearMontDate(min);
+                case DateQuestion.YEAR_FORMAT -> formatter.convertYearDate(min);
+                default -> throw new IllegalArgumentException("Unhandled format type: " + dateFormat);
+            };
+        }
+
+        if (max != null && !max.isEmpty()) {
+            maxResult = switch (dateFormat) {
+                case DateQuestion.YEAR_MONTH_DAY_FORMAT -> formatter.convertYearMontDayDate(max);
+                case DateQuestion.YEAR_MONTH_FORMAT -> formatter.convertYearMontDate(max);
+                case DateQuestion.YEAR_FORMAT -> formatter.convertYearDate(max);
+                default -> throw new IllegalArgumentException("Unhandled format type: " + dateFormat);
+            };
+        }
+
+        String minFormatted = (minResult != null) ? minResult.value() : null;
+        String maxFormatted = (maxResult != null) ? maxResult.value() : null;
+
+        return generateDateRangeDescription(minFormatted, maxFormatted);
+    }
+
+
+    private String generateDateRangeDescription(String minFormatted, String maxFormatted) {
+        if (minFormatted == null || minFormatted.isEmpty()) return String.format("Avant %s.",maxFormatted);
+        if (maxFormatted == null || maxFormatted.isEmpty()) return String.format("Après %s.",minFormatted);
+        return String.format("Entre %s et %s.", minFormatted, maxFormatted);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescription.java
@@ -45,10 +45,12 @@ public class LunaticDateDescription implements ProcessingStep<Questionnaire> {
             default -> throw new InvalidValueException("Date format '" + format + "' is invalid.");
         }
 
-        LabelType description = new LabelType();
-        description.setValue(generatedDescription);
-        description.setType(LabelTypeEnum.TXT);
-        datepicker.setDescription(description);
+        if (generatedDescription != null) {
+            LabelType description = new LabelType();
+            description.setValue(generatedDescription);
+            description.setType(LabelTypeEnum.TXT);
+            datepicker.setDescription(description);
+        }
     }
 
     private String generateYearMonthDescription(String min, String max) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDurationDescription.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDurationDescription.java
@@ -65,9 +65,9 @@ public class LunaticDurationDescription implements ProcessingStep<Questionnaire>
 
     private static <T extends DurationValue> String durationDescriptionValue(T minValue, T maxValue, DurationControlMessage<T> durationFormatter) {
         if (durationFormatter.isZeroDuration(minValue)) {
-            return String.format("Jusqu'à %s.", durationFormatter.formatDuration(maxValue));
+            return String.format("Jusqu'à %s", durationFormatter.formatDuration(maxValue));
         }
-        return String.format("De %s à %s.", durationFormatter.formatDuration(minValue), durationFormatter.formatDuration(maxValue));
+        return String.format("De %s à %s", durationFormatter.formatDuration(minValue), durationFormatter.formatDuration(maxValue));
     }
 
 }

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/control/LunaticDatepickerControl.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/control/LunaticDatepickerControl.java
@@ -38,10 +38,8 @@ public class LunaticDatepickerControl implements LunaticFormatControl<Datepicker
 
         List<ControlType> controls = new ArrayList<>();
 
-        Optional<ControlType> controlYearFormat = generateDatepickerYearControl(id, format, responseName);
         Optional<ControlType> controlBounds = getFormatControlFromDatepickerAttributes(id, minValue, maxValue, format, responseName);
         controlBounds.ifPresent(controls::addFirst);
-        controlYearFormat.ifPresent(controls::addFirst);
         // Note: it's important that the year format is added in first position, since in some cases only the message
         // of the first control is displayed.
         return controls;
@@ -130,20 +128,6 @@ public class LunaticDatepickerControl implements LunaticFormatControl<Datepicker
         }
 
         return Optional.empty();
-    }
-    private Optional<ControlType> generateDatepickerYearControl(String id, String format, String responseName) {
-        if (format == null || !format.contains("YYYY")) {
-            log.warn("Datepicker '{}' (id={}) format is {} which doesn't have the year (YYYY).",
-                    responseName, id, format);
-            return Optional.empty();
-        }
-        String controlId = id + "-format-year";
-        String expression = String.format("not(not(isnull(%s)) and (" +
-                        "cast(cast(cast(%s, date, \"%s\"), string, \"YYYY\"), integer) <= 999 or " +
-                        "cast(cast(cast(%s, date, \"%s\"), string, \"YYYY\"), integer) > 9999))",
-                responseName, responseName, format, responseName, format);
-        String message = "\"L'année doit être saisie avec 4 chiffres.\"";
-        return Optional.of(LunaticFormatControl.createFormatControl(controlId, expression, message));
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/MandatoryQuestionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/mapping/out/lunatic/MandatoryQuestionTest.java
@@ -6,7 +6,9 @@ import fr.insee.eno.core.mappers.LunaticMapper;
 import fr.insee.eno.core.model.EnoQuestionnaire;
 import fr.insee.eno.core.parameter.EnoParameters;
 import fr.insee.eno.core.processing.out.steps.lunatic.LunaticSortComponents;
+import fr.insee.eno.core.serialize.LunaticSerializer;
 import fr.insee.lunatic.model.flat.ComponentSimpleResponseType;
+import fr.insee.lunatic.model.flat.PairwiseLinks;
 import fr.insee.lunatic.model.flat.Questionnaire;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +32,23 @@ class MandatoryQuestionTest {
         // Then
         assertFalse(((ComponentSimpleResponseType) lunaticQuestionnaire.getComponents().get(1)).getMandatory());
         assertTrue(((ComponentSimpleResponseType) lunaticQuestionnaire.getComponents().get(2)).getMandatory());
+    }
+
+    @Test
+    void integrationTestFromPoguesDDIWithPairwiseWithNullMandatory() throws ParsingException {
+        // Given + When
+        ClassLoader classLoader = this.getClass().getClassLoader();
+        EnoQuestionnaire enoQuestionnaire = PoguesDDIToEno.fromInputStreams(
+                        classLoader.getResourceAsStream("integration/pogues/pogues-pairwise.json"),
+                        classLoader.getResourceAsStream("integration/ddi/ddi-pairwise.xml"))
+                .transform(EnoParameters.of(
+                        EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI));
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        new LunaticMapper().mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+        new LunaticSortComponents(enoQuestionnaire).apply(lunaticQuestionnaire); // (sort so that we can get components by index)
+
+        assertFalse(((ComponentSimpleResponseType)
+                ((PairwiseLinks) lunaticQuestionnaire.getComponents().get(3)).getComponents().getFirst()).getMandatory());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticAddControlFormatTest.java
@@ -158,30 +158,6 @@ class LunaticAddControlFormatTest {
     }
 
     @Test
-    @DisplayName("Datepicker: year format control only")
-    void datepickerYearFormatControl() {
-        lunaticQuestionnaire = new Questionnaire();
-        lunaticQuestionnaire.getComponents().add(datePicker);
-        datePicker.setDateFormat("YYYY-MM-DD");
-
-        processing.apply(lunaticQuestionnaire);
-
-        List<ControlType> controls = datePicker.getControls();
-        assertEquals(1, controls.size());
-        ControlType yearControl = controls.getFirst();
-
-        assertEquals("datepicker-id-format-year", yearControl.getId());
-        String expected = "not(not(isnull(DATE_VAR)) and (" +
-                "cast(cast(cast(DATE_VAR, date, \"YYYY-MM-DD\"), string, \"YYYY\"), integer) <= 999 or " +
-                "cast(cast(cast(DATE_VAR, date, \"YYYY-MM-DD\"), string, \"YYYY\"), integer) > 9999))";
-        assertEquals(expected, yearControl.getControl().getValue());
-        assertEquals(LabelTypeEnum.VTL, yearControl.getControl().getType());
-        assertEquals(LabelTypeEnum.VTL_MD, yearControl.getErrorMessage().getType());
-        assertEquals(ControlTypeEnum.FORMAT, yearControl.getTypeOfControl());
-        assertEquals(ControlCriticalityEnum.ERROR, yearControl.getCriticality());
-    }
-
-    @Test
     @DisplayName("Datepicker: min and max format control")
     void datepickerMinMaxFormatControl() {
         lunaticQuestionnaire = new Questionnaire();
@@ -192,8 +168,8 @@ class LunaticAddControlFormatTest {
         processing.apply(lunaticQuestionnaire);
 
         List<ControlType> controls = datePicker.getControls();
-        assertEquals(2, controls.size());
-        ControlType control = controls.get(1);
+        assertEquals(1, controls.size());
+        ControlType control = controls.getFirst();
 
         assertEquals("datepicker-id-format-date-borne-inf-sup", control.getId());
         String expected = "not(not(isnull(DATE_VAR)) and " +
@@ -217,9 +193,7 @@ class LunaticAddControlFormatTest {
         datePicker.setDateFormat("YYYY-MM-DD");
         processing.apply(lunaticQuestionnaire);
 
-        // Only year format control should be present
-        assertEquals(1, datePicker.getControls().size());
-        assertNotEquals("datepicker-id-format-date-borne-sup", datePicker.getControls().getFirst().getId());
+        assertEquals(0, datePicker.getControls().size());
     }
 
     @Test
@@ -232,8 +206,8 @@ class LunaticAddControlFormatTest {
         processing.apply(lunaticQuestionnaire);
 
         List<ControlType> controls = datePicker.getControls();
-        assertEquals(2, controls.size());
-        ControlType control = controls.get(1);
+        assertEquals(1, controls.size());
+        ControlType control = controls.getFirst();
 
         assertEquals("datepicker-id-format-date-borne-inf", control.getId());
         String expected = "not(not(isnull(DATE_VAR)) and " +
@@ -268,8 +242,8 @@ class LunaticAddControlFormatTest {
         processing.apply(lunaticQuestionnaire);
 
         List<ControlType> controls = datePicker.getControls();
-        assertEquals(2, controls.size());
-        ControlType boundsControl = controls.get(1);
+        assertEquals(1, controls.size());
+        ControlType boundsControl = controls.getFirst();
 
         assertEquals("datepicker-id-format-date-borne-sup", boundsControl.getId());
         String expected = "not(not(isnull(DATE_VAR)) " +
@@ -293,11 +267,9 @@ class LunaticAddControlFormatTest {
         processing.apply(lunaticQuestionnaire);
 
         List<ControlType> controls = datePicker.getControls();
-        assertEquals(2, controls.size());
-        ControlType yearControl = controls.get(0);
-        ControlType boundsControl = controls.get(1);
+        assertEquals(1, controls.size());
+        ControlType boundsControl = controls.getFirst();
         // Only testing ids here to check that the order is right, content is tested in other tests
-        assertEquals("datepicker-id-format-year", yearControl.getId());
         assertEquals("datepicker-id-format-date-borne-sup", boundsControl.getId());
     }
 
@@ -317,7 +289,7 @@ class LunaticAddControlFormatTest {
 
         processing.apply(lunaticQuestionnaire);
 
-        assertEquals(2, datePicker.getControls().size());
+        assertEquals(1, datePicker.getControls().size());
         assertEquals(2, number.getControls().size());
     }
 

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
@@ -1,0 +1,171 @@
+package fr.insee.eno.core.processing.out.steps.lunatic;
+
+import fr.insee.eno.core.PoguesToEno;
+import fr.insee.eno.core.exceptions.business.ParsingException;
+import fr.insee.eno.core.mappers.LunaticMapper;
+import fr.insee.eno.core.model.EnoQuestionnaire;
+import fr.insee.eno.core.model.question.DateQuestion;
+import fr.insee.eno.core.parameter.EnoParameters;
+import fr.insee.eno.core.processing.out.steps.lunatic.table.LunaticTableProcessing;
+import fr.insee.lunatic.model.flat.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LunaticDateDescriptionTest {
+
+    @Test
+    void minAndMaxYearMonthDay() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        datepicker.setMin("2021-12-02");
+        datepicker.setMax("2025-06-04");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Entre 02/12/2021 et 04/06/2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void minAndNoMaxYearMonthDay() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        datepicker.setMin("2021-12-02");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Après 02/12/2021.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void maxAndNoMinYearMonthDay() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        datepicker.setMax("2025-06-04");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Avant 04/06/2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void noMinAndNoMaxYearMonthDay() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_DAY_FORMAT);
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertNull(description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void minAndMaxYearMonth() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_FORMAT);
+        datepicker.setMin("2021-12");
+        datepicker.setMax("2025-06");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Entre 12/2021 et 06/2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void minAndMaxYear() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_FORMAT);
+        datepicker.setMin("2021");
+        datepicker.setMax("2025");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Entre 2021 et 2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void integrationTest() throws ParsingException {
+        // Given
+        EnoQuestionnaire enoQuestionnaire = PoguesToEno.fromInputStream(
+                        this.getClass().getClassLoader().getResourceAsStream("integration/pogues/pogues-dates-2.json"))
+                .transform(EnoParameters.of(EnoParameters.Context.DEFAULT, EnoParameters.ModeParameter.CAWI));
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        new LunaticMapper().mapQuestionnaire(enoQuestionnaire, lunaticQuestionnaire);
+        new LunaticSortComponents(enoQuestionnaire).apply(lunaticQuestionnaire);
+        new LunaticTableProcessing(enoQuestionnaire).apply(lunaticQuestionnaire);
+
+        // When
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        new LunaticDateDescription(enoParameters).apply(lunaticQuestionnaire);
+
+        // Then
+        Datepicker date0 = (Datepicker) lunaticQuestionnaire.getComponents().get(3);
+        Datepicker date1 = (Datepicker) lunaticQuestionnaire.getComponents().get(4);
+        Datepicker date2 = (Datepicker) lunaticQuestionnaire.getComponents().get(5);
+        assertEquals("Entre 01/01/1950 et 01/01/2050.",
+                date0.getDescription().getValue());
+        assertEquals("Entre 01/1950 et 01/2050.",
+                date1.getDescription().getValue());
+        assertEquals("Entre 1950 et 2050.",
+                date2.getDescription().getValue());
+        assertEquals(LabelTypeEnum.TXT, date0.getDescription().getType());
+        assertEquals(LabelTypeEnum.TXT, date1.getDescription().getType());
+        assertEquals(LabelTypeEnum.TXT, date2.getDescription().getType());
+    }
+
+}

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
@@ -90,9 +90,7 @@ class LunaticDateDescriptionTest {
         LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
         processing.apply(lunaticQuestionnaire);
         //
-        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertNull(description.getValue());
-        assertEquals(LabelTypeEnum.TXT, description.getType());
+        assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
     }
 
     @Test
@@ -170,9 +168,7 @@ class LunaticDateDescriptionTest {
         LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
         processing.apply(lunaticQuestionnaire);
         //
-        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertNull(description.getValue());
-        assertEquals(LabelTypeEnum.TXT, description.getType());
+        assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
     }
 
     @Test
@@ -250,9 +246,7 @@ class LunaticDateDescriptionTest {
         LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
         processing.apply(lunaticQuestionnaire);
         //
-        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertNull(description.getValue());
-        assertEquals(LabelTypeEnum.TXT, description.getType());
+        assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
     }
 
     @Test
@@ -277,7 +271,7 @@ class LunaticDateDescriptionTest {
         Datepicker date2 = (Datepicker) lunaticQuestionnaire.getComponents().get(7);
         Datepicker date3 = (Datepicker) lunaticQuestionnaire.getComponents().get(8);
         Datepicker date4 = (Datepicker) lunaticQuestionnaire.getComponents().get(13);
-        assertNull(date0.getDescription().getValue());
+        assertNull(date0.getDescription());
         assertEquals("Après 01/01/1950.",
                 date1.getDescription().getValue());
         assertEquals("Avant 01/01/2050.",
@@ -286,7 +280,6 @@ class LunaticDateDescriptionTest {
                 date3.getDescription().getValue());
         assertEquals("Entre 01/01/1950 et 01/01/2050.",
                 date4.getDescription().getValue());
-        assertEquals(LabelTypeEnum.TXT, date0.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date1.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date2.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date3.getDescription().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
@@ -117,6 +117,65 @@ class LunaticDateDescriptionTest {
     }
 
     @Test
+    void minAndNoMaxYearMonth() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_FORMAT);
+        datepicker.setMin("2021-12");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Après 12/2021.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void maxAndNoMinYearMonth() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_FORMAT);
+        datepicker.setMax("2025-06");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Avant 06/2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void noMinAndNoMaxYearMonth() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_MONTH_FORMAT);
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertNull(description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
     void minAndMaxYear() {
         //
         Questionnaire lunaticQuestionnaire = new Questionnaire();
@@ -138,6 +197,65 @@ class LunaticDateDescriptionTest {
     }
 
     @Test
+    void minAndNoMaxYear() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_FORMAT);
+        datepicker.setMin("2021");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Après 2021.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void maxAndNoMinYear() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_FORMAT);
+        datepicker.setMax("2025");
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertEquals("Avant 2025.", description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
+    void noMinAndNoMaxYear() {
+        //
+        Questionnaire lunaticQuestionnaire = new Questionnaire();
+        Datepicker datepicker = new Datepicker();
+        datepicker.setDateFormat(DateQuestion.YEAR_FORMAT);
+        lunaticQuestionnaire.getComponents().add(datepicker);
+        //
+        EnoParameters enoParameters = EnoParameters.emptyValues();
+        enoParameters.setLanguage(EnoParameters.Language.FR);
+        //
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        processing.apply(lunaticQuestionnaire);
+        //
+        LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
+        assertNull(description.getValue());
+        assertEquals(LabelTypeEnum.TXT, description.getType());
+    }
+
+    @Test
     void integrationTest() throws ParsingException {
         // Given
         EnoQuestionnaire enoQuestionnaire = PoguesToEno.fromInputStream(
@@ -155,17 +273,24 @@ class LunaticDateDescriptionTest {
 
         // Then
         Datepicker date0 = (Datepicker) lunaticQuestionnaire.getComponents().get(3);
-        Datepicker date1 = (Datepicker) lunaticQuestionnaire.getComponents().get(4);
-        Datepicker date2 = (Datepicker) lunaticQuestionnaire.getComponents().get(5);
-        assertEquals("Entre 01/01/1950 et 01/01/2050.",
-                date0.getDescription().getValue());
-        assertEquals("Entre 01/1950 et 01/2050.",
+        Datepicker date1 = (Datepicker) lunaticQuestionnaire.getComponents().get(6);
+        Datepicker date2 = (Datepicker) lunaticQuestionnaire.getComponents().get(7);
+        Datepicker date3 = (Datepicker) lunaticQuestionnaire.getComponents().get(8);
+        Datepicker date4 = (Datepicker) lunaticQuestionnaire.getComponents().get(13);
+        assertNull(date0.getDescription().getValue());
+        assertEquals("Après 01/01/1950.",
                 date1.getDescription().getValue());
-        assertEquals("Entre 1950 et 2050.",
+        assertEquals("Avant 01/01/2050.",
                 date2.getDescription().getValue());
+        assertEquals("Après 01/1950.",
+                date3.getDescription().getValue());
+        assertEquals("Entre 01/01/1950 et 01/01/2050.",
+                date4.getDescription().getValue());
         assertEquals(LabelTypeEnum.TXT, date0.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date1.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date2.getDescription().getType());
+        assertEquals(LabelTypeEnum.TXT, date3.getDescription().getType());
+        assertEquals(LabelTypeEnum.TXT, date4.getDescription().getType());
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
@@ -28,7 +28,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -48,7 +48,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -68,7 +68,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -87,7 +87,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
@@ -106,7 +106,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -126,7 +126,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -146,7 +146,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -165,7 +165,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
@@ -184,7 +184,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -204,7 +204,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -224,7 +224,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
@@ -243,7 +243,7 @@ class LunaticDateDescriptionTest {
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
         //
-        LunaticDateDescription processing = new LunaticDateDescription(enoParameters);
+        LunaticDateDescription processing = new LunaticDateDescription(enoParameters.getLanguage());
         processing.apply(lunaticQuestionnaire);
         //
         assertNull(lunaticQuestionnaire.getComponents().getFirst().getDescription());
@@ -263,7 +263,7 @@ class LunaticDateDescriptionTest {
         // When
         EnoParameters enoParameters = EnoParameters.emptyValues();
         enoParameters.setLanguage(EnoParameters.Language.FR);
-        new LunaticDateDescription(enoParameters).apply(lunaticQuestionnaire);
+        new LunaticDateDescription(enoParameters.getLanguage()).apply(lunaticQuestionnaire);
 
         // Then
         Datepicker date0 = (Datepicker) lunaticQuestionnaire.getComponents().get(3);

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDateDescriptionTest.java
@@ -32,7 +32,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Entre 02/12/2021 et 04/06/2025.", description.getValue());
+        assertEquals("Entre 02/12/2021 et 04/06/2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -52,7 +52,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Après 02/12/2021.", description.getValue());
+        assertEquals("Après 02/12/2021", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -72,7 +72,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Avant 04/06/2025.", description.getValue());
+        assertEquals("Avant 04/06/2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -110,7 +110,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Entre 12/2021 et 06/2025.", description.getValue());
+        assertEquals("Entre 12/2021 et 06/2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -130,7 +130,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Après 12/2021.", description.getValue());
+        assertEquals("Après 12/2021", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -150,7 +150,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Avant 06/2025.", description.getValue());
+        assertEquals("Avant 06/2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -188,7 +188,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Entre 2021 et 2025.", description.getValue());
+        assertEquals("Entre 2021 et 2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -208,7 +208,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Après 2021.", description.getValue());
+        assertEquals("Après 2021", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -228,7 +228,7 @@ class LunaticDateDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Avant 2025.", description.getValue());
+        assertEquals("Avant 2025", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -272,13 +272,13 @@ class LunaticDateDescriptionTest {
         Datepicker date3 = (Datepicker) lunaticQuestionnaire.getComponents().get(8);
         Datepicker date4 = (Datepicker) lunaticQuestionnaire.getComponents().get(13);
         assertNull(date0.getDescription());
-        assertEquals("Après 01/01/1950.",
+        assertEquals("Après 01/01/1950",
                 date1.getDescription().getValue());
-        assertEquals("Avant 01/01/2050.",
+        assertEquals("Avant 01/01/2050",
                 date2.getDescription().getValue());
-        assertEquals("Après 01/1950.",
+        assertEquals("Après 01/1950",
                 date3.getDescription().getValue());
-        assertEquals("Entre 01/01/1950 et 01/01/2050.",
+        assertEquals("Entre 01/01/1950 et 01/01/2050",
                 date4.getDescription().getValue());
         assertEquals(LabelTypeEnum.TXT, date1.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, date2.getDescription().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDurationDescriptionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticDurationDescriptionTest.java
@@ -27,7 +27,7 @@ class LunaticDurationDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("De 1 an et 3 mois à 3 ans et 4 mois.", description.getValue());
+        assertEquals("De 1 an et 3 mois à 3 ans et 4 mois", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -45,7 +45,7 @@ class LunaticDurationDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("De 3 minutes à 5 heures et 4 minutes.", description.getValue());
+        assertEquals("De 3 minutes à 5 heures et 4 minutes", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -63,7 +63,7 @@ class LunaticDurationDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Jusqu'à 3 ans et 4 mois.", description.getValue());
+        assertEquals("Jusqu'à 3 ans et 4 mois", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -81,7 +81,7 @@ class LunaticDurationDescriptionTest {
         processing.apply(lunaticQuestionnaire);
         //
         LabelType description = lunaticQuestionnaire.getComponents().getFirst().getDescription();
-        assertEquals("Jusqu'à 1 heure et 1 minute.", description.getValue());
+        assertEquals("Jusqu'à 1 heure et 1 minute", description.getValue());
         assertEquals(LabelTypeEnum.TXT, description.getType());
     }
 
@@ -102,9 +102,9 @@ class LunaticDurationDescriptionTest {
         // Then
         Duration duration0 = (Duration) lunaticQuestionnaire.getComponents().get(1);
         Duration duration1 = (Duration) lunaticQuestionnaire.getComponents().get(2);
-        assertEquals("Jusqu'à 2 ans et 6 mois.",
+        assertEquals("Jusqu'à 2 ans et 6 mois",
                 duration0.getDescription().getValue());
-        assertEquals("Jusqu'à 1 heure et 30 minutes.",
+        assertEquals("Jusqu'à 1 heure et 30 minutes",
                 duration1.getDescription().getValue());
         assertEquals(LabelTypeEnum.TXT, duration0.getDescription().getType());
         assertEquals(LabelTypeEnum.TXT, duration1.getDescription().getType());

--- a/eno-core/src/test/resources/integration/pogues/pogues-pairwise.json
+++ b/eno-core/src/test/resources/integration/pogues/pogues-pairwise.json
@@ -195,7 +195,6 @@
             {
               "CollectedVariableReference": "lo9u3tv1",
               "id": "lo9uemwq",
-              "mandatory": false,
               "CodeListReference": "lo9tv7s6",
               "Datatype": {
                 "Pattern": "",


### PR DESCRIPTION
1) Implémentation de la logique pour afficher des repères visuels au niveau des dates (aide à la saisie des dates) : indications min/max. 

**4 cas :** 

- **Si min et max :** on affiche **"Entre min et max."**
- **Si min et pas de max :** on affiche **"Après min."**
- **Si max et pas de min :** on affiche **"Avant max."**
- **Si pas de min et pas de max :** on n'affiche rien.

2) Suppression des contrôles sur les années pour les dates.

+ Ajout/suppression de tests.
