### PR TITLE
fix: remove useless conditionFilter of loop

### DIFF
--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
@@ -130,20 +130,9 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
 
     private void setOtherLoopProperties(Loop lunaticLoop, @NonNull fr.insee.eno.core.model.navigation.Loop enoLoop) {
         lunaticLoop.setDepth(BigInteger.ONE);
-        setLunaticLoopFilter(lunaticLoop);
         if (enoLoop instanceof LinkedLoop enoLinkedLoop) {
             setLinkedLoopIterations(lunaticLoop, enoLinkedLoop);
         }
-    }
-
-    /** Condition filter of the loop is the same as its first component. */
-    private static void setLunaticLoopFilter(Loop lunaticLoop) {
-        if (lunaticLoop.getComponents().isEmpty()) {
-            throw new MappingException(String.format(
-                    "Loop '%s' is empty. This means something went wrong during the mapping or loop resolution.",
-                    lunaticLoop.getId()));
-        }
-        lunaticLoop.setConditionFilter(lunaticLoop.getComponents().getFirst().getConditionFilter());
     }
 
     /** Lunatic linked loops have an "iterations" property.

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -163,12 +163,6 @@ class LunaticLoopResolutionTest {
         }
 
         @Test
-        void loopsConditionFilter() {
-            lunaticLoops.forEach(loop ->
-                    assertEquals("true", loop.getConditionFilter().getValue()));
-        }
-
-        @Test
         void loopsDepth() {
             lunaticLoops.forEach(loop ->
                     assertEquals(BigInteger.ONE, loop.getDepth()));

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -71,7 +71,6 @@ class LunaticRoundaboutLoopsTest {
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getLabel().getType());
             assertEquals("\"Roundabout declaration\"", roundabout.getDescription().getValue());
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getDescription().getType());
-            assertEquals("true", roundabout.getConditionFilter().getValue());
             // roundabout specific ones
             assertEquals("count(FIRST_NAME)", roundabout.getIterations().getValue());
             assertEquals(LabelTypeEnum.VTL, roundabout.getIterations().getType());
@@ -165,7 +164,6 @@ class LunaticRoundaboutLoopsTest {
             assertEquals("4", roundabout.getPage());
             assertEquals("\"Roundabout on SS2\"", roundabout.getLabel().getValue());
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getLabel().getType());
-            assertEquals("true", roundabout.getConditionFilter().getValue());
             // roundabout specific ones
             assertEquals("count(Q1)", roundabout.getIterations().getValue());
             assertEquals(LabelTypeEnum.VTL, roundabout.getIterations().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
@@ -49,9 +49,6 @@ class LunaticHierarchyShapeFromTest {
         assertEquals("Q21", subsequenceShapeFrom.getConditionFilter().getShapeFrom());
         assertEquals("Q21", subsequenceShapeFrom.getLabel().getShapeFrom());
 
-        ComponentType loopShapeFrom = findComponentById(lunaticQuestionnaire, "lw4zypq0").get();
-        assertEquals("Q21", loopShapeFrom.getConditionFilter().getShapeFrom());
-
         ComponentType subSequenceShapeFromOtherScope = findComponentById(lunaticQuestionnaire, "lw50fbep").get();
         assertEquals("Q311", subSequenceShapeFromOtherScope.getConditionFilter().getShapeFrom());
         assertEquals("Q311", subSequenceShapeFromOtherScope.getLabel().getShapeFrom());


### PR DESCRIPTION
Cette PR retire les conditionFilter au niveau des boucles & rondPoint:
- pour le rondPoint, c'est l'attribut item.disabled qui est utilisé (condition du "sauf" décrit dans Pogues)
- pour les boucles, la condition du sauf est déjà ajoutée dans les composants enfants de la boucle

Cela évite les erreurs d'interprétation VTL (erreur de scope car calculée au niveau Questionnaire)