### PR TITLE
ci: semantic versioning

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ on:
 # the workflow will publish a release.
 
 # This workflow is triggered when changes are pushed on the main branch.
-# It checks that the version is valid, and has not already been release.
+# It checks that the version is valid, and has not already been released.
 # From the new version, if creates a tag, a GitHub release, a changelog 
 # (also based on conventional commits), and publishes an image on Docker Hub.
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,18 +12,13 @@ on:
       - 'Dockerfile'
 
 # TL;DR: Do conventional commits,
-# don't touch the version number, 
-# enjoy.
+# bump the version before pushing on main, 
+# the workflow will publish a release.
 
 # This workflow is triggered when changes are pushed on the main branch.
-# It computes the version number based on conventional commits, 
-# if the version has not been changed since last tag/release.
+# It checks that the version is valid, and has not already been release.
 # From the new version, if creates a tag, a GitHub release, a changelog 
 # (also based on conventional commits), and publishes an image on Docker Hub.
-
-# If you didn't do conventional commits or you want to set the version number manually, 
-# you can change the version and push it on the main branch. 
-# This version will be used to publish a release and deploy an image on Docker Hub.
 
 env:
   JAVA_VERSION: '21'
@@ -31,10 +26,11 @@ env:
 
 jobs:
 
-  check-version:
+  version:
     runs-on: ubuntu-latest
     outputs:
       release-version: ${{ steps.version-number.outputs.value }}
+      previous-version: ${{ steps.previousTag.outputs.previousTag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,38 +68,41 @@ jobs:
           echo "Was the version changed? $yesOrNo"
           echo "hasVersionChanged=$yesOrNo" >> $GITHUB_OUTPUT
 
-      - name: (Manual version) Check tag existence
-        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'yes' }}
+      - name: (Semantic version) Calculate release version
+        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'no' }}
+        id: compute-version
+        #uses: TODO: find an action that does the job
+        run: |
+          echo "Semantic version is not implemented yet ❌️"
+          echo "Bump the version to trigger the release workflow."
+          exit 1
+
+      - name: Release version number
+        id: version-number
+        run: |
+          versionNumber=${{ steps.compute-version.outputs.value }} # update this when semantic version is done
+          if [[ ${{steps.compare-step.outputs.hasVersionChanged}} == "yes" ]]; then
+            versionNumber=${{ steps.version-step.outputs.version }}
+          echo "Version to be released: $versionNumber"
+          echo "value=$versionNumber" >> $GITHUB_OUTPUT
+
+      - name: Check tag existence
         id: check-tag-exists
         uses: mukunku/tag-exists-action@v1.6.0
         with:
           tag: ${{ steps.version-step.outputs.version }}
 
-      - name: (Manual version) Tag verification
-        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'yes' }}
+      - name: Tag verification
         run: |
-          if [[ "${{ steps.check-tag-exists.outputs.exists }}" == "true" ]]; then
-            echo "Version ${{ steps.version-step.outputs.version }} cannot be released, tag already exists"
+          if [[ "${{ steps.version-number.outputs.value }}" == "true" ]]; then
+            echo "Version ${{ steps.version-number.outputs.value }} cannot be released, tag already exists"
             exit 1
           fi
 
-          if ! [[ "${{ steps.version-step.outputs.version }}" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "The version ${{ steps.version-step.outputs.version }} is not in correct release format X.Y.Z"
+          if ! [[ "${{ steps.version-number.outputs.value }}" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            echo "The version ${{ steps.version-number.outputs.value }} is not in correct release format X.Y.Z"
             exit 1
           fi
-
-      - name: (Semantic version) Calculate release version
-        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'no' }}
-        id: compute-version
-        uses: foo
-       
-      - name: Output release version number
-        id: version-number
-        run: |
-          versionNumber=${{ steps.compute-version.outputs.value }} # TODO
-          if [[ ${{steps.compare-step.outputs.hasVersionChanged}} == "yes" ]]; then
-            versionNumber=${{ steps.version-step.outputs.version }}
-          echo "value=$versionNumber" >> $GITHUB_OUTPUT
 
   sonar:
     name: Sonar analysis
@@ -144,7 +143,7 @@ jobs:
         run: ./gradlew clean build sonar -Dsonar.projectKey=InseeFr_Eno -Dsonar.organization=inseefr
 
   build-sources:
-    needs: sonar
+    needs: [ version, sonar ]
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK
@@ -169,12 +168,10 @@ jobs:
           path: ./eno-ws/build/libs/eno-ws.jar
 
   create-release:
-    needs: [ check-version, build-sources ]
+    needs: [ version, build-sources ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      previous-release-tag: ${{ steps.previousTag.outputs.previousTag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,22 +179,17 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get previous final release tag
-        id: previousTag
-        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[3-9]\.[0-9]\+\.[0-9]\+$" | tail -1)" >> $GITHUB_OUTPUT
-        # Note: the regex works for single digit major version, to be updated if the version goes 10.0.0 or more
-
       - name: Create tag
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ needs.check-version.outputs.release-version }}
+          tag: ${{ needs.version.outputs.release-version }}
 
       - name: Create release note
         id: changelog
         uses: requarks/changelog-action@v1
         with:
-          fromTag: ${{ needs.check-version.outputs.release-version }}
-          toTag: ${{ steps.previousTag.outputs.previousTag}}
+          fromTag: ${{ needs.version.outputs.release-version }}
+          toTag: ${{ needs.version.outputs.previous-version }}
           excludeTypes: ${{ env.RELEASE_NOTE_EXCLUDED_TYPES }}
           token: ${{ secrets.GITHUB_TOKEN }}
           writeToFile: false
@@ -212,9 +204,9 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.check-version.outputs.release-version }}
+          tag_name: ${{ needs.version.outputs.release-version }}
           target_commitish: ${{ github.head_ref || github.ref }}
-          name: ${{ needs.check-version.outputs.release-version }}
+          name: ${{ needs.version.outputs.release-version }}
           body: ${{ steps.changelog.outputs.changes }}
           files: eno-ws/build/libs/eno-ws.jar
         env:
@@ -222,7 +214,7 @@ jobs:
 
   # Separate job for committing in the changelog file since I got bored that auto commit action randomly fails
   commit-changelog:
-    needs: [ check-version, create-release ]
+    needs: [ version, create-release ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -237,8 +229,8 @@ jobs:
         id: changelog
         uses: requarks/changelog-action@v1
         with:
-          fromTag: ${{ needs.check-version.outputs.release-version }}
-          toTag: ${{ needs.create-release.outputs.previous-release-tag }}
+          fromTag: ${{ needs.version.outputs.release-version }}
+          toTag: ${{ needs.version.outputs.previous-version }}
           excludeTypes: ${{ env.RELEASE_NOTE_EXCLUDED_TYPES }}
           token: ${{ secrets.GITHUB_TOKEN }}
           writeToFile: true
@@ -248,11 +240,11 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: 'v3-main'
-          commit_message: 'docs(changelog): ${{ needs.check-version.outputs.release-version }} update [skip ci]'
+          commit_message: 'docs(changelog): ${{ needs.version.outputs.release-version }} update [skip ci]'
           file_pattern: 'CHANGELOG.md'
 
   publish-docker:
-    needs: [ check-version, build-sources ]
+    needs: [ version, build-sources ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -270,4 +262,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           default_branch: ${{ github.ref }}
-          tags: "latest,${{ needs.check-version.outputs.release-version }}"
+          tags: "latest,${{ needs.version.outputs.release-version }}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,6 +11,20 @@ on:
       - 'README**.md'
       - 'Dockerfile'
 
+# TL;DR: Do conventional commits,
+# don't touch the version number, 
+# enjoy.
+
+# This workflow is triggered when changes are pushed on the main branch.
+# It computes the version number based on conventional commits, 
+# if the version has not been changed since last tag/release.
+# From the new version, if creates a tag, a GitHub release, a changelog 
+# (also based on conventional commits), and publishes an image on Docker Hub.
+
+# If you didn't do conventional commits and you want to set the version number manually, 
+# you can change the version and push it on the main branch.concurrency. 
+# This version will be used to publish a release and deploy an image on Docker Hub.
+
 env:
   RELEASE_NOTE_EXCLUDED_TYPES: docs,style,chore,other
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,11 +21,12 @@ on:
 # From the new version, if creates a tag, a GitHub release, a changelog 
 # (also based on conventional commits), and publishes an image on Docker Hub.
 
-# If you didn't do conventional commits and you want to set the version number manually, 
-# you can change the version and push it on the main branch.concurrency. 
+# If you didn't do conventional commits or you want to set the version number manually, 
+# you can change the version and push it on the main branch. 
 # This version will be used to publish a release and deploy an image on Docker Hub.
 
 env:
+  JAVA_VERSION: '21'
   RELEASE_NOTE_EXCLUDED_TYPES: docs,style,chore,other
 
 jobs:
@@ -33,16 +34,15 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     outputs:
-      release-version: ${{ steps.version-step.outputs.version }}
+      release-version: ${{ steps.version-number.outputs.value }}
     steps:
-      - name: Set up JDK 21
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
-
-      - name: Checkout Eno repo
-        uses: actions/checkout@v4
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -53,36 +53,66 @@ jobs:
           ./gradlew # (load the gradle wrapper, required for the get version step)
           echo "version=$(./gradlew printVersion --console=plain -q)" >> $GITHUB_OUTPUT
 
-      - name: Print Eno Version
-        run: echo ${{ steps.version-step.outputs.version }}
+      - name: Get previous final release tag
+        id: previousTag
+        run: echo "previousTag=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | grep "^[3-9]\.[0-9]\+\.[0-9]\+$" | tail -1)" >> $GITHUB_OUTPUT
+        # Note: the regex works for single digit major version, to be updated if the version goes 10.0.0 or more
 
-      - uses: mukunku/tag-exists-action@v1.6.0
-        name: Check tag existence
+      - name: Compare version to previous release tag
+        id: compare-step
+        run: |
+          echo ""
+          echo "Eno version:  ${{ steps.version-step.outputs.version }}"
+          echo "Previous tag: ${{ steps.previousTag.outputs.previousTag }}"
+
+          yesOrNo="no"
+          if [[ ${{steps.version-step.outputs.version != steps.previousTag.outputs.previousTag}} ]]; then
+            yesOrNo="yes"
+          fi
+          echo "Was the version changed? $yesOrNo"
+          echo "hasVersionChanged=$yesOrNo" >> $GITHUB_OUTPUT
+
+      - name: (Manual version) Check tag existence
+        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'yes' }}
         id: check-tag-exists
+        uses: mukunku/tag-exists-action@v1.6.0
         with:
           tag: ${{ steps.version-step.outputs.version }}
 
-      - name: Tag verification
-        id: check-tag
+      - name: (Manual version) Tag verification
+        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'yes' }}
         run: |
           if [[ "${{ steps.check-tag-exists.outputs.exists }}" == "true" ]]; then
-            echo "Nothing to tag/release, the tag ${{ steps.version-step.outputs.version }} already exists"
+            echo "Version ${{ steps.version-step.outputs.version }} cannot be released, tag already exists"
             exit 1
           fi
 
           if ! [[ "${{ steps.version-step.outputs.version }}" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "Nothing to tag/release, the tag ${{ steps.version-step.outputs.version }} is not in correct format X.Y.Z"
+            echo "The version ${{ steps.version-step.outputs.version }} is not in correct release format X.Y.Z"
             exit 1
           fi
+
+      - name: (Semantic version) Calculate release version
+        if: ${{ steps.compare-step.outputs.hasVersionChanged == 'no' }}
+        id: compute-version
+        uses: foo
+       
+      - name: Output release version number
+        id: version-number
+        run: |
+          versionNumber=${{ steps.compute-version.outputs.value }} # TODO
+          if [[ ${{steps.compare-step.outputs.hasVersionChanged}} == "yes" ]]; then
+            versionNumber=${{ steps.version-step.outputs.version }}
+          echo "value=$versionNumber" >> $GITHUB_OUTPUT
 
   sonar:
     name: Sonar analysis
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
       - uses: actions/checkout@v4
@@ -117,11 +147,11 @@ jobs:
     needs: sonar
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check version
         run: |
-          echo ""
+          echo "Versions must be equal"
           echo "Main branch version:    ${{ steps.main-version.outputs.version }}"
           echo "Current branch version: ${{ steps.branch-version.outputs.version }}"
 
@@ -96,26 +96,26 @@ jobs:
       - name: Image tag is ${{ needs.check-version.outputs.image-tag }}
         run: echo "${{ needs.check-version.outputs.image-tag }}"
 
-#      - name: Set up JDK
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: 'temurin'
-#          java-version: ${{ env.JAVA_VERSION }}
-#
-#      - name: Setup Gradle
-#        uses: gradle/actions/setup-gradle@v3
-#
-#      - name: Build Eno modules
-#        run: ./gradlew build
-#
-#      - name: Publish to Docker Hub
-#        uses: elgohr/Publish-Docker-Github-Action@v5
-#        with:
-#          name: inseefr/eno-ws
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#          default_branch: ${{ github.ref }}
-#          tags: ${{ needs.check-version.outputs.image-tag }}
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build Eno modules
+        run: ./gradlew build
+
+      - name: Publish to Docker Hub
+        uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: inseefr/eno-ws
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          default_branch: ${{ github.ref }}
+          tags: ${{ needs.check-version.outputs.image-tag }}
 
   write-comment:
     needs: [ check-version, publish-docker ]

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -70,10 +70,11 @@ jobs:
 
       - name: Check version
         run: |
+          echo ""
           echo "Main branch version:    ${{ steps.main-version.outputs.version }}"
           echo "Current branch version: ${{ steps.branch-version.outputs.version }}"
 
-          if [[ ${{ steps.main-version.outputs.exists }} != ${{ steps.branch-version.outputs.version }} ]]; then
+          if [[ "${{ steps.main-version.outputs.exists }}" != "${{ steps.branch-version.outputs.version }}" ]]; then
             echo "Current version does not match the main branch version."
             echo "Update your code to align with the '${{ github.event.repository.default_branch }}' branch."
             exit 1

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -9,7 +9,6 @@ on:
       - 'CHANGELOG.md'
       - 'README**.md'
       - 'Dockerfile'
-      - '.github/**'
 
 # TL;DR: Don't touch the version number, 
 # put the 'deploy-snapshot' label on a GitHub PR,

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -73,9 +73,9 @@ jobs:
           echo "Main branch version:    ${{ steps.main-version.outputs.version }}"
           echo "Current branch version: ${{ steps.branch-version.outputs.version }}"
 
-          if [[ "${{ steps.main-version.outputs.exists }}" != "true" ]]; then
+          if [[ ${{ steps.main-version.outputs.exists }} != ${{ steps.branch-version.outputs.version }} ]]; then
             echo "Current version does not match the main branch version."
-            ehco "Update your code to align with the '${{ github.event.repository.default_branch }}' branch."
+            echo "Update your code to align with the '${{ github.event.repository.default_branch }}' branch."
             exit 1
           fi
 

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Main branch version:    ${{ steps.main-version.outputs.version }}"
           echo "Current branch version: ${{ steps.branch-version.outputs.version }}"
 
-          if [[ "${{ steps.main-version.outputs.exists }}" != "${{ steps.branch-version.outputs.version }}" ]]; then
+          if [[ "${{ steps.main-version.outputs.version }}" != "${{ steps.branch-version.outputs.version }}" ]]; then
             echo "Current version does not match the main branch version."
             echo "Update your code to align with the '${{ github.event.repository.default_branch }}' branch."
             exit 1

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -11,112 +11,111 @@ on:
       - 'Dockerfile'
       - '.github/**'
 
+# TL;DR: Don't touch the version number, 
+# put the 'deploy-snapshot' label on a GitHub PR,
+# an image will be published on Docker Hub.
+
+# This workflow is triggered when the 'deploy-snapshot' label is put on a PR.
+# It checks that the number version has not been changed (in comparison to the main branch).
+# The application is build, and a tag is published on Docker Hub. 
+# The tag of this image is the current version, suffixed with current commit hash (short), 
+# like X.Y.Z-abcd1234
+
+# If the workflow fails because of the version number, 
+# make sure that your branch is up-to-date with the main branch.
+# If you have manually changed the version number, change it back.
+
+env:
+  JAVA_VERSION: '21'
+
 jobs:
 
   check-version:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'deploy-snapshot') }}
     runs-on: ubuntu-latest
     outputs:
-      release-version: ${{ steps.version-step.outputs.version }}
+      image-tag: ${{ steps.create-tag.outputs.value }}
     steps:
-      - name: Set up JDK 21
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
-
-      - name: Checkout Eno repo
-        uses: actions/checkout@v4
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        # https://github.com/gradle/actions/blob/main/setup-gradle/README.md
 
-      - name: Get Eno Version
-        id: version-step
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Get main branch version
+        id: main-version
         run: |
           ./gradlew # (load the gradle wrapper, required for the get version step)
           echo "version=$(./gradlew printVersion --console=plain -q)" >> $GITHUB_OUTPUT
-        
-      - name: Print Eno Version
-        run: echo ${{ steps.version-step.outputs.version }}
 
-      - uses: mukunku/tag-exists-action@v1.6.0
-        name: Check tag existence
-        id: check-tag-exists
+      - name: Checkout pull request HEAD
+        uses: actions/checkout@v4
         with:
-          tag: ${{ steps.version-step.outputs.version }}
+          ref: ${{ github.event.pull_request.head.sha }} # Note: in the GitHub action, the default value is the merge commit
 
-      - name: Tag verification
-        id: check-tag
+      - name: Get PR branch version
+        id: branch-version
         run: |
-          if [[ "${{ steps.check-tag-exists.outputs.exists }}" == "true" ]]; then
-            echo "Nothing to tag/release, the tag ${{ steps.version-step.outputs.version }} already exists"
+          echo "version=$(./gradlew printVersion --console=plain -q)" >> $GITHUB_OUTPUT
+
+      - name: Check version
+        run: |
+          echo "Main branch version:    ${{ steps.main-version.outputs.version }}"
+          echo "Current branch version: ${{ steps.branch-version.outputs.version }}"
+
+          if [[ "${{ steps.main-version.outputs.exists }}" != "true" ]]; then
+            echo "Current version does not match the main branch version."
+            ehco "Update your code to align with the '${{ github.event.repository.default_branch }}' branch."
             exit 1
           fi
 
-          if ! [[ "${{ steps.version-step.outputs.version }}" =~ ^[0-9]+.[0-9]+.[0-9]+-SNAPSHOT.?[0-9]*$ ]]; then
-            echo "Nothing to tag/release, the tag ${{ steps.version-step.outputs.version }} is not in correct format X.Y.Z-SNAPSHOT"
-            exit 1
-          fi
+          echo "OK 👌"
 
-  build-sources:
+      - name: Create image tag
+        id: create-tag
+        run: |
+          REVISION=$(eval "git rev-parse --short HEAD")
+          echo "value=${{ steps.branch-version.outputs.version }}-$REVISION" >> $GITHUB_OUTPUT
+
+  publish-docker:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-
       - uses: actions/checkout@v4
-      - name: Build Eno modules
-        run: ./gradlew build
+      - name: Image tag is ${{ needs.check-version.outputs.image-tag }}
+        run: echo "${{ needs.check-version.outputs.image-tag }}"
 
-      - name: Upload Eno-WS jar
-        uses: actions/upload-artifact@v4
-        with:
-          name: eno-ws-jar
-          path: ./eno-ws/build/libs/*.jar
-
-  create-tag:
-    needs: [ check-version, build-sources ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create tag
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ needs.check-version.outputs.release-version }}',
-              sha: context.sha
-            })
-
-  publish-docker:
-    needs: [ check-version, create-tag ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Download Eno-WS jar
-        uses: actions/download-artifact@v4
-        with:
-          name: eno-ws-jar
-          path: ./eno-ws/build/libs
-      
-      - name: Publish to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@v5
-        with:
-          name: inseefr/eno-ws
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          default_branch: ${{ github.ref }}
-          tags: ${{ needs.check-version.outputs.release-version }}
+#      - name: Set up JDK
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'temurin'
+#          java-version: ${{ env.JAVA_VERSION }}
+#
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v3
+#
+#      - name: Build Eno modules
+#        run: ./gradlew build
+#
+#      - name: Publish to Docker Hub
+#        uses: elgohr/Publish-Docker-Github-Action@v5
+#        with:
+#          name: inseefr/eno-ws
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#          default_branch: ${{ github.ref }}
+#          tags: ${{ needs.check-version.outputs.image-tag }}
 
   write-comment:
     needs: [ check-version, publish-docker ]
@@ -129,8 +128,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '👋 Version ${{ needs.check-version.outputs.release-version }} deployed on docker hub'
-            })       
+              body: '👋 Image ${{ needs.check-version.outputs.image-tag }} deployed on docker hub'
+            })
 
   remove-deploy-label:
     needs: write-comment


### PR DESCRIPTION
Simplification des workflows de déploiement ~~& automatisation de la gestion du numéro de version~~.

EDIT: j'ai pas trouvé/réussi à faire marche de GitHub action pour calculer le numéro de version à partir des conventional commits, j'ai juste préparé le terrain pour faire du semantic versioning plus tard

## La logique

- **pour les snapshots**: on touche pas à la version, la ci publie une image `<version actuelle>-<sha short du last commit>` : simple, on sait sur quelle version de main on build, et pas d'ambiguïté sur où en est la "snapshot" déployée
  - _pourquoi ce choix ?_ le problème qu'on avait c'est que dans les cas où on bosse en parallèle, le semver sur les "SNAPSHOT" était souvent incohérent entre les branches qui se voient pas forcément les unes avec les autres
  - \+ j'aime bien ne pas polluer le dépôt avec plein de tags
- **pour les releases**: l'idée c'est que si le numéro de version a été modifié manuellement on le prend (même workflow/verifs qu'avant), sinon c'est pareil mais le numéro est automatiquement calculé (pas encore fait mais y a "plus qu'à" intégrer une action)