### PR TITLE
Fix: iterations for standaloneloops

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.47.0"
+    version = "3.48.1-SNAPSHOT"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
@@ -180,6 +180,7 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
                 enoLinkedLoop.getId(), reference));
     }
 
+    /** Lunatic Standalone loops now have an "iterations" property. */
     private void setStandaloneLoopIterations(Loop lunaticLoop, StandaloneLoop enoStandaloneLoop) {
         String variableName = findFirstResponseNameOfLoop(
                 enoStandaloneLoop,

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -92,11 +92,11 @@ class LunaticLoopResolutionTest {
 
         // Then
         assertEquals(1, lunaticQuestionnaire.getComponents().size());
-        assertInstanceOf(Loop.class, lunaticQuestionnaire.getComponents().get(0));
-        assertEquals(LOOP_ID, lunaticQuestionnaire.getComponents().get(0).getId());
-        assertEquals(2, ((Loop) lunaticQuestionnaire.getComponents().get(0)).getComponents().size());
-        assertEquals(SEQUENCE_ID, ((Loop) lunaticQuestionnaire.getComponents().get(0)).getComponents().get(0).getId());
-        assertInstanceOf(Input.class, ((Loop) lunaticQuestionnaire.getComponents().get(0)).getComponents().get(1));
+        assertInstanceOf(Loop.class, lunaticQuestionnaire.getComponents().getFirst());
+        assertEquals(LOOP_ID, lunaticQuestionnaire.getComponents().getFirst().getId());
+        assertEquals(2, ((Loop) lunaticQuestionnaire.getComponents().getFirst()).getComponents().size());
+        assertEquals(SEQUENCE_ID, ((Loop) lunaticQuestionnaire.getComponents().getFirst()).getComponents().getFirst().getId());
+        assertInstanceOf(Input.class, ((Loop) lunaticQuestionnaire.getComponents().getFirst()).getComponents().get(1));
     }
 
     @Nested


### PR DESCRIPTION
- Ajout des **itérations** dans les boucles **"standalone"**.
- Modifications des tests en conséquence car de nouvelles **loopdependencies** sont de ce fait apparues.
- Petite Javadoc.

**PS :** désolé pour le nom de la branche je pensais qu'il y avait du resizing au début.