### PR TITLE
fix: iteration & resising logic

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
@@ -133,13 +133,7 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
         setLunaticLoopFilter(lunaticLoop);
         if (enoLoop instanceof LinkedLoop enoLinkedLoop) {
             setLinkedLoopIterations(lunaticLoop, enoLinkedLoop);
-            return;
         }
-        if (enoLoop instanceof StandaloneLoop enoStandaloneLoop) {
-            setStandaloneLoopIterations(lunaticLoop, enoStandaloneLoop);
-            return;
-        }
-        throw new IllegalStateException("Unexpected loop type: " + enoLoop.getClass().getSimpleName());
     }
 
     /** Condition filter of the loop is the same as its first component. */
@@ -183,19 +177,6 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
         throw new LunaticLoopException(String.format(
                 "Linked loop '%s' reference object's '%s' is neither a loop nor a dynamic table.",
                 enoLinkedLoop.getId(), reference));
-    }
-
-    /** Lunatic Standalone loops now have an "iterations" property. */
-    private void setStandaloneLoopIterations(Loop lunaticLoop, StandaloneLoop enoStandaloneLoop) {
-        String variableName = findFirstResponseNameOfLoop(
-                enoStandaloneLoop,
-                enoIndex,
-                "Cannot compute 'iterations' for standalone loop '" + enoStandaloneLoop.getId() + "'."
-        );
-        lunaticLoop.setIterations(new LabelType());
-        lunaticLoop.getIterations().setValue(countVariable(variableName));
-        lunaticLoop.getIterations().setType(LabelTypeEnum.VTL);
-        lunaticLoop.getLoopDependencies().add(variableName);
     }
 
     /**

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogic.java
@@ -54,7 +54,11 @@ public class LunaticLoopResizingLogic {
 
         if (enoLoop instanceof StandaloneLoop enoStandaloneLoop) {
             resizingVariableNames.addAll(findResizingVariablesForLoop(enoStandaloneLoop));
-            sizeExpression = lunaticLoop.getLines().getMin().getValue();
+            String min = lunaticLoop.getLines().getMin().getValue();
+            String max = lunaticLoop.getLines().getMax().getValue();
+            // if min != max, no resizing for Loop
+            if(!min.equals(max)) return;
+            sizeExpression = max;
         }
         if (enoLoop instanceof LinkedLoop enoLinkedLoop) {
             resizingVariableNames.add(findResizingVariableForLinkedLoop(enoLinkedLoop));

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogic.java
@@ -37,7 +37,7 @@ public class LunaticRosterResizingLogic {
         if (enoDynamicTable.getMaxSizeExpression() == null  || enoDynamicTable.getMinSizeExpression() == null)
             return;
         // If the dynamic size min != max -> no resizing
-        if(enoDynamicTable.getMinSizeExpression().getValue().equals(enoDynamicTable.getMaxSizeExpression().getValue())){
+        if(!enoDynamicTable.getMinSizeExpression().getValue().equals(enoDynamicTable.getMaxSizeExpression().getValue())){
             return;
         }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogic.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogic.java
@@ -34,8 +34,13 @@ public class LunaticRosterResizingLogic {
         DynamicTableQuestion enoDynamicTable = getDynamicTable(enoQuestionnaire, lunaticRoster.getId());
 
         // If the dynamic table size is not defined by a VTL expression, nothing to do here
-        if (enoDynamicTable.getMaxSizeExpression() == null)
+        if (enoDynamicTable.getMaxSizeExpression() == null  || enoDynamicTable.getMinSizeExpression() == null)
             return;
+        // If the dynamic size min != max -> no resizing
+        if(enoDynamicTable.getMinSizeExpression().getValue().equals(enoDynamicTable.getMaxSizeExpression().getValue())){
+            return;
+        }
+
 
         // Variable names that are the keys of the resizing (using a set to make sure there is no duplicates)
         Set<String> resizingVariableNames = findResizingVariablesForRoster(enoDynamicTable);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessing.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessing.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
-import static fr.insee.eno.core.utils.vtl.VtlSyntaxUtils.countVariable;
 
 /** Class that holds the conversion logic between model dynamic tables and Lunatic 'roster' tables. */
 @Slf4j
@@ -49,7 +48,6 @@ public class DynamicTableQuestionProcessing {
             throw new IllegalStateException(
                     "Table question '" + enoTable.getId() + "' has neither a min/max nor an expression size.");
         lunaticRoster.setLines(lines);
-        setIterations(lunaticRoster, enoTable);
     }
 
     private static void setMinMaxProperties(DynamicTableQuestion enoTable, LinesRoster lines) {
@@ -80,13 +78,6 @@ public class DynamicTableQuestionProcessing {
             minSizeLabel.setValue(enoTable.getMaxSizeExpression().getValue());
         lines.setMin(minSizeLabel);
         lines.setMax(maxSizeLabel);
-    }
-
-    private static void setIterations(RosterForLoop lunaticRoster, DynamicTableQuestion enoTable) {
-        LabelType labelType = new LabelType();
-        labelType.setType(LabelTypeEnum.VTL);
-        labelType.setValue(countVariable(enoTable.getResponseCells().getFirst().getResponse().getVariableName()));
-        lunaticRoster.setIterations(labelType);
     }
 
 }

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -154,9 +154,9 @@ class LunaticLoopResolutionTest {
         @Test
         void loopDependencies() {
             // Main loops
-            assertEquals(List.of("Q1A"), lunaticLoops.getFirst().getLoopDependencies());
+            assertThat(lunaticLoops.getFirst().getLoopDependencies()).isEmpty();
             assertThat(lunaticLoops.get(2).getLoopDependencies())
-                    .containsExactlyInAnyOrderElementsOf(Set.of("MIN_OCC", "MAX_OCC", "Q3A"));
+                    .containsExactlyInAnyOrderElementsOf(Set.of("MIN_OCC", "MAX_OCC"));
             // Linked loops
             assertEquals(List.of("Q1A"), lunaticLoops.get(1).getLoopDependencies());
             assertEquals(List.of("Q3A"), lunaticLoops.get(3).getLoopDependencies());
@@ -249,9 +249,9 @@ class LunaticLoopResolutionTest {
         @Test
         void loopDependencies() {
             // Main loops
-            assertEquals(List.of("Q1A"), lunaticLoops.getFirst().getLoopDependencies());
+            assertThat(lunaticLoops.getFirst().getLoopDependencies()).isEmpty();
             assertThat(lunaticLoops.get(2).getLoopDependencies())
-                    .containsExactlyInAnyOrderElementsOf(Set.of("MIN_OCC", "MAX_OCC", "Q2A"));
+                    .containsExactlyInAnyOrderElementsOf(Set.of("MIN_OCC", "MAX_OCC"));
             // Linked loops
             assertEquals(List.of("Q1A"), lunaticLoops.get(1).getLoopDependencies());
             assertEquals(List.of("Q2A"), lunaticLoops.get(3).getLoopDependencies());
@@ -323,7 +323,7 @@ class LunaticLoopResolutionTest {
         @Test
         void loopDependencies() {
             // Main loop
-            assertEquals(List.of("Q1"), lunaticLoops.getFirst().getLoopDependencies());
+            assertThat(lunaticLoops.getFirst().getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q1"), lunaticLoops.get(1).getLoopDependencies());
             assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());
@@ -397,7 +397,7 @@ class LunaticLoopResolutionTest {
         @Test
         void loopDependencies() {
             // Main loop
-            assertEquals(List.of("Q11"), lunaticLoops.getFirst().getLoopDependencies());
+            assertThat(lunaticLoops.getFirst().getLoopDependencies()).isEmpty();
             // Linked loop
             assertEquals(List.of("Q11"), lunaticLoops.get(1).getLoopDependencies());
             assertEquals(LabelTypeEnum.VTL, lunaticLoops.get(1).getIterations().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticAddResizingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticAddResizingTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticAddResizingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticAddResizingTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LunaticAddResizingTest {
@@ -53,18 +52,13 @@ class LunaticAddResizingTest {
 
     @Test
     void resizingEntriesCount() {
-        assertEquals(3, resizingType.countResizingEntries());
+        assertEquals(2, resizingType.countResizingEntries());
     }
 
     @Test
     void loopResizing() {
         //
-        assertEquals("1", resizingType.getResizingEntry("NUMBER").getSize());
-        assertThat(resizingType.getResizingEntry("NUMBER").getVariables())
-                .containsExactlyInAnyOrderElementsOf(List.of("Q2", "PAIRWISE_SOURCE"));
-        //
-        assertEquals("count(Q2)", resizingType.getResizingEntry("Q2").getSize());
-        assertEquals(List.of("Q3"), resizingType.getResizingEntry("Q2").getVariables());
+        assertNull(resizingType.getResizingEntry("NUMBER"));
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticLoopResizingLogicTest.java
@@ -249,13 +249,7 @@ class LunaticLoopResizingLogicTest {
         loopResizingLogic.buildResizingEntries(lunaticLoop, lunaticResizing);
 
         // Then
-        assertEquals(2, lunaticResizing.countResizingEntries());
-        //
-        List.of("LOOP_SIZE_VAR", "LOOP_SIZE_VAR2").forEach(resizingVariableName -> {
-            ResizingEntry resizingEntry = lunaticResizing.getResizingEntry(resizingVariableName);
-            assertEquals("LOOP_SIZE_VAR + LOOP_SIZE_VAR2", resizingEntry.getSize());
-            assertEquals(List.of("RESPONSE_VAR"), resizingEntry.getVariables());
-        });
+        assertEquals(0, lunaticResizing.countResizingEntries());
     }
 
     @Test
@@ -320,9 +314,7 @@ class LunaticLoopResizingLogicTest {
         loopResizingLogic.buildResizingEntries(lunaticLoop, lunaticResizing);
 
         // Then
-        assertEquals(1, lunaticResizing.countResizingEntries());
-        assertEquals("CALCULATED_VAR", lunaticResizing.getResizingEntry("COLLECTED_VAR").getSize());
-        assertEquals(List.of("RESPONSE_VAR"), lunaticResizing.getResizingEntry("COLLECTED_VAR").getVariables());
+        assertEquals(0, lunaticResizing.countResizingEntries());
     }
 
     @Test
@@ -344,9 +336,7 @@ class LunaticLoopResizingLogicTest {
         loopResizingLogic.buildResizingEntries(lunaticLoop, lunaticResizing);
 
         // Then
-        assertEquals(1, lunaticResizing.countResizingEntries());
-        assertEquals("LOOP_SIZE_VAR + EXTERNAL_VAR", lunaticResizing.getResizingEntry("LOOP_SIZE_VAR").getSize());
-        assertEquals(List.of("RESPONSE_VAR"), lunaticResizing.getResizingEntry("LOOP_SIZE_VAR").getVariables());
+        assertEquals(0, lunaticResizing.countResizingEntries());
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogicTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogicTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/resizing/LunaticRosterResizingLogicTest.java
@@ -66,11 +66,7 @@ class LunaticRosterResizingLogicTest {
         lunaticQuestionnaire.setResizing(lunaticResizing);
 
         // Then
-        assertEquals(1, lunaticResizing.countResizingEntries());
-        assertEquals("<foo expression>",
-                lunaticResizing.getResizingEntry("FOO_COLLECTED_VARIABLE").getSize());
-        assertEquals(List.of("TABLE_VAR1", "TABLE_VAR2"),
-                lunaticResizing.getResizingEntry("FOO_COLLECTED_VARIABLE").getVariables());
+        assertEquals(0, lunaticResizing.countResizingEntries());
     }
 
     @Test
@@ -125,11 +121,7 @@ class LunaticRosterResizingLogicTest {
 
         // Then
         ResizingType lunaticResizing = lunaticQuestionnaire.getResizing();
-        assertEquals(1, lunaticResizing.countResizingEntries());
-        assertEquals("cast(HOW_MANY, integer)",
-                lunaticResizing.getResizingEntry("HOW_MANY").getSize());
-        assertEquals(List.of("DYNAMIC_TABLE_VTL_SIZE1", "DYNAMIC_TABLE_VTL_MIN_MAX1"),
-                lunaticResizing.getResizingEntry("HOW_MANY").getVariables());
+        assertEquals(0, lunaticResizing.countResizingEntries());
     }
 
     @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessingTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/table/DynamicTableQuestionProcessingTest.java
@@ -17,8 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DynamicTableQuestionProcessingTest {
 
@@ -53,9 +52,8 @@ class DynamicTableQuestionProcessingTest {
         assertEquals(ComponentTypeEnum.INPUT, lunaticDynamicTable.getComponents().get(0).getComponentType());
         assertEquals(ComponentTypeEnum.INPUT_NUMBER, lunaticDynamicTable.getComponents().get(1).getComponentType());
         assertEquals(ComponentTypeEnum.RADIO, lunaticDynamicTable.getComponents().get(2).getComponentType());
-        // Iterations
-        assertEquals(LabelTypeEnum.VTL, lunaticDynamicTable.getIterations().getType());
-        assertEquals("count(DYNAMIC_TABLE1)", lunaticDynamicTable.getIterations().getValue());
+        // Iterations should be null because min != max
+        assertNull(lunaticDynamicTable.getIterations());
 
     }
 


### PR DESCRIPTION
## Changement de logique pour Lunatic resizing et iterations:

- l'`iterations` est désormais calculée en fonction des variables collectée lorsque (min!=max) (il s'agisait d'un oubli au niveau du composant Question)
    - suppression de code
    - adaptation des tests
- on retire la logique de resizing lorsque min != max pour les boucles et tableaux dynamique
   - adaptation de la logique de resizing
   - adaptation des tests

## Correction induit pour Lunatic
- Correction: Affichage des tableaux min <> max VTL
- Correction: Boucles non paginées, on affiche la bonne taile

=> évite des pertes de données au re-chargement du formulaire lunatic (resize par le bas)

## Travaux Lunatic associés

https://github.com/InseeFr/Lunatic/pull/1266


