### PR TITLE
fix: lunatic loop filter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 
 allprojects {
     group = "fr.insee.eno"
-    version = "3.56.0"
+    version = "3.56.1"
 }
 
 subprojects {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolution.java
@@ -145,6 +145,7 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
      * step2: for each child compute it's filter (not resolved filter -> enoFilter (with filterScope)
      * step3: if this found filter is not the occurrenceFilter i.e "SAUF" condition, add it to the list (if not present)
      * step4: concatenate all found filters
+     * @see LunaticLoopFilter
      * */
     private void setLunaticLoopFilter(Loop lunaticLoop, fr.insee.eno.core.model.navigation.Loop enoLoop) {
         if (lunaticLoop.getComponents().isEmpty()) {
@@ -152,7 +153,10 @@ public class LunaticLoopResolution implements ProcessingStep<Questionnaire> {
                     "Loop '%s' is empty. This means something went wrong during the mapping or loop resolution.",
                     lunaticLoop.getId()));
         }
-        LunaticLoopFilter.computeAndSetConditionFilter(lunaticLoop, occurrenceFilterExpression(enoLoop));
+        LunaticLoopFilter.computeAndSetConditionFilter(lunaticLoop);
+        Optional<String> occurrenceFilterExpression = occurrenceFilterExpression(enoLoop);
+        occurrenceFilterExpression.ifPresent(value ->
+                LunaticLoopFilter.removeOccurrenceFilterExpression(lunaticLoop, value));
     }
 
     private Optional<String> occurrenceFilterExpression(fr.insee.eno.core.model.navigation.Loop enoLoop) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabel.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticReverseConsistencyControlLabel.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Processing reversing the VTL expression  value of controls. The VTL expression needs to be reversed in lunatic format
+ * Processing reversing the VTL expression  value of controls.
+ * The VTL expression needs to be reversed in lunatic format
  */
 public class LunaticReverseConsistencyControlLabel implements ProcessingStep<Questionnaire> {
     /**

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -69,7 +69,7 @@ public class LunaticLoopFilter {
                 .distinct() // don't put the same expression twice
                 .map(VtlSyntaxUtils::removeExtraParenthesis) // to not have double parentheses
                 .map(VtlSyntaxUtils::surroundByParenthesis)
-                .collect(Collectors.joining(" " + VtlSyntaxUtils.AND_KEYWORD + " "));
+                .collect(Collectors.joining(" " + VtlSyntaxUtils.OR_KEYWORD + " "));
         loopFilter.setValue(expression);
         loopFilter.setType(LabelTypeEnum.VTL);
         loopFilter.setShapeFrom(loopStructureFilters.getFirst().getShapeFrom());

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -45,11 +45,11 @@ public class LunaticLoopFilter {
     }
 
     private static boolean isLoopOfSequence(Loop lunaticLoop) {
-        return ComponentTypeEnum.SEQUENCE.equals(lunaticLoop.getComponents().getFirst().getComponentType());
+        return lunaticLoop.getComponents().getFirst() instanceof Sequence;
     }
 
     private static boolean isLoopOfSubsequence(Loop lunaticLoop) {
-        return ComponentTypeEnum.SUBSEQUENCE.equals(lunaticLoop.getComponents().getFirst().getComponentType());
+        return lunaticLoop.getComponents().getFirst() instanceof Subsequence;
     }
 
     private static void safetyCheck(Loop lunaticLoop) {

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -11,6 +11,10 @@ import java.util.stream.Collectors;
 
 public class LunaticLoopFilter {
 
+    private LunaticLoopFilter(){
+        throw new IllegalStateException("Utility class");
+    }
+
     public static void computeAndSetConditionFilter(Loop lunaticLoop) {
         Class<? extends ComponentType> loopStructureType = determineLoopStructure(lunaticLoop);
         List<ConditionFilterType> loopStructureFilters = lunaticLoop.getComponents().stream()

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -1,0 +1,81 @@
+package fr.insee.eno.core.processing.out.steps.lunatic.loop;
+
+import fr.insee.eno.core.exceptions.business.LunaticLoopException;
+import fr.insee.eno.core.utils.vtl.VtlSyntaxUtils;
+import fr.insee.lunatic.model.flat.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LunaticLoopFilter {
+
+    public static void computeAndSetConditionFilter(Loop lunaticLoop, Optional<String> occurrenceFilterExpression) {
+        // First: compute loop filter by concatenating its sequence/subsequence filters
+        Class<? extends ComponentType> loopStructureType = determineLoopStructure(lunaticLoop);
+        List<ConditionFilterType> loopStructureFilters = lunaticLoop.getComponents().stream()
+                .filter(loopStructureType::isInstance)
+                .map(loopStructureType::cast)
+                .map(ComponentType::getConditionFilter)
+                .toList();
+        Optional<ConditionFilterType> computedFilter = computeLoopFilterExpression(loopStructureFilters);
+        if (computedFilter.isEmpty())
+            return;
+        lunaticLoop.setConditionFilter(computedFilter.get());
+
+        // Second: remove the occurrence filter expression (if any) in the expression
+        if (occurrenceFilterExpression.isEmpty())
+            return;
+        String expression = lunaticLoop.getConditionFilter().getValue();
+        lunaticLoop.getConditionFilter().setValue(
+                VtlSyntaxUtils.replaceByTrue(expression, occurrenceFilterExpression.get())
+        );
+    }
+
+    private static Class<? extends ComponentType> determineLoopStructure(Loop lunaticLoop) {
+        if (isLoopOfSequence(lunaticLoop))
+            return Sequence.class;
+        if (isLoopOfSubsequence(lunaticLoop)) {
+            safetyCheck(lunaticLoop);
+            return Subsequence.class;
+        }
+        throw new LunaticLoopException(
+                "First element of loop " + lunaticLoop + " is neither a sequence or a subsequence.");
+    }
+
+    private static boolean isLoopOfSequence(Loop lunaticLoop) {
+        return ComponentTypeEnum.SEQUENCE.equals(lunaticLoop.getComponents().getFirst().getComponentType());
+    }
+
+    private static boolean isLoopOfSubsequence(Loop lunaticLoop) {
+        return ComponentTypeEnum.SUBSEQUENCE.equals(lunaticLoop.getComponents().getFirst().getComponentType());
+    }
+
+    private static void safetyCheck(Loop lunaticLoop) {
+        if (lunaticLoop.getComponents().stream().anyMatch(Sequence.class::isInstance))
+            throw new LunaticLoopException(
+                    "Loop " + lunaticLoop + " starts on a subsequence, shouldn't contain a sequence.");
+    }
+
+    private static Optional<ConditionFilterType> computeLoopFilterExpression(List<ConditionFilterType> loopStructureFilters) {
+        // If any structure component is not filtered, the whole loop will never be filtered.
+        if (loopStructureFilters.stream().anyMatch(Objects::isNull))
+            return Optional.empty();
+
+        ConditionFilterType loopFilter = new ConditionFilterType();
+        String expression = loopStructureFilters.stream()// concatenate VTL expressions
+                .map(LabelType::getValue)
+                .collect(Collectors.joining(" " + VtlSyntaxUtils.AND_KEYWORD + " "));
+        loopFilter.setValue(expression);
+        loopFilter.setType(LabelTypeEnum.VTL);
+        loopFilter.setShapeFrom(loopStructureFilters.getFirst().getShapeFrom());
+        List<String> bindingDependencies = loopStructureFilters.stream() // concatenate bonding dependencies
+                .flatMap(filter -> filter.getBindingDependencies().stream())
+                .distinct()
+                .toList();
+        loopFilter.setBindingDependencies(bindingDependencies);
+        return Optional.of(loopFilter);
+    }
+
+}

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -11,8 +11,7 @@ import java.util.stream.Collectors;
 
 public class LunaticLoopFilter {
 
-    public static void computeAndSetConditionFilter(Loop lunaticLoop, Optional<String> occurrenceFilterExpression) {
-        // First: compute loop filter by concatenating its sequence/subsequence filters
+    public static void computeAndSetConditionFilter(Loop lunaticLoop) {
         Class<? extends ComponentType> loopStructureType = determineLoopStructure(lunaticLoop);
         List<ConditionFilterType> loopStructureFilters = lunaticLoop.getComponents().stream()
                 .filter(loopStructureType::isInstance)
@@ -23,13 +22,14 @@ public class LunaticLoopFilter {
         if (computedFilter.isEmpty())
             return;
         lunaticLoop.setConditionFilter(computedFilter.get());
+    }
 
-        // Second: remove the occurrence filter expression (if any) in the expression
+    public static void removeOccurrenceFilterExpression(Loop lunaticLoop, String occurrenceFilterExpression) {
         if (occurrenceFilterExpression.isEmpty())
             return;
         String expression = lunaticLoop.getConditionFilter().getValue();
         lunaticLoop.getConditionFilter().setValue(
-                VtlSyntaxUtils.replaceByTrue(expression, occurrenceFilterExpression.get())
+                VtlSyntaxUtils.replaceByTrue(expression, occurrenceFilterExpression)
         );
     }
 

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -66,6 +66,7 @@ public class LunaticLoopFilter {
         ConditionFilterType loopFilter = new ConditionFilterType();
         String expression = loopStructureFilters.stream()// concatenate VTL expressions
                 .map(LabelType::getValue)
+                .distinct() // don't put the same expression twice
                 .collect(Collectors.joining(" " + VtlSyntaxUtils.AND_KEYWORD + " "));
         loopFilter.setValue(expression);
         loopFilter.setType(LabelTypeEnum.VTL);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -67,6 +67,7 @@ public class LunaticLoopFilter {
         String expression = loopStructureFilters.stream()// concatenate VTL expressions
                 .map(LabelType::getValue)
                 .distinct() // don't put the same expression twice
+                .map(VtlSyntaxUtils::surroundByParenthesis)
                 .collect(Collectors.joining(" " + VtlSyntaxUtils.AND_KEYWORD + " "));
         loopFilter.setValue(expression);
         loopFilter.setType(LabelTypeEnum.VTL);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -67,6 +67,7 @@ public class LunaticLoopFilter {
         String expression = loopStructureFilters.stream()// concatenate VTL expressions
                 .map(LabelType::getValue)
                 .distinct() // don't put the same expression twice
+                .map(VtlSyntaxUtils::removeExtraParenthesis) // to not have double parentheses
                 .map(VtlSyntaxUtils::surroundByParenthesis)
                 .collect(Collectors.joining(" " + VtlSyntaxUtils.AND_KEYWORD + " "));
         loopFilter.setValue(expression);

--- a/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/processing/out/steps/lunatic/loop/LunaticLoopFilter.java
@@ -73,7 +73,7 @@ public class LunaticLoopFilter {
         loopFilter.setValue(expression);
         loopFilter.setType(LabelTypeEnum.VTL);
         loopFilter.setShapeFrom(loopStructureFilters.getFirst().getShapeFrom());
-        List<String> bindingDependencies = loopStructureFilters.stream() // concatenate bonding dependencies
+        List<String> bindingDependencies = loopStructureFilters.stream() // concatenate binding dependencies
                 .flatMap(filter -> filter.getBindingDependencies().stream())
                 .distinct()
                 .toList();

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
@@ -79,7 +79,7 @@ public class VtlSyntaxUtils {
      * @return vtlExpression without parenthesis
      * example: `(nvl(TEST, "") <> "")` should return `nvl(TEST, "") <> ""`
      */
-    static String removeExtraParenthesis(String expression){ // method is package-private to be tested in isolation
+    public static String removeExtraParenthesis(String expression){ // method is package-private to be tested in isolation
         if (expression.startsWith(getVTLTokenName(VtlTokens.LPAREN)) && expression.endsWith(getVTLTokenName(VtlTokens.RPAREN)))
             return expression.substring(1, expression.length() - 1);
         return expression;

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
@@ -22,7 +22,7 @@ public class VtlSyntaxUtils {
 
     public static final String LEFT_JOIN_OPERATOR = getVTLTokenName(VtlTokens.LEFT_JOIN);
     public static final String USING_KEYWORD = getVTLTokenName(VtlTokens.USING);
-    public static final String AND_KEYWORD = getVTLTokenName(VtlTokens.AND);
+    public static final String OR_KEYWORD = getVTLTokenName(VtlTokens.OR);
 
     // ----- VTL syntax methods used in Eno
 

--- a/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
+++ b/eno-core/src/main/java/fr/insee/eno/core/utils/vtl/VtlSyntaxUtils.java
@@ -22,6 +22,7 @@ public class VtlSyntaxUtils {
 
     public static final String LEFT_JOIN_OPERATOR = getVTLTokenName(VtlTokens.LEFT_JOIN);
     public static final String USING_KEYWORD = getVTLTokenName(VtlTokens.USING);
+    public static final String AND_KEYWORD = getVTLTokenName(VtlTokens.AND);
 
     // ----- VTL syntax methods used in Eno
 

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticLoopResolutionTest.java
@@ -165,7 +165,7 @@ class LunaticLoopResolutionTest {
         @Test
         void loopsConditionFilter() {
             lunaticLoops.forEach(loop ->
-                    assertEquals("true", loop.getConditionFilter().getValue()));
+                    assertEquals("(true)", loop.getConditionFilter().getValue()));
         }
 
         @Test

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -165,7 +165,7 @@ class LunaticRoundaboutLoopsTest {
             assertEquals("4", roundabout.getPage());
             assertEquals("\"Roundabout on SS2\"", roundabout.getLabel().getValue());
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getLabel().getType());
-            assertEquals("true", roundabout.getConditionFilter().getValue());
+            assertEquals("(true)", roundabout.getConditionFilter().getValue());
             // roundabout specific ones
             assertEquals("count(Q1)", roundabout.getIterations().getValue());
             assertEquals(LabelTypeEnum.VTL, roundabout.getIterations().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/LunaticRoundaboutLoopsTest.java
@@ -71,7 +71,7 @@ class LunaticRoundaboutLoopsTest {
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getLabel().getType());
             assertEquals("\"Roundabout declaration\"", roundabout.getDescription().getValue());
             assertEquals(LabelTypeEnum.VTL_MD, roundabout.getDescription().getType());
-            assertEquals("true", roundabout.getConditionFilter().getValue());
+            assertEquals("(true)", roundabout.getConditionFilter().getValue());
             // roundabout specific ones
             assertEquals("count(FIRST_NAME)", roundabout.getIterations().getValue());
             assertEquals(LabelTypeEnum.VTL, roundabout.getIterations().getType());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
@@ -50,7 +50,7 @@ class LunaticHierarchyShapeFromTest {
         assertEquals("Q21", subsequenceShapeFrom.getLabel().getShapeFrom());
 
         ComponentType loopShapeFrom = findComponentById(lunaticQuestionnaire, "lw4zypq0").get();
-        assertEquals("Q21", loopShapeFrom.getConditionFilter().getShapeFrom());
+        //assertEquals("Q21", loopShapeFrom.getConditionFilter().getShapeFrom()); // FIXME
 
         ComponentType subSequenceShapeFromOtherScope = findComponentById(lunaticQuestionnaire, "lw50fbep").get();
         assertEquals("Q311", subSequenceShapeFromOtherScope.getConditionFilter().getShapeFrom());

--- a/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
+++ b/eno-core/src/test/java/fr/insee/eno/core/processing/out/steps/lunatic/shapefrom/LunaticHierarchyShapeFromTest.java
@@ -50,7 +50,7 @@ class LunaticHierarchyShapeFromTest {
         assertEquals("Q21", subsequenceShapeFrom.getLabel().getShapeFrom());
 
         ComponentType loopShapeFrom = findComponentById(lunaticQuestionnaire, "lw4zypq0").get();
-        //assertEquals("Q21", loopShapeFrom.getConditionFilter().getShapeFrom()); // FIXME
+        assertNull(loopShapeFrom.getConditionFilter().getShapeFrom());
 
         ComponentType subSequenceShapeFromOtherScope = findComponentById(lunaticQuestionnaire, "lw50fbep").get();
         assertEquals("Q311", subSequenceShapeFromOtherScope.getConditionFilter().getShapeFrom());


### PR DESCRIPTION
Le problème : Eno décidait que la condition filter d'une boucle était la condition filter de son premier composant (qui est une séquence ou une sous-séquence).

_Exemple de cas qui pose problème_ : 

- boucle sur deux séquences
- sur la première filtre "TOTO = 1"
- sur ma deuxième filtre "TOTO = 0"
- => Filtre sur le composant boucle "TOTO = 1"
- => dans un des cas les deux séquences se retrouvent filtrées, alors qu'on devrait voir la deuxième

Note : le problème est présent depuis (très) longtemps (a priori depuis la première release de prod d'Eno java).
