### PR TITLE
fix(spring): issue in tomcat embedded dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.sonarqube.gradle.SonarTask
 
 plugins {
-    id("org.springframework.boot") version "3.5.0" apply false
+    id("org.springframework.boot") version "3.5.3" apply false
     id("io.spring.dependency-management") version "1.1.7" apply false
     id("application")
     id("jacoco-report-aggregation")
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.52.0"
+    version = "3.52.1"
 }
 
 subprojects {


### PR DESCRIPTION
A noter l'avertissement sur le passage à tomcat 10.1.42 qui introduit une limitation sur les requêtes `multipart/form-data` : à vérifier si ça ne casse pas quelque chose.

cf. https://github.com/spring-projects/spring-boot/releases/tag/v3.5.1