### PR TITLE
ci: improvements

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -161,6 +161,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
 
       - uses: actions/checkout@v4
       - name: Build Eno modules

--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
 
       - name: Build Eno modules
         run: ./gradlew build


### PR DESCRIPTION
- ajout du nom de branche dans les props sonar pour avoir le code coverage sur sonar cloud (hopefully)
- virer le jar dans la release 🍃 
- désactivation du cache là où il n'y a pas l'action de cache avant (ça provoquait des timeouts qui ralentissait considérablement le setup gradle)
- rajout de `.github` dans les exludes pour ne pas trigger de release si uniquement les workflows changent