### PR TITLE
fix(parameters): true default value for question wrapping

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.55.0"
+    version = "3.55.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/parameter/LunaticParameters.java
@@ -27,7 +27,7 @@ public class LunaticParameters {
 
     /** Parameter to include or exclude the question component (temporary modification) */
     @JsonProperty("questionWrapping")
-    private boolean questionWrapping;
+    private boolean questionWrapping = true;
 
     private LunaticParameters() {}
 

--- a/eno-core/src/test/java/fr/insee/eno/core/parameter/EnoParametersTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/parameter/EnoParametersTest.java
@@ -1,0 +1,25 @@
+package fr.insee.eno.core.parameter;
+
+import fr.insee.eno.core.exceptions.business.EnoParametersException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnoParametersTest {
+
+    @Test
+    void parsedParameters_questionWrappingProp() throws EnoParametersException, IOException {
+        String jsonParameters = """
+                {
+                  "lunatic": {}
+                }""";
+
+        EnoParameters enoParameters = EnoParameters.parse(new ByteArrayInputStream(jsonParameters.getBytes()));
+
+        assertTrue(enoParameters.getLunaticParameters().isQuestionWrapping());
+    }
+
+}


### PR DESCRIPTION
Le paramètre `"questionWrapping"` qui active le composant question n'était pas à `true` par défaut en passant par un fichier où ce paramètre n'était pas défini.
